### PR TITLE
Add settings modal

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,24 +11,7 @@ import { WorkoutPage } from '@/pages/workout';
 import { HistoryPage } from '@/pages/history';
 import { Workout } from '@shared/schema';
 import { Dumbbell, Moon, Sun, Settings } from 'lucide-react';
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem
-} from '@/components/ui/dropdown-menu';
-import {
-  AlertDialog,
-  AlertDialogTrigger,
-  AlertDialogContent,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogCancel,
-  AlertDialogAction
-} from '@/components/ui/alert-dialog';
-import { localWorkoutStorage } from '@/lib/storage';
+import { SettingsDialog } from '@/components/SettingsDialog';
 
 function Navigation() {
   const [location, setLocation] = useLocation();
@@ -89,44 +72,15 @@ function Header() {
                 <Moon className="h-4 w-4 text-gray-600 dark:text-gray-400" />
               )}
             </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
-                >
-                  <Settings className="h-4 w-4 text-gray-600 dark:text-gray-400" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <DropdownMenuItem>Reset App Data</DropdownMenuItem>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Reset Application</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        This will delete all workouts and preferences. Continue?
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Cancel</AlertDialogCancel>
-                      <AlertDialogAction
-                        className="bg-red-600 text-white hover:bg-red-700"
-                        onClick={async () => {
-                          await localWorkoutStorage.clearAllData();
-                          window.location.reload();
-                        }}
-                      >
-                        Reset
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </DropdownMenuContent>
-            </DropdownMenu>
+            <SettingsDialog>
+              <Button
+                variant="ghost"
+                size="sm"
+                className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors"
+              >
+                <Settings className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+              </Button>
+            </SettingsDialog>
           </div>
         </div>
       </div>

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -1,0 +1,77 @@
+import { useState, ChangeEvent } from 'react';
+import { Dialog, DialogTrigger, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Separator } from '@/components/ui/separator';
+import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader, AlertDialogTitle, AlertDialogDescription, AlertDialogFooter, AlertDialogCancel, AlertDialogAction } from '@/components/ui/alert-dialog';
+import { localWorkoutStorage } from '@/lib/storage';
+import { toast } from '@/hooks/use-toast';
+
+export function SettingsDialog({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+
+  const handleExport = async () => {
+    const data = await localWorkoutStorage.exportData();
+    const headers = ['id', 'date', 'type', 'completed', 'duration'];
+    const rows = data.workouts.map(w => [w.id, w.date, w.type, w.completed, w.duration ?? ''].join(','));
+    const csv = [headers.join(','), ...rows].join('\n');
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'workouts.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleImport = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      toast({
+        title: 'Import not implemented',
+        description: 'Importing workouts will be available in a future update.'
+      });
+      e.target.value = '';
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="space-y-4">
+        <DialogHeader>
+          <DialogTitle>Settings</DialogTitle>
+          <DialogDescription>Manage app data and preferences.</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <Button onClick={handleExport} className="w-full">Export Workouts</Button>
+          <div>
+            <input id="import-file" type="file" accept=".csv" onChange={handleImport} className="hidden" />
+            <label htmlFor="import-file">
+              <Button asChild className="w-full cursor-pointer">
+                <span>Import Workouts</span>
+              </Button>
+            </label>
+          </div>
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button variant="destructive" className="w-full">Reset All Data</Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Reset Application</AlertDialogTitle>
+                <AlertDialogDescription>This will delete all workouts and preferences. Continue?</AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction className="bg-red-600 text-white hover:bg-red-700" onClick={async () => { await localWorkoutStorage.clearAllData(); window.location.reload(); }}>Reset</AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
+        <Separator />
+        <div className="text-sm text-gray-500 dark:text-gray-400">
+          IronPup v1.0.0
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SettingsDialog` component
- switch header cogwheel to open the Settings dialog

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686aa624f3c08329a7d22f55446b994c