### PR TITLE
Add vitest unit test for workout schedule

### DIFF
--- a/client/src/lib/workout-data.test.ts
+++ b/client/src/lib/workout-data.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest'
+import { generateWorkoutSchedule } from './workout-data'
+
+describe('generateWorkoutSchedule', () => {
+  it('creates expected schedule for February 2023', () => {
+    const year = 2023
+    const month = 2
+    const schedule = generateWorkoutSchedule(year, month)
+
+    const daysInMonth = new Date(year, month, 0).getDate()
+    let expected = 0
+    for (let day = 1; day <= daysInMonth; day++) {
+      if (day % 3 === 0 && day % 7 !== 0) continue
+      expected++
+    }
+
+    expect(schedule.length).toBe(expected)
+    expect(schedule[0].date).toBe('2023-02-01')
+    expect(schedule[schedule.length - 1].date).toBe('2023-02-28')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -97,7 +98,8 @@
     "tailwindcss": "^3.4.17",
     "tsx": "^4.19.1",
     "typescript": "5.6.3",
-    "vite": "^5.4.19"
+    "vite": "^5.4.19",
+    "vitest": "^3.2.4"
   },
   "optionalDependencies": {
     "bufferutil": "^4.0.8"


### PR DESCRIPTION
## Summary
- add a unit test for `generateWorkoutSchedule`
- add `vitest` dev dependency
- expose `test` script in package.json

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6869d82e23d88329b48f028dbf88d355