### PR TITLE
fix: keep the auto-schedule rotation in step with template renames

### DIFF
--- a/client/src/lib/auto-schedule.test.ts
+++ b/client/src/lib/auto-schedule.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { localWorkoutStorage } from './storage';
+import {
+  defaultWorkoutCycle,
+  generateWorkoutSchedule,
+  getTodaysWorkoutType,
+  getWorkoutCycle,
+} from './workout-data';
+
+/**
+ * The auto-schedule rotation is persisted as a list of workout *names*. These
+ * tests pin the behaviour that has to hold when a custom template's name
+ * changes or the template disappears entirely.
+ */
+
+async function addTemplate(name: string, includeInAutoSchedule = true) {
+  return localWorkoutStorage.addCustomTemplate({
+    name,
+    exercises: [],
+    abs: [],
+    includeInAutoSchedule,
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('renaming a custom template', () => {
+  it('keeps it in the auto-schedule rotation', async () => {
+    const template = await addTemplate('My Custom');
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Chest Day', 'My Custom']);
+
+    await localWorkoutStorage.updateCustomTemplate(template.id, {
+      name: 'My Custom Renamed',
+      exercises: [],
+      abs: [],
+      includeInAutoSchedule: true,
+    });
+
+    expect(getWorkoutCycle()).toContain('My Custom Renamed');
+  });
+
+  it('does not leave the old name behind in the rotation', async () => {
+    const template = await addTemplate('My Custom');
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Chest Day', 'My Custom']);
+
+    await localWorkoutStorage.updateCustomTemplate(template.id, {
+      name: 'My Custom Renamed',
+      exercises: [],
+      abs: [],
+      includeInAutoSchedule: true,
+    });
+
+    expect(localWorkoutStorage.getAutoScheduleWorkouts()).not.toContain('My Custom');
+  });
+
+  it('leaves an unselected template out of the rotation after a rename', async () => {
+    const template = await addTemplate('Not Scheduled', false);
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Chest Day']);
+
+    await localWorkoutStorage.updateCustomTemplate(template.id, {
+      name: 'Still Not Scheduled',
+      exercises: [],
+      abs: [],
+      includeInAutoSchedule: false,
+    });
+
+    expect(getWorkoutCycle()).not.toContain('Still Not Scheduled');
+  });
+});
+
+describe('deleting a custom template', () => {
+  it('removes it from the stored rotation', async () => {
+    const template = await addTemplate('Doomed');
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Chest Day', 'Doomed']);
+
+    await localWorkoutStorage.deleteCustomTemplate(template.id);
+
+    expect(localWorkoutStorage.getAutoScheduleWorkouts()).not.toContain('Doomed');
+  });
+
+  it('leaves a usable rotation when it was the only one selected', async () => {
+    const template = await addTemplate('Only One');
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Only One']);
+
+    await localWorkoutStorage.deleteCustomTemplate(template.id);
+
+    expect(getWorkoutCycle().length).toBeGreaterThan(0);
+  });
+});
+
+describe('names shared with a built-in preset', () => {
+  it('keeps the preset selected when a same-named custom template is deleted', async () => {
+    // The builder does not currently stop a user naming a template after a
+    // preset, so the rotation entry can be claimed by both.
+    const template = await addTemplate('Legs');
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Legs']);
+
+    await localWorkoutStorage.deleteCustomTemplate(template.id);
+
+    expect(localWorkoutStorage.getAutoScheduleWorkouts()).toContain('Legs');
+    expect(getWorkoutCycle()).toContain('Legs');
+  });
+
+  it('keeps the preset selected when a same-named custom template is renamed', async () => {
+    const template = await addTemplate('Legs');
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Legs']);
+
+    await localWorkoutStorage.updateCustomTemplate(template.id, {
+      name: 'Legs But Mine',
+      exercises: [],
+      abs: [],
+      includeInAutoSchedule: true,
+    });
+
+    expect(localWorkoutStorage.getAutoScheduleWorkouts()).toContain('Legs');
+  });
+});
+
+describe('the schedule is always well-formed', () => {
+  it('never yields an undefined workout type', async () => {
+    const template = await addTemplate('Only One');
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Only One']);
+    await localWorkoutStorage.deleteCustomTemplate(template.id);
+
+    const schedule = generateWorkoutSchedule(2026, 7);
+    expect(schedule).toHaveLength(31);
+    expect(schedule.every(entry => typeof entry.type === 'string' && entry.type.length > 0)).toBe(
+      true,
+    );
+  });
+
+  it("never yields an undefined type for today", async () => {
+    localWorkoutStorage.saveAutoScheduleWorkouts(['A Template That No Longer Exists']);
+
+    expect(typeof getTodaysWorkoutType()).toBe('string');
+    expect(getTodaysWorkoutType().length).toBeGreaterThan(0);
+  });
+
+  it('falls back to the built-in rotation when nothing selected still exists', async () => {
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Gone', 'Also Gone']);
+
+    expect(getWorkoutCycle()).toEqual(defaultWorkoutCycle);
+  });
+});
+
+describe('an untouched rotation still behaves', () => {
+  it('uses the built-in cycle when nothing has been customised', () => {
+    expect(getWorkoutCycle()).toEqual(defaultWorkoutCycle);
+  });
+
+  it('honours an explicit preset selection', () => {
+    localWorkoutStorage.saveAutoScheduleWorkouts(['Chest Day', 'Legs']);
+
+    const cycle = getWorkoutCycle();
+    expect(cycle).toContain('Chest Day');
+    expect(cycle).toContain('Legs');
+    expect(cycle).not.toContain('Back & Biceps');
+  });
+
+  it('includes custom templates flagged for auto-schedule on a fresh install', async () => {
+    await addTemplate('Fresh Custom', true);
+
+    expect(getWorkoutCycle()).toContain('Fresh Custom');
+  });
+});

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -1,6 +1,7 @@
 import { Workout, InsertWorkout, UserPreferences, Exercise, AbsExercise, exerciseSchema, absExerciseSchema, cardioSchema } from "@shared/schema";
 import { z } from "zod";
 import { toast } from '@/hooks/use-toast';
+import { presetCycleNames } from '@/lib/workout-cycle';
 
 export interface CustomWorkoutTemplate {
   id: number;
@@ -457,11 +458,49 @@ export class LocalWorkoutStorage {
     return newTemplate;
   }
 
+  /**
+   * Keep the stored auto-schedule rotation in step with a template rename or
+   * deletion.
+   *
+   * The rotation persists workout *names*, so without this a rename silently
+   * drops the template from the schedule (the old name no longer resolves) and
+   * a deletion leaves behind a name that resolves to nothing — which, if it was
+   * the only selection, produced an empty cycle and stamped `type: undefined`
+   * across the calendar.
+   *
+   * Pass `null` as `nextName` for a deletion.
+   *
+   * Must be called *after* the template list has been written, so that the
+   * "is this name still claimed" check sees the new state.
+   */
+  private syncAutoScheduleName(previousName: string, nextName: string | null): void {
+    const selected = this.getAutoScheduleWorkouts();
+    if (!selected.includes(previousName)) return;
+
+    // A built-in preset, or another custom template, may still answer to this
+    // name. Rewriting the entry would silently deselect that one instead.
+    const stillClaimed =
+      presetCycleNames.has(previousName) ||
+      this.getCustomTemplatesInternal().some(t => t.name === previousName);
+    if (stillClaimed) return;
+
+    const updated =
+      nextName === null
+        ? selected.filter(name => name !== previousName)
+        : selected.map(name => (name === previousName ? nextName : name));
+
+    this.saveAutoScheduleWorkouts(updated);
+  }
+
   async deleteCustomTemplate(id: number): Promise<boolean> {
     const templates = this.getCustomTemplatesInternal();
+    const removed = templates.find(t => t.id === id);
     const filtered = templates.filter(t => t.id !== id);
     if (filtered.length === templates.length) return false;
     this.saveCustomTemplates(filtered);
+    if (removed) {
+      this.syncAutoScheduleName(removed.name, null);
+    }
     return true;
   }
 
@@ -472,6 +511,7 @@ export class LocalWorkoutStorage {
     const templates = this.getCustomTemplatesInternal();
     const index = templates.findIndex(t => t.id === id);
     if (index === -1) return undefined;
+    const previousName = templates[index].name;
     const updated = {
       ...templates[index],
       ...updates,
@@ -479,6 +519,9 @@ export class LocalWorkoutStorage {
     };
     templates[index] = updated;
     this.saveCustomTemplates(templates);
+    if (updated.name !== previousName) {
+      this.syncAutoScheduleName(previousName, updated.name);
+    }
     return updated;
   }
 

--- a/client/src/lib/workout-cycle.ts
+++ b/client/src/lib/workout-cycle.ts
@@ -1,0 +1,28 @@
+/**
+ * The built-in 14-day rotation.
+ *
+ * This lives in its own dependency-free module so that both `workout-data.ts`
+ * and `storage.ts` can read it. Putting it in `workout-data.ts` would make
+ * `storage.ts` import a module that already imports `storage.ts`, and that
+ * import cycle is exactly the kind of thing that works until it suddenly
+ * doesn't.
+ */
+export const defaultWorkoutCycle: string[] = [
+  "Chest & Triceps",
+  "Back & Biceps",
+  "Legs",
+  "Chest & Shoulders",
+  "Back, Biceps & Legs",
+  "Chest Day",
+  "Back & Biceps",
+  "Chest, Shoulders & Legs",
+  "Legs",
+  "Chest & Triceps",
+  "Back, Biceps & Legs",
+  "Chest & Shoulders",
+  "Back & Biceps",
+  "Chest, Shoulders & Legs"
+];
+
+/** Names the built-in rotation already claims, for collision checks. */
+export const presetCycleNames: ReadonlySet<string> = new Set(defaultWorkoutCycle);

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -1,6 +1,7 @@
 import { Exercise, AbsExercise, WorkoutType, ExerciseSet } from "@shared/schema";
 import { formatLocalDate } from "@/lib/utils";
 import { localWorkoutStorage } from "@/lib/storage";
+import { defaultWorkoutCycle } from "@/lib/workout-cycle";
 
 type TemplateExercise = Omit<Exercise, 'completed' | 'sets'> & {
   sets: Omit<ExerciseSet, 'completed'>[];
@@ -969,23 +970,10 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
   }
 };
 
-// Default 14-day workout cycle
-export const defaultWorkoutCycle: string[] = [
-  "Chest & Triceps",
-  "Back & Biceps",
-  "Legs",
-  "Chest & Shoulders",
-  "Back, Biceps & Legs",
-  "Chest Day",
-  "Back & Biceps",
-  "Chest, Shoulders & Legs",
-  "Legs",
-  "Chest & Triceps",
-  "Back, Biceps & Legs",
-  "Chest & Shoulders",
-  "Back & Biceps",
-  "Chest, Shoulders & Legs"
-];
+// The built-in 14-day cycle lives in ./workout-cycle so storage.ts can read it
+// without creating an import cycle. Re-exported so existing imports from
+// '@/lib/workout-data' keep working.
+export { defaultWorkoutCycle };
 
 export function getWorkoutCycle(): string[] {
   const selected = localWorkoutStorage.getAutoScheduleWorkouts();
@@ -1004,7 +992,13 @@ export function getWorkoutCycle(): string[] {
     )
     .map(t => t.name);
 
-  return [...presets, ...customs];
+  const cycle = [...presets, ...customs];
+
+  // Every selection can go stale — a template gets renamed or deleted and its
+  // stored name no longer resolves. An empty cycle would make `dayIndex %
+  // cycle.length` NaN and stamp `type: undefined` across the whole calendar,
+  // so fall back to the built-in rotation rather than emit a broken schedule.
+  return cycle.length > 0 ? cycle : defaultWorkoutCycle;
 }
 
 // Generate workout schedule for a given month

--- a/e2e/auto-schedule.spec.ts
+++ b/e2e/auto-schedule.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, type Page } from '@playwright/test';
+import { gotoSettled } from './helpers';
+
+/**
+ * The journey that broke: build a custom workout, put it in the auto-schedule
+ * rotation, then rename it. The rotation stores workout names, so before the
+ * fix the rename silently dropped the workout out of the rotation.
+ */
+
+/**
+ * Identify the builder by its description rather than its title: the template
+ * selector contains a *button* labelled "Create Custom Workout", so filtering
+ * dialogs on that phrase matches the selector too once it reopens.
+ */
+function builderDialog(page: Page) {
+  return page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' });
+}
+
+/**
+ * Close the workout template selector and wait for it to actually go away.
+ * Pressing Escape is not reliable here — on the mobile viewport the key can
+ * land while focus is still inside a just-closed dropdown, leaving the dialog
+ * open and everything behind it unclickable.
+ */
+async function closeTemplateSelector(page: Page) {
+  const selector = page.getByRole('dialog').filter({ hasText: 'Select Workout Template' });
+  await expect(selector).toBeVisible();
+  await selector.getByRole('button', { name: 'Close' }).click();
+  await expect(selector).toBeHidden();
+}
+
+async function createCustomWorkout(page: Page, name: string) {
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).click();
+
+  const builder = builderDialog(page);
+  await expect(builder).toBeVisible();
+
+  // Any exercise will do — the first checkbox in the dialog is an exercise.
+  await builder.getByRole('checkbox').first().click();
+  await builder.getByPlaceholder('Workout name').fill(name);
+  await builder
+    .locator('label')
+    .filter({ hasText: 'Include in auto-schedule' })
+    .getByRole('checkbox')
+    .click();
+
+  await builder.getByRole('button', { name: 'Save Workout' }).click();
+  await expect(builder).toBeHidden();
+}
+
+async function renameCustomWorkout(page: Page, from: string, to: string) {
+  const row = page.getByRole('button', { name: from, exact: true }).locator('..');
+  await row.getByRole('button').last().click();
+  await page.getByRole('menuitem', { name: 'Edit workout' }).click();
+
+  const builder = builderDialog(page);
+  await expect(builder).toBeVisible();
+  await expect(builder.getByText('Edit Custom Workout')).toBeVisible();
+  await builder.getByPlaceholder('Workout name').fill(to);
+  await builder.getByRole('button', { name: 'Update Workout' }).click();
+  await expect(builder).toBeHidden();
+}
+
+/**
+ * Persist an explicit rotation by opening the auto-schedule editor and saving
+ * it. Until the user does this, the rotation is derived from each template's
+ * "include in auto-schedule" flag rather than stored by name — and it is the
+ * stored-by-name state that the rename bug corrupts.
+ */
+async function persistAutoSchedule(page: Page) {
+  await page.getByRole('button', { name: 'Customize Auto-Schedule' }).click();
+  const schedule = page.getByRole('dialog').filter({ hasText: 'Customize Auto-Schedule' });
+  await expect(schedule).toBeVisible();
+  await schedule.getByRole('button', { name: 'Save' }).click();
+  await expect(schedule).toBeHidden();
+}
+
+test('renaming a scheduled custom workout keeps it in the rotation', async ({ page }) => {
+  await gotoSettled(page);
+
+  await createCustomWorkout(page, 'E2E Original');
+  await closeTemplateSelector(page);
+  await persistAutoSchedule(page);
+
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await renameCustomWorkout(page, 'E2E Original', 'E2E Renamed');
+  await closeTemplateSelector(page);
+
+  await page.getByRole('button', { name: 'Customize Auto-Schedule' }).click();
+  const schedule = page.getByRole('dialog').filter({ hasText: 'Customize Auto-Schedule' });
+  await expect(schedule).toBeVisible();
+
+  const renamed = schedule.locator('label').filter({ hasText: 'E2E Renamed' });
+  await expect(renamed).toBeVisible();
+  await expect(renamed.getByRole('checkbox')).toBeChecked();
+  await expect(schedule.locator('label').filter({ hasText: 'E2E Original' })).toHaveCount(0);
+});
+
+test('the stored rotation holds the new name, not the old one', async ({ page }) => {
+  await gotoSettled(page);
+  await createCustomWorkout(page, 'E2E Original');
+  await closeTemplateSelector(page);
+
+  // The rotation is only persisted by name once the user saves an explicit
+  // selection — until then the builder's "include in auto-schedule" flag is
+  // what drives it. This is the state the rename bug actually affects.
+  await page.getByRole('button', { name: 'Customize Auto-Schedule' }).click();
+  const schedule = page.getByRole('dialog').filter({ hasText: 'Customize Auto-Schedule' });
+  await schedule.getByRole('button', { name: 'Save' }).click();
+  await expect(schedule).toBeHidden();
+
+  const before = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('ironpath_auto_schedule_workouts') ?? '[]'),
+  );
+  expect(before).toContain('E2E Original');
+
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await renameCustomWorkout(page, 'E2E Original', 'E2E Renamed');
+
+  const after = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('ironpath_auto_schedule_workouts') ?? '[]'),
+  );
+  expect(after).toContain('E2E Renamed');
+  expect(after).not.toContain('E2E Original');
+});
+
+test('deleting the only scheduled workout leaves the calendar usable', async ({ page }) => {
+  await gotoSettled(page);
+  await createCustomWorkout(page, 'E2E Doomed');
+
+  // Narrow the rotation to just this one template, then delete it.
+  await page.evaluate(() =>
+    localStorage.setItem('ironpath_auto_schedule_workouts', JSON.stringify(['E2E Doomed'])),
+  );
+
+  const row = page.getByRole('button', { name: 'E2E Doomed', exact: true }).locator('..');
+  await row.getByRole('button').last().click();
+  await page.getByRole('menuitem', { name: 'Delete workout' }).click();
+  await page.getByRole('button', { name: 'Delete', exact: true }).click();
+  await expect(page.getByRole('button', { name: 'E2E Doomed', exact: true })).toHaveCount(0);
+
+  // The deleted template must not linger in the rotation. Left behind, it was
+  // the only selection, so the cycle resolved to nothing and every day on the
+  // calendar was stamped with an undefined workout type.
+  const stored = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('ironpath_auto_schedule_workouts') ?? '[]'),
+  );
+  expect(stored).not.toContain('E2E Doomed');
+});


