### PR TITLE
Fix workout date timezone issues

### DIFF
--- a/client/src/components/workout-card.tsx
+++ b/client/src/components/workout-card.tsx
@@ -2,6 +2,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Workout } from '@shared/schema';
+import { parseISODate } from '@/lib/utils';
 import {
   Calendar,
   Clock,
@@ -34,7 +35,7 @@ export function WorkoutCard({ workout, onStart, onView, onDelete }: WorkoutCardP
   const completionPercentage = totalExercises > 0 ? (completedExercises / totalExercises) * 100 : 0;
 
   const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
+    const date = parseISODate(dateString);
     return date.toLocaleDateString('en-US', {
       weekday: 'short',
       month: 'short',

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function parseISODate(date: string): Date {
+  const [year, month, day] = date.split("-").map(Number)
+  return new Date(year, month - 1, day)
+}
+

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -5,6 +5,7 @@ import { CalendarGrid } from '@/components/calendar-grid';
 import { WorkoutCard } from '@/components/workout-card';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from '@/lib/workout-data';
+import { parseISODate } from '@/lib/utils';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { Workout } from '@shared/schema';
 
@@ -112,7 +113,10 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
       onNavigateToWorkout(existingWorkout);
     } else {
       // Create new workout for selected date
-      const schedule = generateWorkoutSchedule(new Date(date).getFullYear(), new Date(date).getMonth() + 1);
+      const schedule = generateWorkoutSchedule(
+        parseISODate(date).getFullYear(),
+        parseISODate(date).getMonth() + 1
+      );
       const scheduledWorkout = schedule.find(w => w.date === date);
       
       if (scheduledWorkout) {

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { Workout } from '@shared/schema';
 import { BarChart, Calendar, Download, FileText, TrendingUp } from 'lucide-react';
+import { parseISODate } from '@/lib/utils';
 
 export function HistoryPage() {
   const [selectedPeriod, setSelectedPeriod] = useState<'week' | 'month' | 'year'>('month');
@@ -59,7 +60,7 @@ export function HistoryPage() {
         break;
     }
 
-    return workouts.filter(workout => new Date(workout.date) >= startDate);
+    return workouts.filter(workout => parseISODate(workout.date) >= startDate);
   }, [workouts, selectedPeriod]);
 
   const stats = useMemo(() => {
@@ -70,13 +71,16 @@ export function HistoryPage() {
 
     const sortedWorkouts = [...workouts]
       .filter(w => w.completed)
-      .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
+      .sort(
+        (a, b) =>
+          parseISODate(b.date).getTime() - parseISODate(a.date).getTime()
+      );
 
     let currentStreak = 0;
     const today = new Date();
 
     for (let i = 0; i < sortedWorkouts.length; i++) {
-      const workoutDate = new Date(sortedWorkouts[i].date);
+      const workoutDate = parseISODate(sortedWorkouts[i].date);
       const diffDays = Math.floor((today.getTime() - workoutDate.getTime()) / (1000 * 60 * 60 * 24));
       if (diffDays === currentStreak) {
         currentStreak++;
@@ -105,7 +109,7 @@ export function HistoryPage() {
   };
 
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
+    return parseISODate(dateString).toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
       year: 'numeric'

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -6,6 +6,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { ExerciseForm } from '@/components/exercise-form';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
+import { parseISODate } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 
@@ -183,7 +184,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
             {workout.type}
           </h1>
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            {new Date(workout.date).toLocaleDateString('en-US', {
+            {parseISODate(workout.date).toLocaleDateString('en-US', {
               weekday: 'long',
               month: 'long',
               day: 'numeric'


### PR DESCRIPTION
## Summary
- ensure local time is used when showing workout dates
- add `parseISODate` helper
- use `parseISODate` across calendar, history and workout views

## Testing
- `npx --yes vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686afa2d8e988329955c60bbae794978