### PR TITLE
refactor: keep Drizzle's Postgres builder out of the client bundle

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -9,7 +9,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
-import { Exercise, AbsExercise } from '@shared/schema';
+import type { Exercise, AbsExercise } from '@shared/schema';
 import { CustomWorkoutTemplate } from '@/lib/storage';
 import { exerciseLibrary } from '@/lib/exercise-library';
 import { ExerciseOption } from '@/lib/exercise-library';

--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -2,7 +2,7 @@ import { Calendar, ChevronLeft, ChevronRight } from 'lucide-react';
 import { useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
-import { Workout } from '@shared/schema';
+import type { Workout } from '@shared/schema';
 import { generateWorkoutSchedule } from '@/lib/workout-data';
 import { cn, formatLocalDate } from '@/lib/utils';
 

--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { Exercise, ExerciseSet } from '@shared/schema';
+import type { Exercise, ExerciseSet } from '@shared/schema';
 import { Check, Clock, HelpCircle } from 'lucide-react';
 import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { useToast } from '@/hooks/use-toast';

--- a/client/src/components/workout-card.tsx
+++ b/client/src/components/workout-card.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Workout } from '@shared/schema';
+import type { Workout } from '@shared/schema';
 import { parseISODate } from '@/lib/utils';
 import {
   Calendar,

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Workout, InsertWorkout, UserPreferences, Exercise } from '@shared/schema';
+import type { Workout, InsertWorkout, UserPreferences, Exercise } from '@shared/schema';
 import { localWorkoutStorage, CustomWorkoutTemplate } from '@/lib/storage';
 import { workoutTemplates } from '@/lib/workout-data';
 import { formatLocalDate } from '@/lib/utils';

