### PR TITLE
Add daily workout rotation

### DIFF
--- a/client/src/lib/workout-data.test.ts
+++ b/client/src/lib/workout-data.test.ts
@@ -1,21 +1,24 @@
 import { describe, it, expect } from 'vitest'
-import { generateWorkoutSchedule } from './workout-data'
+import { generateWorkoutSchedule, workoutTemplates } from './workout-data'
 
 describe('generateWorkoutSchedule', () => {
-  it('creates expected schedule for February 2023', () => {
+  it('assigns a workout for every day in February 2023', () => {
     const year = 2023
     const month = 2
     const schedule = generateWorkoutSchedule(year, month)
 
     const daysInMonth = new Date(year, month, 0).getDate()
-    let expected = 0
-    for (let day = 1; day <= daysInMonth; day++) {
-      if (day % 3 === 0 && day % 7 !== 0) continue
-      expected++
-    }
-
-    expect(schedule.length).toBe(expected)
+    expect(schedule.length).toBe(daysInMonth)
     expect(schedule[0].date).toBe('2023-02-01')
     expect(schedule[schedule.length - 1].date).toBe('2023-02-28')
+
+    const types = Object.keys(workoutTemplates)
+    const baseDay = Date.UTC(1970, 0, 1) / 86400000
+
+    for (let i = 0; i < daysInMonth; i++) {
+      const expectedIndex =
+        Math.floor(Date.UTC(year, month - 1, i + 1) / 86400000) - baseDay
+      expect(schedule[i].type).toBe(types[expectedIndex % types.length])
+    }
   })
 })

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -864,14 +864,15 @@ export function generateWorkoutSchedule(year: number, month: number): { date: st
   const daysInMonth = new Date(year, month, 0).getDate();
   const workoutTypesList = Object.keys(workoutTemplates) as WorkoutType[];
 
-  for (let day = 1; day <= daysInMonth; day++) {
-    if (day % 3 === 0 && day % 7 !== 0) continue;
+  const baseDay = Date.UTC(1970, 0, 1) / 86400000;
 
-    const date = new Date(year, month - 1, day).toISOString().split('T')[0];
-    const typeIndex = Math.floor((day - 1) / 2) % workoutTypesList.length;
+  for (let day = 1; day <= daysInMonth; day++) {
+    const dateObj = new Date(year, month - 1, day);
+    const dayIndex = Math.floor(Date.UTC(year, month - 1, day) / 86400000) - baseDay;
+    const typeIndex = dayIndex % workoutTypesList.length;
 
     schedule.push({
-      date,
+      date: dateObj.toISOString().split('T')[0],
       type: workoutTypesList[typeIndex]
     });
   }
@@ -882,8 +883,10 @@ export function generateWorkoutSchedule(year: number, month: number): { date: st
 // Get today's workout type
 export function getTodaysWorkoutType(): WorkoutType {
   const today = new Date();
-  const dayOfYear = Math.floor((today.getTime() - new Date(today.getFullYear(), 0, 0).getTime()) / (1000 * 60 * 60 * 24));
   const workoutTypesList = Object.keys(workoutTemplates) as WorkoutType[];
 
-  return workoutTypesList[dayOfYear % workoutTypesList.length];
+  const baseDay = Date.UTC(1970, 0, 1) / 86400000;
+  const dayIndex = Math.floor(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate()) / 86400000) - baseDay;
+
+  return workoutTypesList[dayIndex % workoutTypesList.length];
 }


### PR DESCRIPTION
## Summary
- create a repeating workout schedule that assigns a workout for every day
- update the test to expect a workout each day

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686bffac5980832989105a104b153c98