### PR TITLE
Fix non-null assertion in CustomWorkoutBuilderModal

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -155,9 +155,14 @@ export function CustomWorkoutBuilderModal({
 
   const handleSave = () => {
     if (name.trim() === '' || selected.size === 0 || isDuplicate) return;
-    const exercises: Exercise[] = Array.from(selected).map(m => {
-      const info = exerciseLibrary.find(e => e.machine === m)!;
-      return {
+    const exercises: Exercise[] = [];
+    Array.from(selected).forEach(m => {
+      const info = exerciseLibrary.find(e => e.machine === m);
+      if (!info) {
+        console.warn(`Unknown exercise machine: ${m}`);
+        return;
+      }
+      exercises.push({
         machine: info.machine,
         region: info.region,
         equipment: info.equipment,
@@ -168,16 +173,22 @@ export function CustomWorkoutBuilderModal({
           { weight: undefined, reps: undefined, rest: '', completed: false },
           { weight: undefined, reps: undefined, rest: '', completed: false },
         ],
-      } as Exercise;
+      } as Exercise);
     });
-    const abs: AbsExercise[] = Array.from(selectedAbs).map(n => {
-      const info = absLibrary.find(a => a.name === n)!;
-      return {
+
+    const abs: AbsExercise[] = [];
+    Array.from(selectedAbs).forEach(n => {
+      const info = absLibrary.find(a => a.name === n);
+      if (!info) {
+        console.warn(`Unknown abs exercise: ${n}`);
+        return;
+      }
+      abs.push({
         name: info.name,
         reps: info.reps,
         time: info.time,
         completed: false,
-      } as AbsExercise;
+      } as AbsExercise);
     });
     if (template && onUpdate) {
       onUpdate(template.id, name, exercises, abs, includeInSchedule);


### PR DESCRIPTION
## Summary
- avoid crashing when selected exercises are missing
- warn and skip unknown selections instead of assuming presence

## Testing
- `npm run check` *(fails: 'custom.abs' is possibly undefined)*
- `npx vitest run --environment jsdom` *(fails: topRef.current?.scrollIntoView is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_687e59087d7483299a0040d178311ef7