### PR TITLE
Add 14-day workout scheduling cycle

### DIFF
--- a/client/src/lib/workout-data.test.ts
+++ b/client/src/lib/workout-data.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { generateWorkoutSchedule, workoutTemplates } from './workout-data'
+import { generateWorkoutSchedule, defaultWorkoutCycle } from './workout-data'
 
 describe('generateWorkoutSchedule', () => {
   it('assigns a workout for every day in February 2023', () => {
@@ -12,13 +12,14 @@ describe('generateWorkoutSchedule', () => {
     expect(schedule[0].date).toBe('2023-02-01')
     expect(schedule[schedule.length - 1].date).toBe('2023-02-28')
 
-    const types = Object.keys(workoutTemplates)
     const baseDay = Date.UTC(1970, 0, 1) / 86400000
 
     for (let i = 0; i < daysInMonth; i++) {
       const expectedIndex =
         Math.floor(Date.UTC(year, month - 1, i + 1) / 86400000) - baseDay
-      expect(schedule[i].type).toBe(types[expectedIndex % types.length])
+      expect(schedule[i].type).toBe(
+        defaultWorkoutCycle[expectedIndex % defaultWorkoutCycle.length]
+      )
     }
   })
 })

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -858,22 +858,39 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
   }
 };
 
+// Default 14-day workout cycle
+export const defaultWorkoutCycle: WorkoutType[] = [
+  "Chest & Triceps",
+  "Back & Biceps",
+  "Back and Legs",
+  "Chest & Shoulders",
+  "Back, Biceps & Legs",
+  "Chest Day",
+  "Back & Biceps",
+  "Chest, Shoulders & Legs",
+  "Back and Legs",
+  "Chest & Triceps",
+  "Back, Biceps & Legs",
+  "Chest & Shoulders",
+  "Back & Biceps",
+  "Chest, Shoulders & Legs"
+];
+
 // Generate workout schedule for a given month
 export function generateWorkoutSchedule(year: number, month: number): { date: string; type: WorkoutType }[] {
   const schedule: { date: string; type: WorkoutType }[] = [];
   const daysInMonth = new Date(year, month, 0).getDate();
-  const workoutTypesList = Object.keys(workoutTemplates) as WorkoutType[];
 
   const baseDay = Date.UTC(1970, 0, 1) / 86400000;
 
   for (let day = 1; day <= daysInMonth; day++) {
     const dateObj = new Date(year, month - 1, day);
     const dayIndex = Math.floor(Date.UTC(year, month - 1, day) / 86400000) - baseDay;
-    const typeIndex = dayIndex % workoutTypesList.length;
+    const typeIndex = dayIndex % defaultWorkoutCycle.length;
 
     schedule.push({
       date: dateObj.toISOString().split('T')[0],
-      type: workoutTypesList[typeIndex]
+      type: defaultWorkoutCycle[typeIndex]
     });
   }
 
@@ -883,10 +900,9 @@ export function generateWorkoutSchedule(year: number, month: number): { date: st
 // Get today's workout type
 export function getTodaysWorkoutType(): WorkoutType {
   const today = new Date();
-  const workoutTypesList = Object.keys(workoutTemplates) as WorkoutType[];
 
   const baseDay = Date.UTC(1970, 0, 1) / 86400000;
   const dayIndex = Math.floor(Date.UTC(today.getFullYear(), today.getMonth(), today.getDate()) / 86400000) - baseDay;
 
-  return workoutTypesList[dayIndex % workoutTypesList.length];
+  return defaultWorkoutCycle[dayIndex % defaultWorkoutCycle.length];
 }


### PR DESCRIPTION
## Summary
- implement a fixed 14‑day workout cycle
- generate schedules from the new cycle
- update tests for cycle logic

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686c0a86100483299c6af62693c0b3db