### PR TITLE
fix: three display and progress defects

### DIFF
--- a/client/src/components/calendar-grid.test.tsx
+++ b/client/src/components/calendar-grid.test.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Workout } from '@shared/schema';
+
+// Count the work the day-grid memo does, by instrumenting the helper it calls
+// once per cell.
+const formatCalls = { n: 0 };
+vi.mock('@/lib/utils', async importActual => {
+  const actual = await importActual<typeof import('@/lib/utils')>();
+  return {
+    ...actual,
+    formatLocalDate: (d: Date) => {
+      formatCalls.n++;
+      return actual.formatLocalDate(d);
+    },
+  };
+});
+
+import { CalendarGrid } from './calendar-grid';
+
+const props = {
+  currentDate: new Date(2026, 6, 1),
+  onDateChange: () => {},
+  onSelectDate: () => {},
+  workouts: [] as Workout[],
+  selectedDate: null,
+};
+
+beforeEach(() => {
+  formatCalls.n = 0;
+});
+
+describe('the 42-cell day grid', () => {
+  it('is not rebuilt on an unrelated re-render', () => {
+    const { rerender } = render(<CalendarGrid {...props} />);
+    const afterFirst = formatCalls.n;
+
+    rerender(<CalendarGrid {...props} />);
+
+    // The memo depended on a `new Date()` created during render, so its
+    // dependency changed identity every time and it never cached anything.
+    expect(formatCalls.n - afterFirst).toBe(0);
+    expect(afterFirst).toBeGreaterThan(0);
+  });
+
+  it('is rebuilt when the month changes', () => {
+    const { rerender } = render(<CalendarGrid {...props} />);
+    const afterFirst = formatCalls.n;
+
+    rerender(<CalendarGrid {...props} currentDate={new Date(2026, 7, 1)} />);
+
+    expect(formatCalls.n).toBeGreaterThan(afterFirst);
+  });
+
+  it("still marks today's cell", () => {
+    const now = new Date();
+    const { container } = render(<CalendarGrid {...props} currentDate={now} />);
+    expect(container.textContent).toContain('📅');
+  });
+});

