### PR TITLE
Implement workout resume feature

### DIFF
--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -38,6 +38,10 @@ export function useWorkoutStorage() {
     return await localWorkoutStorage.getWorkoutByDate(date);
   };
 
+  const getWorkoutById = async (id: number) => {
+    return await localWorkoutStorage.getWorkout(id);
+  };
+
   const createWorkout = async (workout: InsertWorkout) => {
     const newWorkout = await localWorkoutStorage.createWorkout(workout);
     setWorkouts((prev) => [...prev, newWorkout]);
@@ -126,6 +130,18 @@ export function useWorkoutStorage() {
     return success;
   };
 
+  const getActiveWorkoutId = () => {
+    return localWorkoutStorage.getActiveWorkoutId();
+  };
+
+  const setActiveWorkoutId = (id: number) => {
+    localWorkoutStorage.setActiveWorkoutId(id);
+  };
+
+  const clearActiveWorkoutId = () => {
+    localWorkoutStorage.clearActiveWorkoutId();
+  };
+
   const resetAllData = async () => {
     await localWorkoutStorage.clearAllData();
     await loadData();
@@ -144,6 +160,10 @@ export function useWorkoutStorage() {
     updateWorkout,
     deleteWorkout,
     resetAllData,
+    getActiveWorkoutId,
+    setActiveWorkoutId,
+    clearActiveWorkoutId,
+    getWorkoutById,
     exportData,
     exportCSV
   };

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -3,7 +3,8 @@ import { Workout, InsertWorkout, UserPreferences } from "@shared/schema";
 const STORAGE_KEYS = {
   WORKOUTS: 'ironpup_workouts',
   PREFERENCES: 'ironpup_preferences',
-  CURRENT_ID: 'ironpup_current_id'
+  CURRENT_ID: 'ironpup_current_id',
+  ACTIVE_WORKOUT: 'ironpup_active_workout'
 } as const;
 
 export class LocalWorkoutStorage {
@@ -23,6 +24,19 @@ export class LocalWorkoutStorage {
 
   private saveWorkouts(workouts: Workout[]): void {
     localStorage.setItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
+  }
+
+  getActiveWorkoutId(): number | null {
+    const stored = localStorage.getItem(STORAGE_KEYS.ACTIVE_WORKOUT);
+    return stored ? parseInt(stored, 10) : null;
+  }
+
+  setActiveWorkoutId(id: number): void {
+    localStorage.setItem(STORAGE_KEYS.ACTIVE_WORKOUT, id.toString());
+  }
+
+  clearActiveWorkoutId(): void {
+    localStorage.removeItem(STORAGE_KEYS.ACTIVE_WORKOUT);
   }
 
   async getWorkout(id: number): Promise<Workout | undefined> {

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -16,6 +16,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<string | null>(null);
   const [selectedWorkout, setSelectedWorkout] = useState<Workout | null>(null);
+  const [activeWorkout, setActiveWorkout] = useState<Workout | null>(null);
   const [templateModalOpen, setTemplateModalOpen] = useState(false);
   const [dateForCreation, setDateForCreation] = useState<string | null>(null);
   const {
@@ -24,7 +25,10 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     createWorkout,
     createWorkoutForDate,
     deleteWorkout,
-    loading
+    loading,
+    getActiveWorkoutId,
+    clearActiveWorkoutId,
+    getWorkoutById
   } = useWorkoutStorage();
 
   useEffect(() => {
@@ -56,6 +60,19 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     setTemplateModalOpen(false);
     setDateForCreation(null);
   };
+
+  useEffect(() => {
+    const id = getActiveWorkoutId();
+    if (id) {
+      getWorkoutById(id).then(workout => {
+        if (workout && !workout.completed) {
+          setActiveWorkout(workout);
+        } else {
+          clearActiveWorkoutId();
+        }
+      });
+    }
+  }, []);
 
   const handleSelectDate = (date: string | Date) => {
     setSelectedWorkout(null);
@@ -273,6 +290,14 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
 
       {/* Quick Actions */}
       <div className="space-y-3">
+        {activeWorkout && (
+          <Button
+            onClick={() => onNavigateToWorkout(activeWorkout)}
+            className="w-full bg-green-600 hover:bg-green-700 text-white py-3 px-4 rounded-lg font-medium transition-colors"
+          >
+            Resume Workout
+          </Button>
+        )}
         <Button
           onClick={handleStartTodayWorkout}
           className="w-full bg-primary text-white py-3 px-4 rounded-lg font-medium hover:bg-primary/90 transition-colors"

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -18,8 +18,18 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   const [workout, setWorkout] = useState<Workout>(initialWorkout);
   const [currentExerciseIndex, setCurrentExerciseIndex] = useState(0);
   const [autoSaveEnabled, setAutoSaveEnabled] = useState(true);
-  const { updateWorkout } = useWorkoutStorage();
+  const { updateWorkout, setActiveWorkoutId, clearActiveWorkoutId } = useWorkoutStorage();
   const { toast } = useToast();
+
+  useEffect(() => {
+    setActiveWorkoutId(workout.id);
+    return () => {
+      // keep active id if workout not completed
+      if (workout.completed) {
+        clearActiveWorkoutId();
+      }
+    };
+  }, []);
 
   useEffect(() => {
     // Auto-save functionality
@@ -115,6 +125,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         completed: true,
         duration: completedWorkout.duration
       });
+      clearActiveWorkoutId();
       
       toast({
         title: "Workout completed! 🎉",


### PR DESCRIPTION
## Summary
- add `ACTIVE_WORKOUT` key to local storage
- expose active workout helpers in `useWorkoutStorage`
- store active workout id in `WorkoutPage`
- load active workout and offer resume option in `CalendarPage`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686aee8a9c048329b0f4fa374258efae