### PR TITLE
Fix calendar completion icon priority

### DIFF
--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -142,10 +142,10 @@ export function CalendarGrid({
             );
           }
 
-          const status = dayData.isToday
-            ? '📅'
-            : isCompleted
-              ? '✅'
+          const status = isCompleted
+            ? '✅'
+            : dayData.isToday
+              ? '📅'
               : hasWorkout
                 ? '🕒'
                 : '';


### PR DESCRIPTION
## Summary
- prioritize the green checkmark over the "today" icon in calendar grid

## Testing
- `npm run check`
- `npm test` *(once to run and once to stop watch mode)*

------
https://chatgpt.com/codex/tasks/task_e_686c66a31da48329b3b69b4c14df3fdd