### PR TITLE
Fix custom workout duplication and add deletion

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -18,9 +18,10 @@ interface CustomWorkoutBuilderModalProps {
   open: boolean;
   onClose: () => void;
   onCreate: (name: string, exercises: Exercise[], abs: AbsExercise[]) => void;
+  existingNames: string[];
 }
 
-export function CustomWorkoutBuilderModal({ open, onClose, onCreate }: CustomWorkoutBuilderModalProps) {
+export function CustomWorkoutBuilderModal({ open, onClose, onCreate, existingNames }: CustomWorkoutBuilderModalProps) {
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [selectedAbs, setSelectedAbs] = useState<Set<string>>(new Set());
   const [name, setName] = useState('');
@@ -49,8 +50,10 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate }: CustomWor
     });
   };
 
+  const isDuplicate = existingNames.some(n => n.toLowerCase() === name.trim().toLowerCase());
+
   const handleCreate = () => {
-    if (name.trim() === '' || selected.size === 0) return;
+    if (name.trim() === '' || selected.size === 0 || isDuplicate) return;
     const exercises: Exercise[] = Array.from(selected).map(m => {
       const info = exerciseLibrary.find(e => e.machine === m)!;
       return {
@@ -138,7 +141,10 @@ export function CustomWorkoutBuilderModal({ open, onClose, onCreate }: CustomWor
           <p className="text-red-600 text-sm">🚨 Danger: Too many exercises in one session isn’t effective. Consider splitting it up.</p>
         )}
         <Input placeholder="Workout name" value={name} onChange={e => setName(e.target.value)} />
-        <Button onClick={handleCreate} disabled={name.trim() === '' || selected.size === 0}>Save Workout</Button>
+        {isDuplicate && (
+          <p className="text-red-600 text-sm">Workout name must be unique</p>
+        )}
+        <Button onClick={handleCreate} disabled={name.trim() === '' || selected.size === 0 || isDuplicate}>Save Workout</Button>
       </DialogContent>
     </Dialog>
   );

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -14,9 +14,10 @@ interface WorkoutTemplateSelectorModalProps {
   onClose: () => void;
   onSelectTemplate: (template: string) => void;
   onCreateCustom: () => void;
+  onDeleteTemplate: (id: number) => void;
 }
 
-export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, onSelectTemplate, onCreateCustom }: WorkoutTemplateSelectorModalProps) {
+export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, onSelectTemplate, onCreateCustom, onDeleteTemplate }: WorkoutTemplateSelectorModalProps) {
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       onClose();
@@ -55,9 +56,26 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
             <div className="pt-2 border-t border-gray-200 dark:border-gray-700 space-y-2">
               <div className="text-sm font-medium text-gray-600 dark:text-gray-400">Custom Workouts</div>
               {customTemplates.map(t => (
-                <Button key={t.id} variant="outline" onClick={() => onSelectTemplate(t.name)}>
-                  {t.name}
-                </Button>
+                <div key={t.id} className="flex items-center space-x-1">
+                  <Button
+                    variant="outline"
+                    className="flex-1 justify-start"
+                    onClick={() => onSelectTemplate(t.name)}
+                  >
+                    {t.name}
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    className="text-red-600"
+                    onClick={() => {
+                      if (confirm('Are you sure you want to delete this workout?')) {
+                        onDeleteTemplate(t.id);
+                      }
+                    }}
+                  >
+                    ✕
+                  </Button>
+                </div>
               ))}
             </div>
           )}

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -157,6 +157,14 @@ export function useWorkoutStorage() {
     return newTemplate;
   };
 
+  const deleteCustomTemplate = async (id: number) => {
+    const success = await localWorkoutStorage.deleteCustomTemplate(id);
+    if (success) {
+      setCustomTemplates(prev => prev.filter(t => t.id !== id));
+    }
+    return success;
+  };
+
 
   const resetAllData = async () => {
     await localWorkoutStorage.clearAllData();
@@ -178,6 +186,7 @@ export function useWorkoutStorage() {
     updateWorkout,
     deleteWorkout,
     addCustomTemplate,
+    deleteCustomTemplate,
     resetAllData,
     exportData,
     exportCSV

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -167,6 +167,14 @@ export class LocalWorkoutStorage {
     return newTemplate;
   }
 
+  async deleteCustomTemplate(id: number): Promise<boolean> {
+    const templates = this.getCustomTemplatesInternal();
+    const filtered = templates.filter(t => t.id !== id);
+    if (filtered.length === templates.length) return false;
+    this.saveCustomTemplates(filtered);
+    return true;
+  }
+
   async getUserPreferences(): Promise<UserPreferences> {
     const stored = localStorage.getItem(STORAGE_KEYS.PREFERENCES);
     const defaultPrefs: UserPreferences = {

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -28,6 +28,7 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     createWorkoutForDate,
     deleteWorkout,
     addCustomTemplate,
+    deleteCustomTemplate,
     customTemplates,
     loading
   } = useWorkoutStorage();
@@ -107,6 +108,10 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
     await loadWorkoutForDate(dateForCreation);
     setCustomBuilderOpen(false);
     setDateForCreation(null);
+  };
+
+  const handleDeleteCustomTemplate = async (id: number) => {
+    await deleteCustomTemplate(id);
   };
 
 
@@ -366,11 +371,13 @@ export function CalendarPage({ onNavigateToWorkout }: CalendarPageProps) {
         onClose={() => setTemplateModalOpen(false)}
         onSelectTemplate={handleTemplateSelect}
         onCreateCustom={handleCreateCustom}
+        onDeleteTemplate={handleDeleteCustomTemplate}
       />
       <CustomWorkoutBuilderModal
         open={customBuilderOpen}
         onClose={() => setCustomBuilderOpen(false)}
         onCreate={handleCustomWorkoutCreate}
+        existingNames={customTemplates.map(t => t.name)}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- prevent duplicate custom workout names in CustomWorkoutBuilderModal
- expose deleteCustomTemplate in storage and hook
- allow users to remove custom workouts in selector modal
- pass existing names and delete handler from calendar page

## Testing
- `npm run check`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d3c47f1a08329aafe748031670c84