### PR TITLE
Add data reset and workout deletion

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,24 @@ import { WorkoutPage } from '@/pages/workout';
 import { HistoryPage } from '@/pages/history';
 import { Workout } from '@shared/schema';
 import { Dumbbell, Moon, Sun, Settings } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem
+} from '@/components/ui/dropdown-menu';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction
+} from '@/components/ui/alert-dialog';
+import { localWorkoutStorage } from '@/lib/storage';
 
 function Navigation() {
   const [location, setLocation] = useLocation();
@@ -71,13 +89,44 @@ function Header() {
                 <Moon className="h-4 w-4 text-gray-600 dark:text-gray-400" />
               )}
             </Button>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-            >
-              <Settings className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+                >
+                  <Settings className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <DropdownMenuItem>Reset App Data</DropdownMenuItem>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Reset Application</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        This will delete all workouts and preferences. Continue?
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
+                      <AlertDialogAction
+                        className="bg-red-600 text-white hover:bg-red-700"
+                        onClick={async () => {
+                          await localWorkoutStorage.clearAllData();
+                          window.location.reload();
+                        }}
+                      >
+                        Reset
+                      </AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
+              </DropdownMenuContent>
+            </DropdownMenu>
           </div>
         </div>
       </div>

--- a/client/src/components/workout-card.tsx
+++ b/client/src/components/workout-card.tsx
@@ -2,15 +2,33 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Workout } from '@shared/schema';
-import { Calendar, Clock, CheckCircle, PlayCircle } from 'lucide-react';
+import {
+  Calendar,
+  Clock,
+  CheckCircle,
+  PlayCircle,
+  X
+} from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction
+} from '@/components/ui/alert-dialog';
 
 interface WorkoutCardProps {
   workout: Workout;
   onStart: () => void;
   onView: () => void;
+  onDelete?: () => void;
 }
 
-export function WorkoutCard({ workout, onStart, onView }: WorkoutCardProps) {
+export function WorkoutCard({ workout, onStart, onView, onDelete }: WorkoutCardProps) {
   const completedExercises = workout.exercises.filter(e => e.completed).length;
   const totalExercises = workout.exercises.length;
   const completionPercentage = totalExercises > 0 ? (completedExercises / totalExercises) * 100 : 0;
@@ -25,7 +43,37 @@ export function WorkoutCard({ workout, onStart, onView }: WorkoutCardProps) {
   };
 
   return (
-    <Card className="hover:shadow-md transition-shadow">
+    <Card className="relative hover:shadow-md transition-shadow">
+      {onDelete && (
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="absolute top-2 left-2 h-6 w-6 p-0 text-red-600 hover:bg-red-100 dark:hover:bg-red-900"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Workout</AlertDialogTitle>
+              <AlertDialogDescription>
+                Are you sure you want to delete this workout?
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                className="bg-red-600 text-white hover:bg-red-700"
+                onClick={onDelete}
+              >
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
       <CardHeader className="pb-3">
         <div className="flex items-center justify-between">
           <CardTitle className="text-lg font-semibold text-gray-900 dark:text-white">

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -149,6 +149,19 @@ export function useWorkoutStorage() {
     URL.revokeObjectURL(url);
   };
 
+  const deleteWorkout = async (id: number) => {
+    const success = await localWorkoutStorage.deleteWorkout(id);
+    if (success) {
+      setWorkouts(prev => prev.filter(w => w.id !== id));
+    }
+    return success;
+  };
+
+  const resetAllData = async () => {
+    await localWorkoutStorage.clearAllData();
+    await loadData();
+  };
+
   return {
     workouts,
     preferences,
@@ -160,6 +173,8 @@ export function useWorkoutStorage() {
     createWorkout,
     createWorkoutForDate,
     updateWorkout,
+    deleteWorkout,
+    resetAllData,
     exportData,
     exportCSV
   };

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -18,7 +18,14 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const [selectedWorkout, setSelectedWorkout] = useState<Workout | null>(null);
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [dateForCreation, setDateForCreation] = useState<string | null>(null);
-  const { workouts, getWorkoutByDate, createWorkout, createWorkoutForDate, loading } = useWorkoutStorage();
+  const {
+    workouts,
+    getWorkoutByDate,
+    createWorkout,
+    createWorkoutForDate,
+    deleteWorkout,
+    loading
+  } = useWorkoutStorage();
 
   useEffect(() => {
     if (selectedDate) {
@@ -29,6 +36,12 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const loadWorkoutForDate = async (date: string) => {
     const workout = await getWorkoutByDate(date);
     setSelectedWorkout(workout || null);
+  };
+
+  const handleDeleteSelectedWorkout = async () => {
+    if (!selectedWorkout) return;
+    await deleteWorkout(selectedWorkout.id);
+    setSelectedWorkout(null);
   };
 
   const openTemplateSelector = (date: string) => {
@@ -242,6 +255,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
                 workout={selectedWorkout}
                 onStart={() => onNavigateToWorkout(selectedWorkout)}
                 onView={() => onNavigateToWorkout(selectedWorkout)}
+                onDelete={handleDeleteSelectedWorkout}
               />
             ) : (
               <div className="text-center py-4">


### PR DESCRIPTION
## Summary
- allow deleting individual workouts in `WorkoutCard`
- expose `deleteWorkout` and `resetAllData` helpers
- refresh `CalendarPage` when a workout is removed
- add settings dropdown to reset all stored data

## Testing
- `npx --yes vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686aa25c46fc8329a09da46e7c47509a