### PR TITLE
Fix weight change decrease formatting

### DIFF
--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -48,7 +48,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
     const difference = currentWeight - bestWeight;
     
     if (difference > 0) return { change: `↑ +${difference} lbs`, color: 'text-blue-600' };
-    if (difference < 0) return { change: `↓ ${difference} lbs`, color: 'text-red-600' };
+    if (difference < 0) return { change: `↓ ${Math.abs(difference)} lbs`, color: 'text-red-600' };
     return { change: '', color: '' };
   };
 


### PR DESCRIPTION
## Summary
- show absolute weight drop in exercise form so negative values display correctly

## Testing
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6869d834a8548329a1885b7da4566a6e