### PR TITLE
Fix dist path for prod server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
-    "start": "NODE_ENV=production node dist/index.js",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist/server",
+    "start": "NODE_ENV=production node dist/server/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "test": "vitest"

--- a/server/index.ts
+++ b/server/index.ts
@@ -47,13 +47,12 @@ app.use((req, res, next) => {
     throw err;
   });
 
-  // importantly only setup vite in development and after
-  // setting up all the other routes so the catch-all route
-  // doesn't interfere with the other routes
-  if (app.get("env") === "development") {
-    await setupVite(app, server);
-  } else {
+  // During development, run Vite's middleware for hot reloading.
+  // In production, serve the prebuilt static files.
+  if (process.env.NODE_ENV === "production") {
     serveStatic(app);
+  } else {
+    await setupVite(app, server);
   }
 
   // ALWAYS serve the app on port 5000

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -1,10 +1,16 @@
 import express, { type Express } from "express";
 import fs from "fs";
 import path from "path";
+import { fileURLToPath } from "url";
 import { createServer as createViteServer, createLogger } from "vite";
 import { type Server } from "http";
 import viteConfig from "../vite.config";
 import { nanoid } from "nanoid";
+
+// Similar to vite.config.ts, provide a Node 18 fallback for import.meta.dirname.
+const DIRNAME = typeof import.meta.dirname !== "undefined"
+  ? import.meta.dirname
+  : path.dirname(fileURLToPath(import.meta.url));
 
 const viteLogger = createLogger();
 
@@ -46,7 +52,7 @@ export async function setupVite(app: Express, server: Server) {
 
     try {
       const clientTemplate = path.resolve(
-        import.meta.dirname,
+        DIRNAME,
         "..",
         "client",
         "index.html",
@@ -68,18 +74,22 @@ export async function setupVite(app: Express, server: Server) {
 }
 
 export function serveStatic(app: Express) {
-  const distPath = path.resolve(import.meta.dirname, "public");
+  // The bundled server is placed in `dist/server` while the client build
+  // output lives one directory up. Resolve that directory and ensure the
+  // client assets exist before attempting to serve them.
+  const clientDistPath = path.resolve(DIRNAME, "..");
+  const indexHtml = path.resolve(clientDistPath, "index.html");
 
-  if (!fs.existsSync(distPath)) {
+  if (!fs.existsSync(indexHtml)) {
     throw new Error(
-      `Could not find the build directory: ${distPath}, make sure to build the client first`,
+      `Could not find the build directory: ${clientDistPath}, make sure to build the client first`,
     );
   }
 
-  app.use(express.static(distPath));
+  app.use(express.static(clientDistPath));
 
   // fall through to index.html if the file doesn't exist
   app.use("*", (_req, res) => {
-    res.sendFile(path.resolve(distPath, "index.html"));
+    res.sendFile(indexHtml);
   });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
 import runtimeErrorOverlay from "@replit/vite-plugin-runtime-error-modal";
+
+// Node <20 does not include import.meta.dirname. Compute it manually for
+// backward compatibility.
+const DIRNAME = typeof import.meta.dirname !== "undefined"
+  ? import.meta.dirname
+  : path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [
@@ -18,15 +25,15 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      "@": path.resolve(import.meta.dirname, "client", "src"),
-      "@shared": path.resolve(import.meta.dirname, "shared"),
-      "@assets": path.resolve(import.meta.dirname, "attached_assets"),
+      "@": path.resolve(DIRNAME, "client", "src"),
+      "@shared": path.resolve(DIRNAME, "shared"),
+      "@assets": path.resolve(DIRNAME, "attached_assets"),
     },
   },
-  root: path.resolve(import.meta.dirname, "client"),
+  root: path.resolve(DIRNAME, "client"),
   build: {
     // ✅ Output goes directly to dist/ — no nested /public
-    outDir: path.resolve(import.meta.dirname, "dist"),
+    outDir: path.resolve(DIRNAME, "dist"),
     emptyOutDir: true,
   },
   server: {


### PR DESCRIPTION
## Summary
- fix server-side static file path
- keep server build output isolated under dist/server
- add backward-compatible support for `import.meta.dirname`
- serve static assets and index.html only in production

## Testing
- `npx -y vitest run`

------
https://chatgpt.com/codex/tasks/task_e_686c7e476c488329820de740e97c2dea