### PR TITLE
fix: stop quota cleanup recursing into memory-only mode

### DIFF
--- a/client/src/lib/storage-quota.test.ts
+++ b/client/src/lib/storage-quota.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LocalWorkoutStorage } from './storage';
+import type { InsertWorkout } from '@shared/schema';
+
+/**
+ * Running out of storage must not take the app down with it.
+ *
+ * `checkQuota()` calls `cleanupOldWorkouts()`, which writes through
+ * `safeSetItem()`, which calls `checkQuota()` again. When the overage comes
+ * from keys other than the workout list, trimming workouts can never bring
+ * usage under the threshold, so that loop has no base case. The resulting
+ * stack overflow is caught by `safeSetItem`'s own try/catch, which flips the
+ * store into memory-only mode — the app carries on looking completely normal
+ * and silently stops persisting anything until the next reload.
+ */
+
+type TestableStorage = LocalWorkoutStorage & {
+  storageLimit: number;
+  warningThreshold: number;
+  storageFailed: boolean;
+};
+
+function makeStorage(limit = 4000): TestableStorage {
+  const storage = new LocalWorkoutStorage() as TestableStorage;
+  storage.storageLimit = limit;
+  storage.warningThreshold = 0.8;
+  return storage;
+}
+
+function workout(date: string): InsertWorkout {
+  return {
+    date,
+    type: 'Chest Day',
+    exercises: [
+      {
+        machine: 'A Deliberately Long Machine Name To Take Up Room',
+        equipment: 'machine',
+        region: 'Chest',
+        feel: 'Medium',
+        sets: [
+          { weight: 100, reps: 10, rest: '1:00', completed: true },
+          { weight: 105, reps: 10, rest: '1:00', completed: true },
+        ],
+        completed: true,
+      },
+    ],
+    abs: [],
+    completed: true,
+  } as unknown as InsertWorkout;
+}
+
+/** Something else on the same origin, larger than the entire budget. */
+function hogStorage(bytes: number) {
+  localStorage.setItem('unrelated_app_blob', 'x'.repeat(bytes));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('when the overage is not the workout list', () => {
+  it('does not recurse until the stack gives out', async () => {
+    const storage = makeStorage();
+    hogStorage(8000);
+
+    await storage.createWorkout(workout('2025-01-01'));
+
+    expect(storage.storageFailed).toBe(false);
+  });
+
+  it('keeps persisting to disk', async () => {
+    const storage = makeStorage();
+    hogStorage(8000);
+
+    await storage.createWorkout(workout('2025-01-01'));
+    await storage.createWorkout(workout('2025-01-02'));
+
+    const onDisk = JSON.parse(localStorage.getItem('ironpath_workouts') ?? '[]');
+    expect(onDisk.some((w: { date: string }) => w.date === '2025-01-02')).toBe(true);
+  });
+
+  it('does not delete the history it cannot possibly free', async () => {
+    const storage = makeStorage();
+    await storage.createWorkout(workout('2025-01-01'));
+    await storage.createWorkout(workout('2025-01-02'));
+
+    // Only now does the unrelated data blow the budget. Discarding every
+    // workout would not get under it, so nothing should be discarded.
+    hogStorage(8000);
+    await storage.createWorkout(workout('2025-01-03'));
+
+    const remaining = await storage.getAllWorkouts();
+    expect(remaining.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+describe('when the workout list is genuinely the problem', () => {
+  it('still trims the oldest entries', async () => {
+    const storage = makeStorage(2500);
+
+    for (let day = 1; day <= 20; day++) {
+      await storage.createWorkout(workout(`2025-03-${String(day).padStart(2, '0')}`));
+    }
+
+    const remaining = await storage.getAllWorkouts();
+    expect(remaining.length).toBeGreaterThan(0);
+    expect(remaining.length).toBeLessThan(20);
+    // Trimming takes the oldest first, so the most recent must survive.
+    expect(remaining[remaining.length - 1].date).toBe('2025-03-20');
+    expect(storage.storageFailed).toBe(false);
+  });
+});

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -79,6 +79,7 @@ export class LocalWorkoutStorage {
   private warned = false;
   private memoryStore: Record<string, string> = {};
   private storageFailed = false;
+  private cleaningUp = false;
 
   private safeGetItem(key: string): string | null {
     if (typeof localStorage === 'undefined' || this.storageFailed) {
@@ -154,10 +155,13 @@ export class LocalWorkoutStorage {
       err instanceof DOMException &&
       (err.name === 'QuotaExceededError' || err.name === 'NS_ERROR_DOM_QUOTA_REACHED');
     if (isQuota) {
-      this.cleanupOldWorkouts();
+      const removed = this.cleanupOldWorkouts();
       toast({
         title: 'Storage full',
-        description: 'Older workout data was removed to free space.',
+        description:
+          removed > 0
+            ? 'Older workout data was removed to free space.'
+            : 'Browser storage is full, but your workout history is not the cause. Nothing was removed.',
         variant: 'destructive',
       });
     } else {
@@ -174,30 +178,62 @@ export class LocalWorkoutStorage {
     return { used, limit: this.storageLimit, percent: used / this.storageLimit };
   }
 
-  private cleanupOldWorkouts() {
-    const stored = this.safeGetItem(STORAGE_KEYS.WORKOUTS);
-    if (!stored) return;
+  /**
+   * Drop the oldest workouts until storage is back under the threshold.
+   *
+   * Returns how many were removed, so callers can describe what actually
+   * happened instead of assuming.
+   */
+  private cleanupOldWorkouts(): number {
+    // This writes through safeSetItem, which re-runs checkQuota, which calls
+    // back here. When the overage is not the workout list that loop has no
+    // base case: it empties the history, keeps recursing on an empty array,
+    // and blows the stack. safeSetItem's own try/catch then swallows the
+    // RangeError and flips the store into memory-only mode — so the app looks
+    // completely normal and silently stops persisting until the next reload.
+    if (this.cleaningUp) return 0;
+    this.cleaningUp = true;
 
-    let workouts: Workout[] = [];
     try {
-      workouts = JSON.parse(stored);
-    } catch {
-      return;
-    }
+      const stored = this.safeGetItem(STORAGE_KEYS.WORKOUTS);
+      if (!stored) return 0;
 
-    workouts = workouts.filter(Boolean).sort((a, b) => a.date.localeCompare(b.date));
-    const targetUsage = this.storageLimit * this.warningThreshold;
-
-    while (workouts.length > 0) {
-      const projectedWorkouts = JSON.stringify(workouts);
-      const projectedUsage = this.computeUsage() - stored.length + projectedWorkouts.length;
-      if (projectedUsage <= targetUsage) {
-        break;
+      let workouts: Workout[] = [];
+      try {
+        workouts = JSON.parse(stored);
+      } catch {
+        return 0;
       }
-      workouts.shift();
-    }
+      if (!Array.isArray(workouts)) return 0;
 
-    this.safeSetItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
+      workouts = workouts.filter(Boolean).sort((a, b) => a.date.localeCompare(b.date));
+      const originalCount = workouts.length;
+      const targetUsage = this.storageLimit * this.warningThreshold;
+      const usageElsewhere = this.computeUsage() - stored.length;
+
+      // If everything else on this origin already exceeds the target, no
+      // amount of trimming helps. Throwing away someone's training history to
+      // achieve nothing is worse than being over budget.
+      if (usageElsewhere > targetUsage) {
+        console.warn(
+          'IronPath: storage is over budget, but workout history is not the cause. Leaving it intact.'
+        );
+        return 0;
+      }
+
+      while (workouts.length > 0) {
+        if (usageElsewhere + JSON.stringify(workouts).length <= targetUsage) break;
+        workouts.shift();
+      }
+
+      const removed = originalCount - workouts.length;
+      if (removed > 0) {
+        this.safeSetItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
+      }
+      return removed;
+    } finally {
+      this.cleaningUp = false;
+    }
   }
   private getCurrentId(): number {
     const stored = this.safeGetItem(STORAGE_KEYS.CURRENT_ID);


### PR DESCRIPTION
## The bug

`checkQuota()` calls `cleanupOldWorkouts()`, which writes through `safeSetItem()`, which calls `checkQuota()` again. When the storage overage comes from keys **other than** the workout list, trimming workouts can never bring usage under the threshold — so that loop has no base case.

**The outcome is worse than a crash.** `safeSetItem`'s own try/catch swallows the resulting `RangeError` and sets `storageFailed`, which routes every subsequent read and write to an in-memory object. The app carries on looking entirely normal — workouts save, the UI updates, no error surfaces — and silently persists nothing until the next reload, at which point everything logged since is gone.

On the way there it also emptied the entire workout history, because the trim loop shifts until it gets under target and it never can.

Reproduced directly:

```
stderr: localStorage setItem failed [RangeError: Maximum call stack size exceeded]
× does not recurse until the stack gives out      → storageFailed: expected true to be false
× keeps persisting to disk                        → expected false to be true
× does not delete the history it cannot free      → expected 0 to be >= 3
```

That third line is the history being wiped.

## How likely is this?

Honestly: not very. It needs the origin to be over the 5MB budget with the overage coming from something other than IronPath's workout list. Nothing else on ironpath.app writes to localStorage today, so in practice you would have to be genuinely near quota with a large exercise-history or template store.

It is in scope because the failure mode is silent, unbounded, and costs data — the same reason as the previous PR. Not because it is imminent.

## The fix

- **A re-entrancy guard**, so cleanup cannot invoke itself through its own write.
- **Bail out when everything else already exceeds the target.** If trimming cannot possibly help, do not trim. Discarding a training history to achieve nothing is worse than being over budget.
- **`cleanupOldWorkouts` now returns how many records it removed**, so the toast can describe what actually happened. It previously said "Older workout data was removed to free space" unconditionally — including when nothing had been removed, which is the one case where you would most want to know the truth.

Also tightened the trim loop: it recomputed total usage on every iteration to derive a value that cannot change during the loop.

## Verification

```
npx tsc --noEmit    -> clean
npx vitest run      -> 53 passed (was 49; 4 new)
npx playwright test -> 34 passed
npm run build       -> ok
```

Three of the four new tests fail without the change, confirmed by stashing `storage.ts`.

The fourth is the important one and it passes **both** ways on purpose: it checks that when the workout list genuinely *is* the problem, the oldest entries are still trimmed and the newest survive. Along with the pre-existing cleanup test, that is what stops this fix from turning into "never clean up anything."

No new end-to-end test here. Triggering this needs an artificially small quota and a large unrelated key — conditions you can only construct from inside the storage layer. Adding a browser test would have meant reaching in and setting private fields through the page, which tests the harness rather than the app. The unit tests are the honest level for this one.

## Risk

One file, one private method plus the toast message. Behaviour is unchanged whenever storage is healthy or when the workout list really is the cause — both covered by tests that pass before and after.

## What to check

Nothing observable, same as the last one. Your history and storage readout in Settings should be exactly as they are now.