### PR TITLE
Add confetti celebration on workout completion

### DIFF
--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -197,6 +197,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   }, [stats.completedItems, stats.totalItems, workout.completed, celebrated]);
 
   return (
+    <>
     <div className="max-w-md mx-auto p-4 space-y-6">
       {/* Header */}
       <div className="flex items-center space-x-3">
@@ -408,5 +409,6 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>
+    </>
   );
 }

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -9,6 +9,16 @@ import { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
 import { parseISODate } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import confetti from 'canvas-confetti';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
 
 interface WorkoutPageProps {
   workout: Workout;
@@ -19,6 +29,8 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   const [workout, setWorkout] = useState<Workout>(initialWorkout);
   const [currentExerciseIndex, setCurrentExerciseIndex] = useState(0);
   const [autoSaveEnabled, setAutoSaveEnabled] = useState(true);
+  const [celebrated, setCelebrated] = useState(false);
+  const [showDialog, setShowDialog] = useState(false);
   const { updateWorkout } = useWorkoutStorage();
   const { toast } = useToast();
 
@@ -166,6 +178,23 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   };
 
   const stats = getProgressStats();
+
+  useEffect(() => {
+    if (
+      !celebrated &&
+      !workout.completed &&
+      stats.totalItems > 0 &&
+      stats.completedItems === stats.totalItems
+    ) {
+      setCelebrated(true);
+      confetti({
+        particleCount: 150,
+        spread: 70,
+        origin: { y: 0.6 },
+      });
+      setShowDialog(true);
+    }
+  }, [stats.completedItems, stats.totalItems, workout.completed, celebrated]);
 
   return (
     <div className="max-w-md mx-auto p-4 space-y-6">
@@ -364,5 +393,20 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         </Button>
       </div>
     </div>
+    <AlertDialog open={showDialog} onOpenChange={setShowDialog}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>🎉 Workout Complete!</AlertDialogTitle>
+          <AlertDialogDescription>
+            You crushed it today.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction onClick={() => setShowDialog(false)}>
+            Close
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }

--- a/client/src/types/canvas-confetti.d.ts
+++ b/client/src/types/canvas-confetti.d.ts
@@ -1,0 +1,1 @@
+declare module 'canvas-confetti';

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@radix-ui/react-toggle-group": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.2.0",
     "@tanstack/react-query": "^5.60.5",
+    "canvas-confetti": "^1.9.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",


### PR DESCRIPTION
## Summary
- celebrate when progress reaches 100%
- show a dialog congratulating the user
- add `canvas-confetti` dependency

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b1529e22c83299c5f00935c399a06