### PR TITLE
test: add Playwright end-to-end coverage and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# A newer push to the same branch supersedes an in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Typecheck, unit tests, end-to-end
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Unit tests
+        run: npx vitest run
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: End-to-end tests
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@
 
 node_modules/
 dist/
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,56 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+/**
+ * Navigate and wait until the service worker has settled.
+ *
+ * On a first visit the app registers its service worker, which calls
+ * `clients.claim()`. That fires `controllerchange`, and `index.html` responds by
+ * calling `window.location.reload()` — so a first load silently becomes two.
+ *
+ * That reload discards anything typed before it lands, which makes every test
+ * that interacts quickly flaky (and is a real defect for users, not just for
+ * tests — see the service-worker fix). Reloading once deliberately puts the page
+ * in a steady state where the controller is already installed, so
+ * `controllerchange` cannot fire again for this context.
+ *
+ * Once the underlying bug is fixed, this can collapse back to `page.goto(path)`.
+ */
+export async function gotoSettled(page: Page, path = '/'): Promise<void> {
+  await page.goto(path);
+  await page.waitForFunction(() => !!navigator.serviceWorker?.controller, null, {
+    timeout: 15_000,
+  });
+  await page.reload();
+  await page.waitForLoadState('load');
+}
+
+/** Number of times the document has loaded — 1 unless something reloaded it. */
+export async function countPageLoads(page: Page): Promise<number> {
+  return page.evaluate(
+    () => performance.getEntriesByType('navigation').length,
+  );
+}
+
+/**
+ * Replace the contents of a numeric input, reliably.
+ *
+ * The app moves the caret to the end of these fields on focus, inside a
+ * `requestAnimationFrame` (see `useCursorEndOnFocus`). If that frame fires
+ * between Playwright's select-all and its insert, the selection collapses and
+ * the new text is appended instead of replacing — e.g. filling "137" over a
+ * seeded "75" yields "75137".
+ *
+ * That race is invisible to a human (nobody types within one frame of tapping a
+ * field), so this is harness compensation, not a workaround for a user-facing
+ * bug. Retrying the whole clear-then-fill sequence makes it deterministic.
+ */
+export async function setNumericValue(
+  locator: Locator,
+  value: string,
+): Promise<void> {
+  await expect(async () => {
+    await locator.fill('');
+    await locator.fill(value);
+    await expect(locator).toHaveValue(value);
+  }).toPass({ timeout: 10_000 });
+}

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from '@playwright/test';
+import { gotoSettled, setNumericValue } from './helpers';
+
+/**
+ * Baseline smoke coverage: the paths that must never break, exercised against a
+ * real production build in a real browser. Each browser context starts with an
+ * empty localStorage, so tests do not share state.
+ */
+
+test('the app shell loads and renders the calendar', async ({ page }) => {
+  await gotoSettled(page);
+
+  await expect(page.getByRole('heading', { name: 'IronPath' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Calendar' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'History' })).toBeVisible();
+
+  // The stats row renders three counters as buttons. Scoped by role because
+  // "Completed" also appears as static text in the workout-status legend.
+  await expect(page.getByRole('button', { name: /Completed/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Day Streak/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /Top Streak/ })).toBeVisible();
+});
+
+test("starting today's workout opens a workout with prefilled sets", async ({ page }) => {
+  await gotoSettled(page);
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await expect(page.getByText('Main Workout')).toBeVisible();
+
+  // Built-in templates seed weight/reps, so the first set is non-empty.
+  const firstWeight = page.getByLabel('Weight').first();
+  await expect(firstWeight).toBeVisible();
+  await expect(firstWeight).not.toHaveValue('');
+});
+
+test('logged weight survives a full page reload', async ({ page }) => {
+  await gotoSettled(page);
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+
+  const firstWeight = page.getByLabel('Weight').first();
+  await setNumericValue(firstWeight, '137');
+  await page.getByRole('button', { name: 'Save Workout' }).click();
+
+  // The save path is async, so wait for the value to actually reach storage
+  // before reloading. This also separates "did it persist" from "did it
+  // rehydrate" — a failure here points at storage, a failure after the reload
+  // points at rehydration.
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const stored = JSON.parse(localStorage.getItem('ironpath_workouts') ?? '[]');
+        return stored.some((w: { exercises?: { sets?: { weight?: number }[] }[] }) =>
+          w.exercises?.some(e => e.sets?.some(s => s.weight === 137)),
+        );
+      }),
+    )
+    .toBe(true);
+
+  await page.reload();
+
+  // Deep-linking back into the workout must rehydrate it from localStorage.
+  await expect(page.getByLabel('Weight').first()).toHaveValue('137');
+});
+
+test('a started workout appears on the calendar after navigating back', async ({ page }) => {
+  await gotoSettled(page);
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+
+  await page.getByRole('button', { name: 'Calendar' }).click();
+  await expect(page).toHaveURL(/\/$/);
+
+  // Today's cell carries the pending marker rather than the plain today marker.
+  await expect(page.getByText('🕒').first()).toBeVisible();
+});
+
+test('the workout page is reachable by deep link after a cold start', async ({ page }) => {
+  await gotoSettled(page);
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  const workoutUrl = page.url();
+
+  // Fresh navigation to the deep link exercises the SPA fallback plus
+  // rehydration from storage, which is what a reload in the gym does.
+  await page.goto(workoutUrl);
+  await expect(page.getByText('Main Workout')).toBeVisible();
+  await expect(page.getByLabel('Weight').first()).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.62.0",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1670,6 +1671,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.0.tgz",
+      "integrity": "sha512-9zOJ6ZQRAena31MpOH9VSzIz8Ou3YJ/wtY/eQm5T2uhfhG7/U3COrMS8xOtUrZrp9OgdmzEnIYODye3nY1VqzA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@radix-ui/number": {
@@ -7442,6 +7459,53 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.0.tgz",
+      "integrity": "sha512-Z14dG305dgaLu6foB1TXQagFiW8JfSUIUaUuPaKQ6NtBPKF1P/qXcqfh6c6K/icPqdy37JmjbiBXf6JNg6Sylw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.0.tgz",
+      "integrity": "sha512-nsNRyq0r2zsG8AcRHWknc9QRA5XCueC7gWMrs+Gx2tlZn9hcl8zudfh00lhJPY1DE7NmZ6bDsT9g2yey8mXljA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "NODE_ENV=production node dist/server/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "test": "vitest"
+    "test": "vitest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",
@@ -78,6 +79,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.62.0",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@testing-library/jest-dom": "^6.9.1",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,44 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 4173;
+const BASE_URL = `http://localhost:${PORT}`;
+
+/**
+ * End-to-end tests run against a real production build served by `vite preview`,
+ * not the dev server. IronPath is a PWA whose behaviour depends on the built
+ * output — hashed assets, the service worker, and the SPA fallback — none of
+ * which the dev server represents faithfully.
+ */
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      // The app is built mobile-first and is used on a phone in a gym.
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 7'] },
+    },
+  ],
+
+  webServer: {
+    command: `npm run build && npx vite preview --port ${PORT} --strictPort`,
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["client/src/**/*", "shared/**/*", "server/**/*"],
+  "include": ["client/src/**/*", "shared/**/*", "server/**/*", "e2e/**/*", "playwright.config.ts"],
   "exclude": ["node_modules", "build", "dist", "**/*.test.ts"],
   "compilerOptions": {
     "incremental": true,


### PR DESCRIPTION
## Why

**Nothing was running the test suite automatically.** Netlify's build command is `vite build && esbuild ...`, which never invokes vitest — so a PR with every test failing would still build and deploy green. The 11 existing unit tests only ran if someone remembered to run them locally.

This adds the missing gate, and the browser-level coverage that jsdom can't provide.

## What

- **GitHub Actions workflow** — typecheck + vitest + Playwright on every PR and every push to `main`. Free on public repos, so no billing impact.
- **Playwright**, configured against a real production build served by `vite preview` rather than the dev server. IronPath is a PWA whose behaviour depends on built output — hashed assets, the service worker, the SPA fallback — none of which the dev server represents faithfully.
- **Five smoke tests** over paths that must not break: app shell renders, starting today's workout, logged weight surviving a reload, the calendar pending marker, and deep-linking into a workout after a cold start.
- **Two viewport projects**, desktop and Pixel 7, since this is used on a phone in a gym.
- **tsconfig `include` extended** to cover `e2e/` and `playwright.config.ts`, so the test code is typechecked instead of silently unchecked.

## Verification

Full CI chain locally:

```
npx tsc --noEmit  -> clean
npx vitest run    -> 11 passed (5 files)
npx playwright test -> 10 passed (5 tests x 2 viewports)
```

Then **ten consecutive full-suite runs: 10/10 green, zero flakes.** That number matters — the suite was flaky when first written, and I chased it down rather than adding retries. See below.

## Two things the browser found that jsdom could not

Both are documented at the helper definitions in `e2e/helpers.ts`.

**1. The app reloads itself on first load.** Registering the service worker calls `clients.claim()`, which fires `controllerchange`, and `index.html` responds with `window.location.reload()`. One navigation becomes two — confirmed by instrumenting `page.on('load')`:

```
   67ms PAGE LOAD     <- the goto
  162ms PAGE LOAD     <- the app reloading itself
```

Anything typed before that reload lands is discarded. In a test it looks like flake; for a user opening the app fresh and starting to log immediately, it's lost input. `gotoSettled()` absorbs it here, and **the underlying bug is fixed in the service-worker PR that follows** — at which point the helper collapses back to a plain `page.goto`.

**2. Automated fill can append instead of replace.** `useCursorEndOnFocus` moves the caret to the end of numeric inputs inside a `requestAnimationFrame`. When that frame fires between Playwright's select-all and its insert, the selection collapses and text appends — filling `137` over the template's seeded `75` produced `75137`. `setNumericValue()` retries clear-then-fill to make it deterministic.

This one is **harness compensation, not an app defect** — a human cannot type within 16ms of tapping a field, so it doesn't affect real use. Flagging it because it looks like a bug in the diff and isn't.

## Risk

No application code is touched. Everything here is test infrastructure, CI config, and a `tsconfig` include. The only production-adjacent change is `@playwright/test` landing in `devDependencies`, which never ships to users.

## What to check

1. The Actions run on this PR goes green.
2. `npm run test:e2e` locally, if you want to watch it drive the app.
3. The Netlify preview still builds and behaves normally.

## Follow-up

The service-worker PR will invert the first finding into an assertion — `expect(pageLoads).toBe(1)` — so the fix is proven by the same instrument that found the bug.