### PR TITLE
Fix timezone-safe date formatting

### DIFF
--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Workout } from '@shared/schema';
 import { generateWorkoutSchedule } from '@/lib/workout-data';
-import { cn } from '@/lib/utils';
+import { cn, formatLocalDate } from '@/lib/utils';
 
 interface CalendarGridProps {
   currentDate: Date;
@@ -45,7 +45,7 @@ export function CalendarGrid({
     const day = prevMonthDays - i;
     calendarDays.push({
       day: day,
-      date: new Date(year, month - 1, day).toISOString().split('T')[0],
+      date: formatLocalDate(new Date(year, month - 1, day)),
       isCurrentMonth: false,
       isToday: false
     });
@@ -53,7 +53,7 @@ export function CalendarGrid({
 
   for (let day = 1; day <= daysInMonth; day++) {
     const date = new Date(year, month, day);
-    const dateString = date.toISOString().split('T')[0];
+    const dateString = formatLocalDate(date);
     const isToday = date.toDateString() === today.toDateString();
 
     calendarDays.push({
@@ -68,7 +68,7 @@ export function CalendarGrid({
   for (let day = 1; day <= remainingDays; day++) {
     calendarDays.push({
       day: day,
-      date: new Date(year, month + 1, day).toISOString().split('T')[0],
+      date: formatLocalDate(new Date(year, month + 1, day)),
       isCurrentMonth: false,
       isToday: false
     });

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { Workout, InsertWorkout, UserPreferences, Exercise } from '@shared/schema';
 import { localWorkoutStorage } from '@/lib/storage';
 import { workoutTemplates } from '@/lib/workout-data';
+import { formatLocalDate } from '@/lib/utils';
 
 export function useWorkoutStorage() {
   const [workouts, setWorkouts] = useState<Workout[]>([]);
@@ -118,9 +119,7 @@ export function useWorkoutStorage() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `ironpup-data-${new Date()
-      .toISOString()
-      .split("T")[0]}.json`;
+    a.download = `ironpup-data-${formatLocalDate(new Date())}.json`;
     a.click();
     URL.revokeObjectURL(url);
   };
@@ -136,9 +135,7 @@ export function useWorkoutStorage() {
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
-    a.download = `ironpup-data-${new Date()
-      .toISOString()
-      .split("T")[0]}.csv`;
+    a.download = `ironpup-data-${formatLocalDate(new Date())}.csv`;
     a.click();
     URL.revokeObjectURL(url);
   };

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -10,3 +10,10 @@ export function parseISODate(date: string): Date {
   return new Date(year, month - 1, day)
 }
 
+export function formatLocalDate(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, "0")
+  const day = String(date.getDate()).padStart(2, "0")
+  return `${year}-${month}-${day}`
+}
+

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -1,4 +1,5 @@
 import { Exercise, AbsExercise, WorkoutType, ExerciseSet } from "@shared/schema";
+import { formatLocalDate } from "@/lib/utils";
 
 type TemplateExercise = Omit<Exercise, 'completed' | 'sets'> & {
   sets: Omit<ExerciseSet, 'completed'>[];
@@ -889,7 +890,7 @@ export function generateWorkoutSchedule(year: number, month: number): { date: st
     const typeIndex = dayIndex % defaultWorkoutCycle.length;
 
     schedule.push({
-      date: dateObj.toISOString().split('T')[0],
+      date: formatLocalDate(dateObj),
       type: defaultWorkoutCycle[typeIndex]
     });
   }

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -5,7 +5,7 @@ import { CalendarGrid } from '@/components/calendar-grid';
 import { WorkoutCard } from '@/components/workout-card';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from '@/lib/workout-data';
-import { parseISODate } from '@/lib/utils';
+import { parseISODate, formatLocalDate } from '@/lib/utils';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { Workout } from '@shared/schema';
 
@@ -67,18 +67,14 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     if (typeof date === "string") {
       normalized = date; // assume already in YYYY-MM-DD format
     } else {
-      // convert from JS Date to YYYY-MM-DD without timezone shift
-      const year = date.getFullYear();
-      const month = String(date.getMonth() + 1).padStart(2, "0");
-      const day = String(date.getDate()).padStart(2, "0");
-      normalized = `${year}-${month}-${day}`;
+      normalized = formatLocalDate(date);
     }
 
     setSelectedDate(normalized);
   };
 
   const handleStartTodayWorkout = async () => {
-    const today = new Date().toISOString().split('T')[0];
+    const today = formatLocalDate(new Date());
     const existingWorkout = await getWorkoutByDate(today);
     
     if (existingWorkout) {
@@ -164,7 +160,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     for (let i = 0; i < 30; i++) {
       const date = new Date(today);
       date.setDate(today.getDate() - i);
-      const dateString = date.toISOString().split('T')[0];
+      const dateString = formatLocalDate(date);
       
       const workout = workouts.find(w => w.date === dateString);
       if (workout && workout.completed) {


### PR DESCRIPTION
## Summary
- add a `formatLocalDate` helper
- use `formatLocalDate` when generating workout schedules
- format calendar dates using `formatLocalDate`
- normalize dates with helper when starting workouts and calculating streaks
- export files with locale-safe filenames

## Testing
- `npm run check`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c11251ea88329a59ea5c748ffed4e