### PR TITLE
Add Chest & Triceps workout template

### DIFF
--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -43,6 +43,7 @@ export function WorkoutTemplateSelectorModal({ open, onClose, onSelectTemplate }
             Back & Legs (ActiveTrax)
           </Button>
           <Button variant="outline" onClick={() => onSelectTemplate('Back & Biceps (ActiveTrax)')}>Back & Biceps (ActiveTrax)</Button>
+          <Button variant="outline" onClick={() => onSelectTemplate('Chest & Triceps (ActiveTrax)')}>Chest & Triceps (ActiveTrax)</Button>
           <Button variant="outline" onClick={() => onSelectTemplate('Chest & Shoulders (ActiveTrax)')}>Chest & Shoulders (ActiveTrax)</Button>
         </div>
       </DialogContent>

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -373,6 +373,97 @@ export const workoutTemplates: Record<WorkoutType, {
     ]
   },
 
+  "Chest & Triceps (ActiveTrax)": {
+    exercises: [
+      {
+        code: "N/A",
+        machine: "Seated Chest Press",
+        region: "Chest",
+        feel: "Medium",
+        sets: [
+          { weight: 75, reps: 15, rest: "1:00" },
+          { weight: 100, reps: 15, rest: "1:00" },
+          { weight: 100, reps: 15, rest: "1:00" }
+        ],
+        bestWeight: 100,
+        bestReps: 15
+      },
+      {
+        code: "N/A",
+        machine: "Cable Crossover",
+        region: "Chest",
+        feel: "Medium",
+        sets: [
+          { weight: 60, reps: 15, rest: "1:00" },
+          { weight: 80, reps: 6, rest: "1:00" },
+          { weight: 80, reps: 6, rest: "1:00" }
+        ],
+        bestWeight: 80,
+        bestReps: 6
+      },
+      {
+        code: "N/A",
+        machine: "Kick Back",
+        region: "Triceps",
+        feel: "Medium",
+        sets: [
+          { weight: 15, reps: 15, rest: "1:00" },
+          { weight: 15, reps: 15, rest: "1:00" },
+          { weight: 15, reps: 15, rest: "1:00" }
+        ],
+        bestWeight: 15,
+        bestReps: 15
+      },
+      {
+        code: "N/A",
+        machine: "Straight Bar Pushdown",
+        region: "Triceps",
+        feel: "Medium",
+        sets: [
+          { weight: 140, reps: 10, rest: "1:00" },
+          { weight: 140, reps: 10, rest: "1:00" },
+          { weight: 150, reps: 10, rest: "1:00" }
+        ],
+        bestWeight: 150,
+        bestReps: 10
+      },
+      {
+        code: "N/A",
+        machine: "Low-Pulley Kick Back",
+        region: "Triceps",
+        feel: "Medium",
+        sets: [
+          { weight: 50, reps: 10, rest: "1:30" },
+          { weight: 50, reps: 10, rest: "1:30" },
+          { weight: 50, reps: 10, rest: "1:30" }
+        ],
+        bestWeight: 50,
+        bestReps: 10
+      },
+      {
+        code: "N/A",
+        machine: "Seated Lateral Raise",
+        region: "Shoulders",
+        feel: "Medium",
+        sets: [
+          { weight: 15, reps: 10, rest: "1:00" },
+          { weight: 15, reps: 10, rest: "1:00" },
+          { weight: 15, reps: 10, rest: "1:00" }
+        ],
+        bestWeight: 15,
+        bestReps: 10
+      }
+    ],
+    abs: [
+      { name: "Crunch with Legs In", reps: 30 },
+      { name: "Decline 90 Degree Reverse Crunch", reps: 30 },
+      { name: "90 Degree Side Oblique Crunch", reps: 30 },
+      { name: "Decline Reverse Crunch", reps: 30 },
+      { name: "Side Oblique Crunch with Arms Extended", reps: 30 },
+      { name: "Ball Crunch", reps: 30 }
+    ]
+  },
+
   "Chest & Shoulders (ActiveTrax)": {
     exercises: [
       {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -47,6 +47,7 @@ export const workoutTypes = [
   "Chest, Shoulders, and Back",
   "Chest Day (ActiveTrax)",
   "Back & Biceps (ActiveTrax)",
+  "Chest & Triceps (ActiveTrax)",
   "Chest & Shoulders (ActiveTrax)",
   "Leg Day (ActiveTrax)"
 ] as const;


### PR DESCRIPTION
## Summary
- add new Chest & Triceps (ActiveTrax) workout template
- register new template type in schema
- show template in workout template selector

## Testing
- `npm run check` *(fails: TS errors)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ac7c73a608329bd86c25343db82f8