--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -30,9 +30,12 @@ export function CalendarGrid({
 }: CalendarGridProps) {
   const year = currentDate.getFullYear();
   const month = currentDate.getMonth();
-  const today = new Date();
+  // A `new Date()` built during render is a fresh object every time, so using
+  // it as a memo dependency meant the 42-cell grid was rebuilt on every
+  // render and the memo cached nothing. A day string is stable.
+  const todayKey = new Date().toDateString();
 
-  
+
   const calendarDays = useMemo(() => {
     const firstDay = new Date(year, month, 1);
     const lastDay = new Date(year, month + 1, 0);
@@ -62,7 +65,7 @@ export function CalendarGrid({
     for (let day = 1; day <= daysInMonth; day++) {
       const date = new Date(year, month, day);
       const dateString = formatLocalDate(date);
-      const isToday = date.toDateString() === today.toDateString();
+      const isToday = date.toDateString() === todayKey;
 
       days.push({
         day,
@@ -83,7 +86,7 @@ export function CalendarGrid({
     }
 
     return days;
-  }, [year, month, today]);
+  }, [year, month, todayKey]);
 
   const workoutSchedule = useMemo(
     () => generateWorkoutSchedule(year, month + 1),

--- a/client/src/components/exercise-form.test.tsx
+++ b/client/src/components/exercise-form.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ExerciseForm } from './exercise-form';
+import type { Exercise } from '@shared/schema';
+
+/**
+ * The "BEST" line is only meaningful when there is a previous best to compare
+ * against. Exercises built in the custom workout builder carry no
+ * `bestWeight`/`bestReps`, which produced an empty line reading
+ * "BEST:  lbs ×  reps", and made the first set ever logged look like a
+ * personal record because the baseline defaulted to zero.
+ */
+
+function exercise(overrides: Partial<Exercise> = {}): Exercise {
+  return {
+    machine: 'Seated Row',
+    region: 'Back',
+    equipment: 'machine',
+    feel: 'Medium',
+    completed: false,
+    sets: [{ weight: undefined, reps: undefined, rest: '', completed: false }],
+    ...overrides,
+  } as unknown as Exercise;
+}
+
+describe('an exercise with no recorded best', () => {
+  it('does not render an empty BEST line', () => {
+    render(<ExerciseForm exercise={exercise()} onUpdate={() => {}} />);
+    expect(screen.queryByText(/BEST:/)).toBeNull();
+  });
+
+  it('does not call the first set you log a personal record', () => {
+    render(
+      <ExerciseForm
+        exercise={exercise({
+          sets: [{ weight: 100, reps: 10, rest: '1:00', completed: false }],
+        })}
+        onUpdate={() => {}}
+      />,
+    );
+    expect(document.body.textContent).not.toContain('↑ +100');
+  });
+});
+
+describe('an exercise with a recorded best', () => {
+  it('still shows it', () => {
+    render(
+      <ExerciseForm
+        exercise={exercise({ bestWeight: 120, bestReps: 8 })}
+        onUpdate={() => {}}
+      />,
+    );
+    expect(screen.getByText(/BEST:/)).toBeTruthy();
+    expect(document.body.textContent).toContain('120 lbs × 8 reps');
+  });
+
+  it('still flags beating it', () => {
+    render(
+      <ExerciseForm
+        exercise={exercise({
+          bestWeight: 120,
+          bestReps: 8,
+          sets: [{ weight: 130, reps: 8, rest: '1:00', completed: false }],
+        })}
+        onUpdate={() => {}}
+      />,
+    );
+    expect(document.body.textContent).toContain('↑ +10 lbs');
+  });
+
+  it('still flags falling short of it', () => {
+    render(
+      <ExerciseForm
+        exercise={exercise({
+          bestWeight: 120,
+          bestReps: 8,
+          sets: [{ weight: 110, reps: 8, rest: '1:00', completed: false }],
+        })}
+        onUpdate={() => {}}
+      />,
+    );
+    expect(document.body.textContent).toContain('↓ 10 lbs');
+  });
+});

--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -91,11 +91,19 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
     return 'pending';
   };
 
+  // A previous best only exists once the exercise has actually been done
+  // before. Exercises added through the custom workout builder carry none, and
+  // treating that as zero made the first set anyone logged look like a
+  // personal record.
+  const hasRecordedBest = localExercise.bestWeight !== undefined;
+
   const getWeightChange = () => {
-    const currentWeight = Math.max(...localExercise.sets.map(s => s.weight || 0));
-    const bestWeight = localExercise.bestWeight || 0;
-    const difference = currentWeight - bestWeight;
-    
+    if (!hasRecordedBest) return { change: '', color: '' };
+
+    const weights = localExercise.sets.map(s => s.weight ?? 0);
+    const currentWeight = weights.length > 0 ? Math.max(...weights) : 0;
+    const difference = currentWeight - localExercise.bestWeight!;
+
     if (difference > 0) return { change: `↑ +${difference} lbs`, color: 'text-blue-600' };
     if (difference < 0) return { change: `↓ ${Math.abs(difference)} lbs`, color: 'text-red-600' };
     return { change: '', color: '' };
@@ -242,18 +250,21 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
           })}
         </div>
 
-        {/* Best Performance */}
-        <div className="mt-2 flex items-center space-x-2">
-          <span className="text-xs text-gray-500 dark:text-gray-400">BEST:</span>
-          <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
-            {localExercise.bestWeight} lbs × {localExercise.bestReps} reps
-          </span>
-          {getWeightChange().change && (
-            <span className={`text-xs ${getWeightChange().color}`}>
-              {getWeightChange().change}
+        {/* Best Performance — omitted entirely when there is nothing to compare against */}
+        {hasRecordedBest && (
+          <div className="mt-2 flex items-center space-x-2">
+            <span className="text-xs text-gray-500 dark:text-gray-400">BEST:</span>
+            <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
+              {localExercise.bestWeight} lbs
+              {localExercise.bestReps !== undefined && ` × ${localExercise.bestReps} reps`}
             </span>
-          )}
-        </div>
+            {getWeightChange().change && (
+              <span className={`text-xs ${getWeightChange().color}`}>
+                {getWeightChange().change}
+              </span>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
     <ExerciseImageDialog

--- a/client/src/pages/workout-cardio.test.tsx
+++ b/client/src/pages/workout-cardio.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { WorkoutPage } from './workout';
+import type { Workout } from '@shared/schema';
+
+/**
+ * Progress counted a cardio block whether or not the workout had one.
+ *
+ * A workout with no `cardio` therefore sat permanently one item short: the bar
+ * could not reach 100%, the completion celebration could not fire, and
+ * "Complete Workout" refused because it required `cardio.completed` — leaving
+ * no way to finish the workout at all.
+ */
+
+const mockUpdateWorkout = vi.fn();
+const mockToast = vi.fn((_options: { title?: string; description?: string }) => ({
+  id: 'toast1',
+}));
+
+vi.mock('@/hooks/use-workout-storage', () => ({
+  useWorkoutStorage: () => ({ updateWorkout: mockUpdateWorkout }),
+}));
+vi.mock('canvas-confetti', () => ({ default: vi.fn() }));
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast, dismiss: vi.fn() }),
+}));
+
+function workout(overrides: Partial<Workout> = {}): Workout {
+  return {
+    id: 1,
+    date: '2025-02-02',
+    type: 'Chest Day',
+    exercises: [
+      {
+        machine: 'Bench Press',
+        equipment: 'freeweight',
+        region: 'Chest',
+        feel: 'Medium',
+        sets: [{ weight: 100, reps: 8, rest: '1:00', completed: true }],
+        completed: true,
+      },
+    ],
+    abs: [],
+    cardio: undefined,
+    completed: false,
+    duration: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as unknown as Workout;
+}
+
+beforeEach(() => {
+  mockUpdateWorkout.mockReset();
+  mockToast.mockReset();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('a workout with no cardio block', () => {
+  it('can reach 100%', () => {
+    render(<WorkoutPage workout={workout()} onNavigateBack={() => {}} />);
+    expect(screen.getByText('1/1 items')).toBeTruthy();
+  });
+
+  it('can actually be completed', () => {
+    render(<WorkoutPage workout={workout()} onNavigateBack={() => {}} />);
+
+    fireEvent.click(screen.getByText('Complete Workout'));
+
+    expect(mockUpdateWorkout).toHaveBeenCalled();
+    expect(mockUpdateWorkout.mock.calls.at(-1)?.[1]).toMatchObject({ completed: true });
+  });
+
+  it('does not report the workout as incomplete', () => {
+    render(<WorkoutPage workout={workout()} onNavigateBack={() => {}} />);
+
+    fireEvent.click(screen.getByText('Complete Workout'));
+
+    const titles = mockToast.mock.calls.map(call => call[0]?.title);
+    expect(titles).not.toContain('Incomplete workout');
+  });
+});
+
+describe('a workout that does have a cardio block', () => {
+  const withCardio = workout({
+    cardio: { type: 'Treadmill', duration: '', distance: '', completed: false },
+  });
+
+  it('still counts it toward progress', () => {
+    render(<WorkoutPage workout={withCardio} onNavigateBack={() => {}} />);
+    expect(screen.getByText('1/2 items')).toBeTruthy();
+  });
+
+  it('still refuses to complete while cardio is outstanding', () => {
+    render(<WorkoutPage workout={withCardio} onNavigateBack={() => {}} />);
+
+    fireEvent.click(screen.getByText('Complete Workout'));
+
+    const titles = mockToast.mock.calls.map(call => call[0]?.title);
+    expect(titles).toContain('Incomplete workout');
+    expect(mockUpdateWorkout).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -164,7 +164,10 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   const handleCompleteWorkout = async () => {
     const allExercisesComplete = workout.exercises.every(e => e.completed);
     const allAbsComplete = workout.abs.every(a => a.completed);
-    const cardioComplete = workout.cardio?.completed || false;
+    // A workout with no cardio block has nothing outstanding there. Requiring
+    // `cardio.completed` unconditionally left such a workout impossible to
+    // finish — the button refused forever, with no cardio section to tick.
+    const cardioComplete = !workout.cardio || Boolean(workout.cardio.completed);
     const allFieldsFilled = workout.exercises.every(ex =>
       ex.sets.every(
         s => s.weight !== undefined && s.reps !== undefined
@@ -241,11 +244,14 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     const totalExercises = workout.exercises.length;
     const completedAbs = workout.abs.filter(a => a.completed).length;
     const totalAbs = workout.abs.length;
-    const cardioComplete = workout.cardio?.completed ? 1 : 0;
-    
-    const totalItems = totalExercises + totalAbs + 1; // +1 for cardio
+    // Only count cardio when the workout actually has a cardio block, or the
+    // total is permanently one higher than anything the user can complete.
+    const hasCardio = Boolean(workout.cardio);
+    const cardioComplete = hasCardio && workout.cardio?.completed ? 1 : 0;
+
+    const totalItems = totalExercises + totalAbs + (hasCardio ? 1 : 0);
     const completedItems = completedExercises + completedAbs + cardioComplete;
-    
+
     return {
       completedExercises,
       totalExercises,
@@ -254,7 +260,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
       cardioComplete,
       totalItems,
       completedItems,
-      percentage: Math.round((completedItems / totalItems) * 100)
+      percentage: totalItems > 0 ? Math.round((completedItems / totalItems) * 100) : 0
     };
   };
 


### PR DESCRIPTION
Three small, independent defects. Batched because each is a couple of lines and none touches the others — happy to split if you would rather review them separately.

## 1. A workout with no cardio block could never be finished

The worst of the three. Progress counted a cardio item whether or not the workout had one, and `handleCompleteWorkout` required `cardio.completed` unconditionally.

So a workout without a cardio block sat permanently one item short: the bar could not reach 100%, the completion celebration could not fire, and **"Complete Workout" refused forever** — with no cardio section on screen to tick. There was no way to finish it.

With one completed exercise, no abs and no cardio, progress read `1/2 items`.

Both checks now depend on the block actually existing, and the percentage guards against a zero total.

Every workout the app creates today does get a cardio block, so this is reachable via imported or older data rather than the normal path. It is a dead end when you hit it, though, which is why it is first.

## 2. Custom exercises showed an empty "BEST" line and a false personal record

`bestWeight` comes from the built-in templates, so an exercise created in the custom workout builder has none.

React renders `undefined` as nothing, so the line came out as:

```
BEST:  lbs ×  reps
```

And because the comparison treated a missing best as zero, **the first set you ever logged was flagged `↑ +100 lbs`** — every custom exercise congratulated you on a personal record the first time you used it.

The line is now omitted entirely when there is nothing to compare against.

Worth noting for later, not fixed here: `bestWeight` is a constant baked into the template and is never updated from what you actually lift. So "BEST" on a built-in exercise is a fixed number from the source file, not your record. Making it reflect real history means deriving it from `ironpath_exercise_history`, which is a behaviour change rather than a bug fix — separate PR if you want it.

## 3. The calendar rebuilt its 42-cell grid on every render

The `useMemo` listed a `new Date()` created during render as a dependency. A fresh object every time means the dependency always changed, so the memo cached nothing.

Measured: first render 73 `formatLocalDate` calls, second render with identical props **42 more** — one per cell.

Keyed on a day string instead. Not a correctness bug, just work being done for no reason on a device you are holding with chalky hands.

## Verification

```
npx tsc --noEmit    -> clean
npx vitest run      -> 66 passed (was 53; 13 new)
npx playwright test -> 34 passed
npm run build       -> ok
```

Six of the thirteen new tests fail without the change, verified by stashing the three source files.

The other seven are deliberate guards on the behaviour that already worked: cardio still blocks completion when a workout has one, a real best still renders and still flags being beaten (`↑ +10 lbs`) or missed (`↓ 10 lbs`), and the grid still rebuilds when the month changes and still marks today. Those matter more than the six here — each of these fixes is a conditional wrapped around existing behaviour, and the risk is suppressing a case that should still fire.

## What to check

1. Open any workout and look at the "BEST" line under each exercise. Built-in exercises should look exactly as before; custom ones should now show nothing there rather than an empty line.
2. Log a set on a custom exercise — no personal-record arrow on the first one.
3. The calendar should look and behave identically.

## Deliberately not included

The fourth item from the audit — `useWorkoutStorage` being called independently by four components, each loading and validating the whole history separately. I looked at it for this batch and decided against: the measured cost is a few milliseconds at realistic history sizes, the stale-state risk is latent rather than active (pages unmount on navigation, so each remount reloads), and fixing it properly means lifting it into a context provider touching every page. That is a refactor with real regression risk in exchange for milliseconds. My recommendation is to leave it unless you have seen sluggishness — happy to do it if you want.