### PR TITLE
Fix missing dialog descriptions

### DIFF
--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -1,4 +1,10 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 
 interface WorkoutTemplateSelectorModalProps {
@@ -19,6 +25,9 @@ export function WorkoutTemplateSelectorModal({ open, onClose, onSelectTemplate }
       <DialogContent className="space-y-4">
         <DialogHeader>
           <DialogTitle>Select Workout Template</DialogTitle>
+          <DialogDescription>
+            Choose a template to pre-fill your workout details.
+          </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col space-y-2">
           <Button variant="outline" onClick={() => onSelectTemplate('Chest Day (ActiveTrax)')}>Chest Day (ActiveTrax)</Button>

--- a/client/src/components/ui/command.tsx
+++ b/client/src/components/ui/command.tsx
@@ -4,7 +4,11 @@ import { Command as CommandPrimitive } from "cmdk"
 import { Search } from "lucide-react"
 
 import { cn } from "@/lib/utils"
-import { Dialog, DialogContent } from "@/components/ui/dialog"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+} from "@/components/ui/dialog"
 
 const Command = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive>,
@@ -25,6 +29,9 @@ const CommandDialog = ({ children, ...props }: DialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <DialogDescription className="sr-only">
+          Command dialog
+        </DialogDescription>
         <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>


### PR DESCRIPTION
## Summary
- address accessibility warnings by adding `DialogDescription` elements
- silence browser console warnings about missing `Description`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6869e21ea5148329b0cea55f0263d03b