--- a/client/src/lib/bundle-boundaries.test.ts
+++ b/client/src/lib/bundle-boundaries.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+/**
+ * `shared/schema.ts` imports `drizzle-orm/pg-core` to describe the Postgres
+ * tables. Importing a *value* from it therefore drags the table builder into
+ * whatever bundle did the importing — and the client is a browser app with no
+ * database.
+ *
+ * That is how ~36KB of Postgres schema machinery ended up shipping to phones:
+ * one file needed the zod validators, which live in the same module. The
+ * runtime schemas now live in `shared/workout-schemas.ts`, which imports only
+ * zod.
+ *
+ * This guards the boundary statically, because the failure is silent — the
+ * app works perfectly either way, it is just bigger.
+ */
+
+const CLIENT_SOURCES = import.meta.glob('../**/*.{ts,tsx}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
+
+/** Strip comments so prose about the rule is not mistaken for a violation. */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/**
+ * Split a file into whole import statements before testing them.
+ *
+ * Matching a single regex against the file does not work: several of these
+ * files omit semicolons, so a character class like `[^;]*` runs straight past
+ * the end of one import and into the next, and an innocent `import type` line
+ * gets attributed to the plain `import` above it.
+ */
+function importStatements(source: string): string[] {
+  return stripComments(source).match(/import[\s\S]*?from\s*['"][^'"]+['"]/g) ?? [];
+}
+
+function importsValueFromSchemaModule(source: string): boolean {
+  return importStatements(source).some(
+    statement =>
+      /from\s*['"]@shared\/schema['"]$/.test(statement.trim()) &&
+      !/^import\s+type\b/.test(statement.trim()),
+  );
+}
+
+describe('client bundle boundaries', () => {
+  it('has client sources to check', () => {
+    expect(Object.keys(CLIENT_SOURCES).length).toBeGreaterThan(20);
+  });
+
+  it('never imports a runtime value from @shared/schema', () => {
+    // `import type { ... } from '@shared/schema'` is erased at compile time
+    // and costs nothing. A plain `import { ... }` is not.
+    const offenders = Object.entries(CLIENT_SOURCES)
+      .filter(([, source]) => importsValueFromSchemaModule(source))
+      .map(([path]) => path);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the runtime schema module free of Drizzle', async () => {
+    const shared = import.meta.glob('../../../shared/*.ts', {
+      eager: true,
+      query: '?raw',
+      import: 'default',
+    }) as Record<string, string>;
+
+    const entry = Object.entries(shared).find(([path]) =>
+      path.endsWith('workout-schemas.ts'),
+    );
+    expect(entry).toBeDefined();
+    expect(entry![1]).not.toMatch(/from\s*['"]drizzle/);
+  });
+});

--- a/client/src/lib/storage.test.ts
+++ b/client/src/lib/storage.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 import { LocalWorkoutStorage } from './storage'
-import { InsertWorkout } from '@shared/schema'
+import type { InsertWorkout } from '@shared/schema'
 
 function makeWorkout(date: string): InsertWorkout {
   return {

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -1,4 +1,8 @@
-import { Workout, InsertWorkout, UserPreferences, Exercise, AbsExercise, exerciseSchema, absExerciseSchema, cardioSchema } from "@shared/schema";
+// Types only from @shared/schema — importing a *value* from there would pull
+// Drizzle's Postgres table builder into the browser bundle. Runtime schemas
+// come from the Drizzle-free module instead.
+import type { Workout, InsertWorkout, UserPreferences, Exercise, AbsExercise } from "@shared/schema";
+import { exerciseSchema, absExerciseSchema, cardioSchema } from "@shared/workout-schemas";
 import { z } from "zod";
 import { toast } from '@/hooks/use-toast';
 import { presetCycleNames } from '@/lib/workout-cycle';

--- a/client/src/lib/streak.test.ts
+++ b/client/src/lib/streak.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { calculateTopDayStreak } from './streak'
-import { Workout } from '@shared/schema'
+import type { Workout } from '@shared/schema'
 
 let idCounter = 1
 

--- a/client/src/lib/streak.ts
+++ b/client/src/lib/streak.ts
@@ -1,4 +1,4 @@
-import { Workout } from '@shared/schema';
+import type { Workout } from '@shared/schema';
 import { parseISODate, formatLocalDate } from '@/lib/utils';
 
 export function calculateDayStreak(workouts: Workout[], streakDays: number[]): number {

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -1,4 +1,4 @@
-import { Exercise, AbsExercise, WorkoutType, ExerciseSet } from "@shared/schema";
+import type { Exercise, AbsExercise, WorkoutType, ExerciseSet } from "@shared/schema";
 import { formatLocalDate } from "@/lib/utils";
 import { localWorkoutStorage } from "@/lib/storage";
 import { defaultWorkoutCycle } from "@/lib/workout-cycle";

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -14,7 +14,7 @@ import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModa
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { CustomizeStreakModal } from '@/components/CustomizeStreakModal';
-import { Workout, Exercise, AbsExercise } from '@shared/schema';
+import type { Workout, Exercise, AbsExercise } from '@shared/schema';
 import { CustomWorkoutTemplate, localWorkoutStorage } from '@/lib/storage';
 
 export function CalendarPage() {

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
-import { Workout } from '@shared/schema';
+import type { Workout } from '@shared/schema';
 import { BarChart, Calendar, Download, FileText, TrendingUp } from 'lucide-react';
 import { parseISODate } from '@/lib/utils';
 import { calculateDayStreak } from '@/lib/streak';

--- a/client/src/pages/workout.test.tsx
+++ b/client/src/pages/workout.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, fireEvent, screen, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { WorkoutPage } from './workout';
-import { Workout } from '@shared/schema';
+import type { Workout } from '@shared/schema';
 
 const mockUpdateWorkout = vi.fn();
 

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -6,7 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ExerciseForm } from '@/components/exercise-form';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
-import { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
+import type { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
 import { parseISODate, minutesFromDuration } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,59 +1,25 @@
 import { pgTable, text, serial, integer, boolean, timestamp, jsonb } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
+import {
+  exerciseSchema,
+  absExerciseSchema,
+  cardioSchema,
+  exerciseSetSchema,
+  workoutTypes
+} from "./workout-schemas";
 
-// Exercise set schema
-const exerciseSetSchema = z.object({
-  weight: z.number().optional(),
-  reps: z.number().optional(),
-  rest: z.string().optional(), // e.g., "1:30"
-  completed: z.boolean().default(false)
-});
-
-// Exercise schema
-const exerciseSchema = z.object({
-  code: z.string().optional(), // Machine code like "S16"
-  machine: z.string(),
-  equipment: z.enum(["machine", "freeweight", "both"]),
-  region: z.string(),
-  feel: z.enum(["Light", "Medium", "Hard", "Heavy", "N/A"]),
-  sets: z.array(exerciseSetSchema),
-  bestWeight: z.number().optional(),
-  bestReps: z.number().optional(),
-  completed: z.boolean().default(false)
-});
-
-// Abs exercise schema
-const absExerciseSchema = z.object({
-  name: z.string(),
-  reps: z.number().optional(),
-  time: z.string().optional(), // For time-based exercises like planks
-  completed: z.boolean().default(false)
-});
-
-// Cardio schema
-const cardioSchema = z.object({
-  type: z.enum(["Treadmill", "Bike", "Elliptical", "Rowing"]),
-  duration: z.string().optional(), // e.g., "15:00"
-  distance: z.string().optional(), // e.g., "2.5"
-  completed: z.boolean().default(false)
-});
-
-// Workout types (add all valid workout templates here)
-export const workoutTypes = [
-  "Chest, Shoulder Focus",
-  "Legs",
-  "Chest, Tricep Focus",
-  "Back, Biceps, and Legs",
-  "Chest, Shoulders, and Back",
-  "Chest Day",
-  "Back & Biceps",
-  "Back, Biceps & Legs",
-  "Chest & Triceps",
-  "Chest & Shoulders",
-  "Leg Day",
-  "Chest, Shoulders & Legs"
-] as const;
+/**
+ * Database tables.
+ *
+ * This module imports `drizzle-orm/pg-core`, so anything that imports a
+ * *value* from here pulls the Postgres table builder in with it. The client is
+ * a browser app with no database, so it must only ever import types from here
+ * — or, for runtime schemas, import from ./workout-schemas directly.
+ *
+ * Everything in ./workout-schemas is re-exported below so existing imports
+ * keep working either way.
+ */
 
 // Workouts table
 export const workouts = pgTable("workouts", {
@@ -95,11 +61,7 @@ export type Workout = typeof workouts.$inferSelect;
 export type InsertWorkout = z.infer<typeof insertWorkoutSchema>;
 export type UserPreferences = typeof userPreferences.$inferSelect;
 export type InsertUserPreferences = z.infer<typeof insertUserPreferencesSchema>;
-export type Exercise = z.infer<typeof exerciseSchema>;
-export type ExerciseSet = z.infer<typeof exerciseSetSchema>;
-export type AbsExercise = z.infer<typeof absExerciseSchema>;
-export type Cardio = z.infer<typeof cardioSchema>;
-export type WorkoutType = typeof workoutTypes[number];
 
-// Export schemas for validation
-export { exerciseSchema, exerciseSetSchema, absExerciseSchema, cardioSchema };
+// Re-exported from ./workout-schemas so existing import sites are unchanged.
+export { exerciseSchema, exerciseSetSchema, absExerciseSchema, cardioSchema, workoutTypes };
+export type { Exercise, ExerciseSet, AbsExercise, Cardio, WorkoutType } from "./workout-schemas";

--- a/shared/workout-schemas.ts
+++ b/shared/workout-schemas.ts
@@ -1,0 +1,72 @@
+import { z } from "zod";
+
+/**
+ * Runtime schemas and the types inferred from them.
+ *
+ * Kept free of any Drizzle import on purpose. `schema.ts` describes the same
+ * shapes as Postgres tables, which means importing anything from it at runtime
+ * drags `drizzle-orm/pg-core` into whatever bundle did the importing — and the
+ * client is a browser app with no database. Values live here; the table
+ * definitions stay next door and are only ever needed by the server.
+ *
+ * `schema.ts` re-exports everything below, so existing imports keep working.
+ */
+
+// Exercise set schema
+export const exerciseSetSchema = z.object({
+  weight: z.number().optional(),
+  reps: z.number().optional(),
+  rest: z.string().optional(), // e.g., "1:30"
+  completed: z.boolean().default(false)
+});
+
+// Exercise schema
+export const exerciseSchema = z.object({
+  code: z.string().optional(), // Machine code like "S16"
+  machine: z.string(),
+  equipment: z.enum(["machine", "freeweight", "both"]),
+  region: z.string(),
+  feel: z.enum(["Light", "Medium", "Hard", "Heavy", "N/A"]),
+  sets: z.array(exerciseSetSchema),
+  bestWeight: z.number().optional(),
+  bestReps: z.number().optional(),
+  completed: z.boolean().default(false)
+});
+
+// Abs exercise schema
+export const absExerciseSchema = z.object({
+  name: z.string(),
+  reps: z.number().optional(),
+  time: z.string().optional(), // For time-based exercises like planks
+  completed: z.boolean().default(false)
+});
+
+// Cardio schema
+export const cardioSchema = z.object({
+  type: z.enum(["Treadmill", "Bike", "Elliptical", "Rowing"]),
+  duration: z.string().optional(), // e.g., "15:00"
+  distance: z.string().optional(), // e.g., "2.5"
+  completed: z.boolean().default(false)
+});
+
+// Workout types (add all valid workout templates here)
+export const workoutTypes = [
+  "Chest, Shoulder Focus",
+  "Legs",
+  "Chest, Tricep Focus",
+  "Back, Biceps, and Legs",
+  "Chest, Shoulders, and Back",
+  "Chest Day",
+  "Back & Biceps",
+  "Back, Biceps & Legs",
+  "Chest & Triceps",
+  "Chest & Shoulders",
+  "Leg Day",
+  "Chest, Shoulders & Legs"
+] as const;
+
+export type Exercise = z.infer<typeof exerciseSchema>;
+export type ExerciseSet = z.infer<typeof exerciseSetSchema>;
+export type AbsExercise = z.infer<typeof absExerciseSchema>;
+export type Cardio = z.infer<typeof cardioSchema>;
+export type WorkoutType = typeof workoutTypes[number];


### PR DESCRIPTION
## The problem

`shared/schema.ts` describes the Postgres tables, so it imports `drizzle-orm/pg-core` and calls `pgTable` at module scope. Importing a **value** from that module therefore pulls the table builder in with it.

`storage.ts` did exactly that — it needs the zod validators (`exerciseSchema`, `absExerciseSchema`, `cardioSchema`), and those lived in the same file as the table definitions. One import, and a browser app with no database was shipping Postgres schema machinery to every phone that loaded it.

Confirmed rather than assumed: `PgTable` was present in `dist/assets/*.js`.

## The fix

The runtime schemas move to a new `shared/workout-schemas.ts`, which imports only zod. `shared/schema.ts` imports them back for its `$type<>()` annotations and re-exports everything, so:

- The shapes are unchanged, and there is still exactly one definition of each.
- Every existing `@shared/schema` import site keeps working.

Every remaining client import from `@shared/schema` is now `import type`, which TypeScript erases at compile time and costs nothing. Only `storage.ts` needed a real change; the rest was mechanical.

## Measured

Clean build of each side, same machine, same moment:

```
raw:     530.5 kB -> 493.0 kB   (37.5 kB, -7.1%)
gzipped: 157.4 kB -> 146.7 kB   (10.7 kB, -6.8%)
```

Bigger than the ~19 kB I estimated in the audit, because `drizzle-zod` went out with `pg-core`.

Not a dramatic number, but it is 37 kB of code that exists solely to build SQL tables, on a PWA whose whole point is loading on gym wifi.

## Guarded

The regression here is completely silent — the app behaves identically either way, it is just bigger — so nothing would catch it coming back except a static check. Added one:

- No client source may import a runtime value from `@shared/schema` (`import type` is fine).
- `shared/workout-schemas.ts` must stay free of any Drizzle import.

I verified the guard actually fires by dropping a deliberate violation into `client/src/lib/` and watching it fail, then removing it. Worth doing — the first version of the check passed against that violation, because several files here omit semicolons and my regex ran straight past the end of one import statement into the next.

## Verification

```
npx tsc --noEmit          -> clean
npx vitest run            -> 69 passed (was 66; 3 new)
npx playwright test       -> 34 passed
npm run build             -> ok
esbuild server/index.ts   -> ok
```

The server build matters here — `shared/schema.ts` is what the server and `drizzle-kit push` consume, and the point of re-exporting rather than moving was to leave that side untouched. `drizzle.config.ts` still points at the same file, and the table definitions in it are unchanged.

## Risk

No behaviour change anywhere. The diff is large in file count but almost entirely `import` becoming `import type`. The two substantive files are `shared/schema.ts` (split, re-exports) and `shared/workout-schemas.ts` (new, contains the schema bodies moved verbatim).

## Worth checking

Nothing visible. If you want confirmation the change did what it says, the Netlify preview's main JS chunk should be roughly 37 kB smaller than the one on `main`.