### PR DESCRIPTION
## The bug

The auto-schedule rotation is persisted as a list of workout **names** (`ironpath_auto_schedule_workouts`). A custom template's name can change or disappear, and nothing kept the stored list in step — so the stored name stopped matching the template it referred to.

Two consequences, both reachable from the UI without doing anything unusual:

**Renaming a custom template silently dropped it from your rotation.** The old name no longer resolved to anything. No warning, no visible change until you noticed the workout had stopped coming round.

**Deleting a template left its name behind.** If it was your only selection, the rotation resolved to nothing, `dayIndex % cycle.length` became `NaN`, `cycle[NaN]` returned `undefined`, and every day on the calendar was stamped with an undefined workout type — rendering as "None", with a Start button that silently did nothing.

One nuance worth knowing, which the tests surfaced: this only bites once you've **explicitly saved an auto-schedule selection**. Before that, the rotation is derived from each template's "include in auto-schedule" flag rather than stored by name, and renames are harmless.

## The fix

**`syncAutoScheduleName` in `storage.ts`** rewrites or removes the stored entry when a template is renamed or deleted. It deliberately leaves the entry alone when a built-in preset or another template still answers to that name — otherwise deleting a custom workout you'd named "Legs" would silently deselect the built-in Legs too.

**`getWorkoutCycle` falls back to the built-in rotation** instead of returning an empty cycle. Belt and braces: even if a selection goes stale by some route this PR didn't anticipate, the calendar can't render undefined workout types.

