### PR TITLE
Add workout template selector

### DIFF
--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -1,0 +1,30 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+
+interface WorkoutTemplateSelectorModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSelectTemplate: (template: string) => void;
+}
+
+export function WorkoutTemplateSelectorModal({ open, onClose, onSelectTemplate }: WorkoutTemplateSelectorModalProps) {
+  const handleOpenChange = (isOpen: boolean) => {
+    if (!isOpen) {
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle>Select Workout Template</DialogTitle>
+        </DialogHeader>
+        <div className="flex flex-col space-y-2">
+          <Button variant="outline" onClick={() => onSelectTemplate('Chest Day (ActiveTrax)')}>Chest Day (ActiveTrax)</Button>
+          <Button variant="outline" onClick={() => onSelectTemplate('Back & Legs (ActiveTrax)')}>Back & Legs (ActiveTrax)</Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -75,6 +75,34 @@ export function useWorkoutStorage() {
     return newWorkout;
   };
 
+  const createWorkoutForDate = async (
+    date: string,
+    templateName: string,
+  ) => {
+    const template = workoutTemplates[
+      templateName as keyof typeof workoutTemplates
+    ];
+    if (!template) return undefined;
+
+    return await createWorkout({
+      date,
+      type: templateName,
+      completed: false,
+      cardio: {
+        type: "Treadmill",
+        duration: "",
+        distance: "",
+        completed: false,
+      },
+      abs: template.abs.map((a) => ({ ...a, completed: false })),
+      exercises: template.exercises.map((e) => ({
+        ...e,
+        completed: false,
+        sets: e.sets.map((set) => ({ ...set, completed: false })),
+      })),
+    });
+  };
+
   const updateWorkout = async (
     id: number,
     updates: Partial<InsertWorkout>,
@@ -130,6 +158,7 @@ export function useWorkoutStorage() {
     refresh: loadData,
     getWorkoutByDate,
     createWorkout,
+    createWorkoutForDate,
     updateWorkout,
     exportData,
     exportCSV

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -5,6 +5,7 @@ import { CalendarGrid } from '@/components/calendar-grid';
 import { WorkoutCard } from '@/components/workout-card';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from '@/lib/workout-data';
+import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { Workout } from '@shared/schema';
 
 interface CalendarPageProps {
@@ -15,7 +16,9 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedWorkout, setSelectedWorkout] = useState<Workout | null>(null);
-  const { workouts, getWorkoutByDate, createWorkout, loading } = useWorkoutStorage();
+  const [templateModalOpen, setTemplateModalOpen] = useState(false);
+  const [dateForCreation, setDateForCreation] = useState<string | null>(null);
+  const { workouts, getWorkoutByDate, createWorkout, createWorkoutForDate, loading } = useWorkoutStorage();
 
   useEffect(() => {
     if (selectedDate) {
@@ -26,6 +29,19 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const loadWorkoutForDate = async (date: string) => {
     const workout = await getWorkoutByDate(date);
     setSelectedWorkout(workout || null);
+  };
+
+  const openTemplateSelector = (date: string) => {
+    setDateForCreation(date);
+    setTemplateModalOpen(true);
+  };
+
+  const handleTemplateSelect = async (templateName: string) => {
+    if (!dateForCreation) return;
+    await createWorkoutForDate(dateForCreation, templateName);
+    await loadWorkoutForDate(dateForCreation);
+    setTemplateModalOpen(false);
+    setDateForCreation(null);
   };
 
   const handleSelectDate = (date: string | Date) => {
@@ -233,7 +249,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
                 <p className="text-gray-600 dark:text-gray-400 mb-4">
                   No workout scheduled for this date
                 </p>
-                <Button onClick={() => handleStartWorkout(selectedDate)}>
+                <Button onClick={() => openTemplateSelector(selectedDate)}>
                   Create Workout
                 </Button>
               </div>
@@ -251,6 +267,11 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
           Start Today's Workout
         </Button>
       </div>
+      <WorkoutTemplateSelectorModal
+        open={templateModalOpen}
+        onClose={() => setTemplateModalOpen(false)}
+        onSelectTemplate={handleTemplateSelect}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add `WorkoutTemplateSelectorModal` for choosing between templates
- store date and show modal when creating a new workout from calendar
- implement `createWorkoutForDate` helper in workout storage hook
- wire modal to create workouts using selected template

## Testing
- `npx vitest` *(fails: Need to install packages)*

------
https://chatgpt.com/codex/tasks/task_e_6869dd8e4b34832993688ed2a6eca16c