### PR TITLE
Rename misnamed workout template

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A sleek, full-stack workout tracker app designed for lifters who want an intuiti
 ## Features
 
 - 🗖️ **Interactive Workout Calendar** – View and manage workouts day-by-day, with colored status icons for pending, completed, and current-day sessions.
-- 🏋️‍♂️ **Custom Workout Templates** – Add your own "Back & Legs", "Chest Day", and other templates for fast schedule generation.
+- 🏋️‍♂️ **Custom Workout Templates** – Add your own "Legs", "Chest Day", and other templates for fast schedule generation.
 - 📈 **Progress & Streak Tracking** – Tracks progress visually and calculates daily completion streaks using locale-safe date handling.
 - 🧠 **Auto-Save with Local Persistence** – Your progress is saved automatically, even offline.
 - 📤 **Export to JSON or CSV** – Export your workout history with locale-safe filenames for easy backups or analysis.

--- a/attached_assets/design.txt
+++ b/attached_assets/design.txt
@@ -38,7 +38,7 @@ Doctor Biz cycles through multiple workout focus days. These are shown in calend
 
 Chest, Shoulder Focus
 
-Back and Legs
+Legs
 
 Chest, Tricep Focus
 

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -45,14 +45,14 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
           <Button variant="outline" onClick={() => onSelectTemplate('Chest Day')}>Chest Day</Button>
           {/*
             Template keys are defined in workout-data.ts using
-            "Back and Legs". Passing the mismatched label caused
+            "Legs". Passing the mismatched label caused
             workout creation to silently fail.
           */}
           <Button
             variant="outline"
-            onClick={() => onSelectTemplate('Back and Legs')}
+            onClick={() => onSelectTemplate('Legs')}
           >
-            Back & Legs
+            Legs
           </Button>
           <Button variant="outline" onClick={() => onSelectTemplate('Back & Biceps')}>Back & Biceps</Button>
           <Button variant="outline" onClick={() => onSelectTemplate('Back, Biceps & Legs')}>Back, Biceps & Legs</Button>

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -114,7 +114,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
     ]
   },
 
-  "Back and Legs": {
+  "Legs": {
     exercises: [
       {
         code: "S36",
@@ -864,13 +864,13 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
 export const defaultWorkoutCycle: string[] = [
   "Chest & Triceps",
   "Back & Biceps",
-  "Back and Legs",
+  "Legs",
   "Chest & Shoulders",
   "Back, Biceps & Legs",
   "Chest Day",
   "Back & Biceps",
   "Chest, Shoulders & Legs",
-  "Back and Legs",
+  "Legs",
   "Chest & Triceps",
   "Back, Biceps & Legs",
   "Chest & Shoulders",

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -41,7 +41,7 @@ const cardioSchema = z.object({
 // Workout types (add all valid workout templates here)
 export const workoutTypes = [
   "Chest, Shoulder Focus",
-  "Back and Legs",
+  "Legs",
   "Chest, Tricep Focus",
   "Back, Biceps, and Legs",
   "Chest, Shoulders, and Back",


### PR DESCRIPTION
## Summary
- rename "Back and Legs" workout template to just "Legs"
- update all references in schema, data, selector modal and docs

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run check` *(terminated)*

------
https://chatgpt.com/codex/tasks/task_e_686e9a518b888329a18b645022e70d2d