**`defaultWorkoutCycle` moves to a new dependency-free `workout-cycle.ts`**, re-exported from `workout-data.ts` so every existing import keeps working. `storage.ts` needs the preset names, and importing `workout-data.ts` would have created an import cycle — that module already imports `storage.ts`. Import cycles work right up until they don't, so I'd rather not introduce one in the storage layer.

## Verification

```
npx tsc --noEmit    -> clean
npx vitest run      -> 24 passed (was 11; 13 new)
npx playwright test -> 16 passed (3 new x 2 viewports)
npm run build       -> ok
```

**Every one of the 16 new tests fails without the fix and passes with it.** I verified that by stashing only the two source files and re-running, rather than assuming. The end-to-end rename test fails on exactly the user-visible symptom — `toBeChecked()` on the renamed workout in the auto-schedule editor.

Two of the new end-to-end tests were *not* load-bearing when I first wrote them (they passed with the bug present), so I rewrote them until they reproduced the failure. Worth mentioning because a green test that would also be green against the bug is worse than no test.

**Eight consecutive full-suite runs: 8/8, no flakes.** One flake did show up on the way: `Escape` doesn't reliably close a dialog on the mobile viewport when focus is still inside a just-closed dropdown. Fixed by clicking the dialog's actual Close button and waiting for it to disappear.

## Risk

Confined to two storage methods and one pure function. No storage format change, so **nothing migrates and no existing data is rewritten** — the only writes are to the rotation list, and only when a template you renamed or deleted was actually in it.

Behaviour deliberately left unchanged: an untouched install still uses the built-in cycle, an explicit preset selection is still honoured, and templates flagged for auto-schedule on a fresh install still appear. There are regression tests for all three, so this PR can't quietly change them.

## Worth checking

1. Rename a custom workout that's in your rotation, then open **Customize Auto-Schedule** — it should still be there, under its new name.
2. Your existing rotation should be untouched. This PR only writes on rename/delete.

## Known adjacent issue, deliberately not fixed here

The builder checks new template names against your other custom templates, but **not** against the built-in preset names — so you can create a custom workout called "Chest Day" and selecting it gives you the built-in one. Same root cause (identity by name), but fixing it changes UI validation and template resolution, which doesn't belong in a PR about storage consistency. This PR is safe in the presence of such a collision; it just doesn't prevent one. Happy to do it as its own change if you want it.