### PR TITLE
Fix clearing weight/reps inputs

### DIFF
--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -14,7 +14,11 @@ interface ExerciseFormProps {
 export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseFormProps) {
   const [localExercise, setLocalExercise] = useState<Exercise>(exercise);
 
-  const updateSet = (setIndex: number, field: keyof ExerciseSet, value: string | number | boolean) => {
+  const updateSet = (
+    setIndex: number,
+    field: keyof ExerciseSet,
+    value: string | number | boolean | undefined
+  ) => {
     const updatedSets = [...localExercise.sets];
     updatedSets[setIndex] = {
       ...updatedSets[setIndex],
@@ -43,7 +47,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
   };
 
   const getWeightChange = () => {
-    const currentWeight = Math.max(...localExercise.sets.map(s => s.weight));
+    const currentWeight = Math.max(...localExercise.sets.map(s => s.weight || 0));
     const bestWeight = localExercise.bestWeight || 0;
     const difference = currentWeight - bestWeight;
     
@@ -107,8 +111,14 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                 
                 <Input
                   type="number"
-                  value={set.weight}
-                  onChange={(e) => updateSet(index, 'weight', parseInt(e.target.value) || 0)}
+                  value={set.weight ?? ''}
+                  onChange={(e) =>
+                    updateSet(
+                      index,
+                      'weight',
+                      e.target.value === '' ? undefined : parseInt(e.target.value)
+                    )
+                  }
                   className="w-16 text-sm"
                   placeholder="lbs"
                   disabled={false}
@@ -118,8 +128,14 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                 
                 <Input
                   type="number"
-                  value={set.reps}
-                  onChange={(e) => updateSet(index, 'reps', parseInt(e.target.value) || 0)}
+                  value={set.reps ?? ''}
+                  onChange={(e) =>
+                    updateSet(
+                      index,
+                      'reps',
+                      e.target.value === '' ? undefined : parseInt(e.target.value)
+                    )
+                  }
                   className="w-14 text-sm"
                   placeholder="reps"
                   disabled={false}

--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -4,6 +4,7 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Exercise, ExerciseSet } from '@shared/schema';
 import { Check, Clock } from 'lucide-react';
+import { useToast } from '@/hooks/use-toast';
 
 interface ExerciseFormProps {
   exercise: Exercise;
@@ -13,6 +14,10 @@ interface ExerciseFormProps {
 
 export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseFormProps) {
   const [localExercise, setLocalExercise] = useState<Exercise>(exercise);
+  const { toast } = useToast();
+
+  const isSetComplete = (set: ExerciseSet) =>
+    set.weight !== undefined && set.reps !== undefined && set.rest.trim() !== '';
 
   const updateSet = (
     setIndex: number,
@@ -31,10 +36,28 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
   };
 
   const markSetComplete = (setIndex: number) => {
+    const set = localExercise.sets[setIndex];
+    if (!isSetComplete(set)) {
+      toast({
+        title: 'Set incomplete',
+        description: 'Enter weight, reps and rest first',
+        variant: 'destructive'
+      });
+      return;
+    }
     updateSet(setIndex, 'completed', true);
   };
 
   const toggleExerciseComplete = () => {
+    const allSetsComplete = localExercise.sets.every(isSetComplete);
+    if (!allSetsComplete) {
+      toast({
+        title: 'Exercise incomplete',
+        description: 'Fill all fields for each set first',
+        variant: 'destructive'
+      });
+      return;
+    }
     const updatedExercise = { ...localExercise, completed: !localExercise.completed };
     setLocalExercise(updatedExercise);
     onUpdate(updatedExercise);
@@ -91,6 +114,9 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
           
           {localExercise.sets.map((set, index) => {
             const status = getSetStatus(set, index);
+            const weightError = set.weight === undefined;
+            const repsError = set.reps === undefined;
+            const restError = set.rest.trim() === '';
             
             return (
               <div
@@ -119,7 +145,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                       e.target.value === '' ? undefined : parseInt(e.target.value)
                     )
                   }
-                  className="w-16 text-sm"
+                  className={`w-16 text-sm ${weightError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="lbs"
                   disabled={false}
                 />
@@ -136,7 +162,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                       e.target.value === '' ? undefined : parseInt(e.target.value)
                     )
                   }
-                  className="w-14 text-sm"
+                  className={`w-14 text-sm ${repsError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="reps"
                   disabled={false}
                 />
@@ -145,7 +171,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                   type="text"
                   value={set.rest}
                   onChange={(e) => updateSet(index, 'rest', e.target.value)}
-                  className="w-16 text-sm"
+                  className={`w-16 text-sm ${restError ? 'border-red-500 focus-visible:ring-red-500' : ''}`}
                   placeholder="rest"
                   disabled={false}
                 />

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -48,9 +48,13 @@ export class LocalWorkoutStorage {
   private updateExerciseHistory(exercises: Exercise[], date: string) {
     const history = this.getExerciseHistory();
     for (const e of exercises) {
+      // only record history when all sets have numeric values
+      if (e.sets.some(s => s.weight === undefined || s.reps === undefined)) {
+        continue;
+      }
       const key = e.machine; // use machine name to avoid duplicate codes
       history[key] = {
-        sets: e.sets.map(s => ({ weight: s.weight, reps: s.reps, rest: s.rest })),
+        sets: e.sets.map(s => ({ weight: s.weight!, reps: s.reps!, rest: s.rest })),
         date,
       };
     }

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -49,7 +49,14 @@ export class LocalWorkoutStorage {
     const history = this.getExerciseHistory();
     for (const e of exercises) {
       // only record history when all sets have numeric values
-      if (e.sets.some(s => s.weight === undefined || s.reps === undefined)) {
+      if (
+        e.sets.some(
+          s =>
+            s.weight === undefined ||
+            s.reps === undefined ||
+            s.rest.trim() === ''
+        )
+      ) {
         continue;
       }
       const key = e.machine; // use machine name to avoid duplicate codes

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -22,7 +22,9 @@ export function HistoryPage() {
           exerciseProgress[exercise.machine] = [];
         }
 
-        const maxWeight = Math.max(...exercise.sets.map(s => s.weight));
+        const maxWeight = Math.max(
+          ...exercise.sets.map(s => s.weight ?? 0)
+        );
         exerciseProgress[exercise.machine].push(maxWeight);
       });
     });

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -104,7 +104,12 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     const allAbsComplete = workout.abs.every(a => a.completed);
     const cardioComplete = workout.cardio?.completed || false;
     const allFieldsFilled = workout.exercises.every(ex =>
-      ex.sets.every(s => s.weight !== undefined && s.reps !== undefined)
+      ex.sets.every(
+        s =>
+          s.weight !== undefined &&
+          s.reps !== undefined &&
+          s.rest.trim() !== ''
+      )
     );
 
     if (!allExercisesComplete || !allAbsComplete || !cardioComplete || !allFieldsFilled) {

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -103,8 +103,11 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     const allExercisesComplete = workout.exercises.every(e => e.completed);
     const allAbsComplete = workout.abs.every(a => a.completed);
     const cardioComplete = workout.cardio?.completed || false;
-    
-    if (!allExercisesComplete || !allAbsComplete || !cardioComplete) {
+    const allFieldsFilled = workout.exercises.every(ex =>
+      ex.sets.every(s => s.weight !== undefined && s.reps !== undefined)
+    );
+
+    if (!allExercisesComplete || !allAbsComplete || !cardioComplete || !allFieldsFilled) {
       toast({
         title: "Incomplete workout",
         description: "Please complete all exercises before marking as complete",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -4,8 +4,8 @@ import { z } from "zod";
 
 // Exercise set schema
 const exerciseSetSchema = z.object({
-  weight: z.number(),
-  reps: z.number(),
+  weight: z.number().optional(),
+  reps: z.number().optional(),
   rest: z.string(), // e.g., "1:30"
   completed: z.boolean().default(false)
 });


### PR DESCRIPTION
## Summary
- allow weight & reps inputs to be blank
- skip exercise history updates when sets incomplete
- block workout completion if any blank set values
- fix history chart and weight change calcs for optional values

## Testing
- `npm run check`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c58682b448329946699515e028822