### PR TITLE
Add Chest, Shoulders & Legs workout template

### DIFF
--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -45,6 +45,7 @@ export function WorkoutTemplateSelectorModal({ open, onClose, onSelectTemplate }
           <Button variant="outline" onClick={() => onSelectTemplate('Back & Biceps (ActiveTrax)')}>Back & Biceps (ActiveTrax)</Button>
           <Button variant="outline" onClick={() => onSelectTemplate('Chest & Triceps (ActiveTrax)')}>Chest & Triceps (ActiveTrax)</Button>
           <Button variant="outline" onClick={() => onSelectTemplate('Chest & Shoulders (ActiveTrax)')}>Chest & Shoulders (ActiveTrax)</Button>
+          <Button variant="outline" onClick={() => onSelectTemplate('Chest, Shoulders & Legs (ActiveTrax)')}>Chest, Shoulders & Legs (ActiveTrax)</Button>
         </div>
       </DialogContent>
     </Dialog>

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -592,6 +592,122 @@ export const workoutTemplates: Record<WorkoutType, {
       { name: "Side Oblique Crunch", reps: 30 },
       { name: "Crunch", reps: 30 }
     ]
+  },
+  "Chest, Shoulders & Legs (ActiveTrax)": {
+    exercises: [
+      {
+        code: "N/A",
+        machine: "Cable Crossover",
+        region: "Chest Pecs",
+        feel: "Medium",
+        sets: [
+          { weight: 60, reps: 15, rest: "1:00" },
+          { weight: 80, reps: 8, rest: "1:00" },
+          { weight: 90, reps: 6, rest: "1:00" }
+        ],
+        bestWeight: 90,
+        bestReps: 15
+      },
+      {
+        code: "N/A",
+        machine: "Seated Shoulder Press",
+        region: "Shoulders",
+        feel: "Medium",
+        sets: [
+          { weight: 25, reps: 15, rest: "1:00" },
+          { weight: 30, reps: 15, rest: "1:00" },
+          { weight: 30, reps: 15, rest: "1:00" }
+        ],
+        bestWeight: 30,
+        bestReps: 15
+      },
+      {
+        code: "N/A",
+        machine: "V-Bar Pushdown",
+        region: "Triceps",
+        feel: "Medium",
+        sets: [
+          { weight: 60, reps: 15, rest: "1:00" },
+          { weight: 70, reps: 15, rest: "1:00" },
+          { weight: 70, reps: 15, rest: "1:00" }
+        ],
+        bestWeight: 70,
+        bestReps: 15
+      },
+      {
+        code: "N/A",
+        machine: "Seated Leg Press",
+        region: "Quads / Hams",
+        feel: "Medium",
+        sets: [
+          { weight: 180, reps: 10, rest: "1:00" },
+          { weight: 200, reps: 10, rest: "1:00" },
+          { weight: 200, reps: 10, rest: "1:00" }
+        ],
+        bestWeight: 200,
+        bestReps: 10
+      },
+      {
+        code: "N/A",
+        machine: "Seated Leg Extension",
+        region: "Quads",
+        feel: "Medium",
+        sets: [
+          { weight: 170, reps: 10, rest: "1:30" },
+          { weight: 170, reps: 10, rest: "1:30" },
+          { weight: 200, reps: 8, rest: "1:30" }
+        ],
+        bestWeight: 200,
+        bestReps: 10
+      },
+      {
+        code: "N/A",
+        machine: "Seated Leg Curl",
+        region: "Hamstrings",
+        feel: "Medium",
+        sets: [
+          { weight: 155, reps: 15, rest: "1:30" },
+          { weight: 165, reps: 12, rest: "1:30" },
+          { weight: 165, reps: 8, rest: "1:30" }
+        ],
+        bestWeight: 165,
+        bestReps: 15
+      },
+      {
+        code: "N/A",
+        machine: "Glute Machine",
+        region: "Glutes",
+        feel: "Medium",
+        sets: [
+          { weight: 130, reps: 15, rest: "1:00" },
+          { weight: 130, reps: 15, rest: "1:00" },
+          { weight: 130, reps: 15, rest: "1:00" }
+        ],
+        bestWeight: 130,
+        bestReps: 15
+      },
+      {
+        code: "N/A",
+        machine: "Standing 1 Leg (1-DB) Calf Raise",
+        region: "Calves",
+        feel: "Medium",
+        sets: [
+          { weight: 45, reps: 15, rest: "1:00" },
+          { weight: 45, reps: 15, rest: "1:00" },
+          { weight: 45, reps: 15, rest: "1:00" }
+        ],
+        bestWeight: 45,
+        bestReps: 15
+      }
+    ],
+    abs: [
+      { name: "Ball Crunch", reps: 30 },
+      { name: "Decline Straight Leg Thrust", reps: 30 },
+      { name: "Decline Side Oblique Crunch", reps: 30 },
+      { name: "Straight Leg Lift with Thrust", reps: 30 },
+      { name: "Side Oblique Crunch with Heel Push", reps: 30 },
+      { name: "Decline Crunch", reps: 30 }
+    ]
   }
 };
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -49,7 +49,8 @@ export const workoutTypes = [
   "Back & Biceps (ActiveTrax)",
   "Chest & Triceps (ActiveTrax)",
   "Chest & Shoulders (ActiveTrax)",
-  "Leg Day (ActiveTrax)"
+  "Leg Day (ActiveTrax)",
+  "Chest, Shoulders & Legs (ActiveTrax)"
 ] as const;
 
 // Workouts table


### PR DESCRIPTION
## Summary
- include new template name in the workout types list
- add full template data for **Chest, Shoulders & Legs (ActiveTrax)**
- expose template in the workout template selector modal

## Testing
- `npm run check` *(fails: Property 'completed' is missing)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686af6d3280c832988bf1cea05110079