### PR TITLE
Fix server error handler

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -43,8 +43,12 @@ app.use((req, res, next) => {
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
 
+    // Respond with the error message but don't rethrow it to avoid
+    // crashing the server. Express will continue handling requests.
     res.status(status).json({ message });
-    throw err;
+
+    // Log the full stack for debugging purposes.
+    log(err.stack || String(err), "error");
   });
 
   // During development, run Vite's middleware for hot reloading.


### PR DESCRIPTION
## Summary
- prevent Express server crashes when a route throws an error

## Testing
- `pnpm check`
- `pnpm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c89bf32a4832980c385fe47ebdd86