### PR TITLE
Fix mobile create workout button

### DIFF
--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -45,21 +45,20 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   };
 
   const handleSelectDate = (date: string | Date) => {
+    setSelectedWorkout(null);
+
     let normalized: string;
-  
-    if (typeof date === 'string') {
+
+    if (typeof date === "string") {
       normalized = date; // assume already in YYYY-MM-DD format
     } else {
       // convert from JS Date to YYYY-MM-DD without timezone shift
       const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, '0');
-      const day = String(date.getDate()).padStart(2, '0');
+      const month = String(date.getMonth() + 1).padStart(2, "0");
+      const day = String(date.getDate()).padStart(2, "0");
       normalized = `${year}-${month}-${day}`;
     }
-  
-    console.log("➡️ handleSelectDate received:", date);
-    console.log("🧮 Normalized:", normalized);
-  
+
     setSelectedDate(normalized);
   };
 


### PR DESCRIPTION
## Summary
- clear selected workout when selecting a new date so "Create Workout" appears correctly

## Testing
- `npm run check` *(fails: TypeScript errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6869e779ed2483299117e048b89f28fd