### PR TITLE
feat: make backup export and restore actually work

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -59,7 +59,10 @@ function Header() {
               {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </Button>
             <SettingsDialog>
-              <Button variant="ghost" size="sm" className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+              {/* Named here because backup/restore lives behind this button and
+                  is otherwise unreachable to a screen reader or a test. The
+                  remaining icon-only buttons are handled in the a11y pass. */}
+              <Button aria-label="Settings" variant="ghost" size="sm" className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                 <Settings className="h-4 w-4" />
               </Button>
             </SettingsDialog>

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -6,11 +6,17 @@ import { AlertDialog, AlertDialogTrigger, AlertDialogContent, AlertDialogHeader,
 import { localWorkoutStorage } from '@/lib/storage';
 import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { toast } from '@/hooks/use-toast';
+import { backupFilename, describeBackup, downloadJson, readJsonFile } from '@/lib/backup';
 
 export function SettingsDialog({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false);
   const [scheduleOpen, setScheduleOpen] = useState(false);
   const [usage, setUsage] = useState({ percent: 0, used: 0, limit: 0 });
+  // Held between choosing a file and confirming the replace, so the summary
+  // shown in the dialog describes the file actually about to be restored.
+  const [pendingImport, setPendingImport] = useState<{ data: unknown; summary: string } | null>(
+    null,
+  );
 
   useEffect(() => {
     if (open) {
@@ -19,27 +25,55 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
   }, [open]);
 
   const handleExport = async () => {
-    const data = await localWorkoutStorage.exportData();
-    const headers = ['id', 'date', 'type', 'completed', 'duration'];
-    const rows = data.workouts.map(w => [w.id, w.date, w.type, w.completed, w.duration ?? ''].join(','));
-    const csv = [headers.join(','), ...rows].join('\n');
-    const blob = new Blob([csv], { type: 'text/csv' });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement('a');
-    a.href = url;
-    a.download = 'workouts.csv';
-    a.click();
-    URL.revokeObjectURL(url);
+    try {
+      downloadJson(backupFilename(), await localWorkoutStorage.exportData());
+    } catch {
+      toast({
+        title: 'Export failed',
+        description: 'Your workouts could not be exported.',
+        variant: 'destructive',
+      });
+    }
   };
 
-  const handleImport = (e: ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files.length > 0) {
+  const handleFileChosen = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    // Reset immediately so choosing the same file twice still fires onChange.
+    event.target.value = '';
+    if (!file) return;
+
+    try {
+      const data = await readJsonFile(file);
+      setPendingImport({ data, summary: describeBackup(data) });
+    } catch (error) {
       toast({
-        title: 'Import not implemented',
-        description: 'Importing workouts will be available in a future update.'
+        title: "Couldn't read that file",
+        description: error instanceof Error ? error.message : 'Unknown error.',
+        variant: 'destructive',
       });
-      e.target.value = '';
     }
+  };
+
+  const confirmImport = async () => {
+    if (!pendingImport) return;
+    const { data } = pendingImport;
+    setPendingImport(null);
+
+    try {
+      await localWorkoutStorage.importData(data);
+    } catch {
+      // importData validates before writing anything, so existing data is
+      // untouched when this happens.
+      toast({
+        title: 'Restore failed',
+        description: 'That backup could not be read. Nothing was changed.',
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    toast({ title: 'Backup restored', description: 'Reloading…' });
+    window.location.reload();
   };
 
   return (
@@ -52,15 +86,25 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
           <DialogDescription>Manage app data and preferences.</DialogDescription>
         </DialogHeader>
         <div className="space-y-3">
-          <Button onClick={handleExport} className="w-full">Export Workouts</Button>
+          <Button onClick={handleExport} className="w-full">Export Backup</Button>
           <div>
-            <input id="import-file" type="file" accept=".csv" onChange={handleImport} className="hidden" />
+            <input
+              id="import-file"
+              type="file"
+              accept="application/json,.json"
+              onChange={handleFileChosen}
+              className="hidden"
+            />
             <label htmlFor="import-file">
               <Button asChild className="w-full cursor-pointer">
-                <span>Import Workouts</span>
+                <span>Restore From Backup</span>
               </Button>
             </label>
           </div>
+          <p className="text-xs text-gray-500 dark:text-gray-400">
+            A backup holds every workout, template, exercise history entry and setting.
+            Restoring replaces everything currently on this device.
+          </p>
           <Button className="w-full" variant="secondary" onClick={() => setScheduleOpen(true)}>
             Customize Auto-Schedule
           </Button>
@@ -95,6 +139,25 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
         </DialogContent>
       </Dialog>
       <AutoScheduleModal open={scheduleOpen} onClose={() => setScheduleOpen(false)} />
+
+      <AlertDialog
+        open={pendingImport !== null}
+        onOpenChange={isOpen => !isOpen && setPendingImport(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore this backup?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This file contains {pendingImport?.summary}. Restoring it replaces every workout,
+              template and setting currently on this device. This cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmImport}>Restore</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   );
 }

--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -3,6 +3,7 @@ import type { Workout, InsertWorkout, UserPreferences, Exercise } from '@shared/
 import { localWorkoutStorage, CustomWorkoutTemplate } from '@/lib/storage';
 import { workoutTemplates } from '@/lib/workout-data';
 import { formatLocalDate } from '@/lib/utils';
+import { backupFilename, downloadJson } from '@/lib/backup';
 
 const STORAGE_VERSION = "1.1.0";
 const VERSION_KEY = "ironpath_version";
@@ -147,16 +148,9 @@ export function useWorkoutStorage() {
   };
 
   const exportData = async () => {
-    const data = await localWorkoutStorage.exportData();
-    const blob = new Blob([JSON.stringify(data, null, 2)], {
-      type: "application/json",
-    });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = `ironpath-data-${formatLocalDate(new Date())}.json`;
-    a.click();
-    URL.revokeObjectURL(url);
+    // Same file the Settings dialog writes, so either route produces something
+    // "Restore From Backup" accepts.
+    downloadJson(backupFilename(), await localWorkoutStorage.exportData());
   };
 
   const exportCSV = async () => {

--- a/client/src/lib/backup.test.ts
+++ b/client/src/lib/backup.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LocalWorkoutStorage } from './storage';
+import { backupFilename, describeBackup, readJsonFile } from './backup';
+import type { InsertWorkout } from '@shared/schema';
+
+/**
+ * A backup is only worth having if restoring it puts the app back the way it
+ * was. "Export" previously wrote five CSV columns — no sets, reps, weights or
+ * templates — and "Import" refused unconditionally, so there was no way back
+ * from a lost phone.
+ */
+
+function workout(date: string, weight: number): InsertWorkout {
+  return {
+    date,
+    type: 'Chest Day',
+    exercises: [
+      {
+        machine: 'Seated Chest Press',
+        equipment: 'machine',
+        region: 'Chest',
+        feel: 'Medium',
+        sets: [{ weight, reps: 10, rest: '1:00', completed: true }],
+        completed: true,
+      },
+    ],
+    abs: [{ name: 'Crunch', reps: 30, completed: true }],
+    cardio: { type: 'Treadmill', duration: '15:00', distance: '1', completed: true },
+    completed: true,
+  } as unknown as InsertWorkout;
+}
+
+/** Populate every key a backup is supposed to carry. */
+async function populate(storage: LocalWorkoutStorage) {
+  const first = await storage.createWorkout(workout('2025-05-01', 135));
+  const second = await storage.createWorkout(workout('2025-05-03', 145));
+  // Exercise history is written by updateWorkout, which is what autosave
+  // calls — creating a workout alone does not record it.
+  await storage.updateWorkout(first.id, { exercises: first.exercises });
+  await storage.updateWorkout(second.id, { exercises: second.exercises });
+  await storage.addCustomTemplate({
+    name: 'My Split',
+    exercises: [],
+    abs: [],
+    includeInAutoSchedule: true,
+  });
+  storage.saveAutoScheduleWorkouts(['Chest Day', 'My Split']);
+  storage.saveHiddenPresets({ Legs: true });
+  storage.savePresetPromptPrefs({ Legs: true });
+  storage.saveStreakDays([1, 3, 5]);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('a backup round-trip', () => {
+  it('restores workouts with their sets intact', async () => {
+    const storage = new LocalWorkoutStorage();
+    await populate(storage);
+    const backup = await storage.exportData();
+
+    localStorage.clear();
+    await storage.importData(backup);
+
+    const restored = await storage.getAllWorkouts();
+    expect(restored).toHaveLength(2);
+    expect(restored[0].exercises[0].sets[0].weight).toBe(135);
+    expect(restored[1].exercises[0].sets[0].weight).toBe(145);
+    expect(restored[0].abs[0].name).toBe('Crunch');
+    expect(restored[0].cardio?.duration).toBe('15:00');
+  });
+
+  it('restores custom templates', async () => {
+    const storage = new LocalWorkoutStorage();
+    await populate(storage);
+    const backup = await storage.exportData();
+
+    localStorage.clear();
+    await storage.importData(backup);
+
+    const templates = await storage.getCustomTemplates();
+    expect(templates.map(t => t.name)).toContain('My Split');
+  });
+
+  it('restores the settings that used to be dropped', async () => {
+    const storage = new LocalWorkoutStorage();
+    await populate(storage);
+    const backup = await storage.exportData();
+
+    localStorage.clear();
+    await storage.importData(backup);
+
+    expect(storage.getAutoScheduleWorkouts()).toEqual(['Chest Day', 'My Split']);
+    expect(storage.getHiddenPresets()).toEqual({ Legs: true });
+    expect(storage.getPresetPromptPrefs()).toEqual({ Legs: true });
+    expect(storage.getStreakDays()).toEqual([1, 3, 5]);
+  });
+
+  it('restores exercise history, so sets still prefill', async () => {
+    const storage = new LocalWorkoutStorage();
+    await populate(storage);
+    const backup = await storage.exportData();
+
+    localStorage.clear();
+    await storage.importData(backup);
+
+    expect(await storage.getLastExerciseSets('Seated Chest Press')).toEqual([
+      { weight: 145, reps: 10, rest: '1:00' },
+    ]);
+  });
+
+  it('carries quarantined records across rather than dropping them', async () => {
+    const storage = new LocalWorkoutStorage();
+    localStorage.setItem(
+      'ironpath_workouts',
+      JSON.stringify([{ id: 7, date: 'not-a-date', type: 'X', exercises: [], abs: [] }]),
+    );
+    const backup = await storage.exportData();
+    expect(backup.quarantined).toHaveLength(1);
+
+    localStorage.clear();
+    await storage.importData(backup);
+
+    expect(storage.getQuarantinedWorkouts()).toHaveLength(1);
+  });
+
+  it('leaves new workouts with non-colliding ids', async () => {
+    const storage = new LocalWorkoutStorage();
+    await populate(storage);
+    const backup = await storage.exportData();
+
+    localStorage.clear();
+    await storage.importData(backup);
+    const created = await storage.createWorkout(workout('2025-06-01', 100));
+
+    const ids = (await storage.getAllWorkouts()).map(w => w.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(created.id).toBeGreaterThan(2);
+  });
+});
+
+describe('a backup written by an older build', () => {
+  it('still restores, leaving absent sections alone', async () => {
+    const storage = new LocalWorkoutStorage();
+    await populate(storage);
+    const full = await storage.exportData();
+
+    // Only the three fields the previous export produced.
+    const legacyBackup = {
+      workouts: full.workouts,
+      preferences: full.preferences,
+      customTemplates: full.customTemplates,
+    };
+
+    localStorage.clear();
+    storage.saveStreakDays([0, 6]);
+    await storage.importData(legacyBackup);
+
+    expect(await storage.getAllWorkouts()).toHaveLength(2);
+    // Not present in the file, so not reset.
+    expect(storage.getStreakDays()).toEqual([0, 6]);
+  });
+});
+
+describe('a file that is not a backup', () => {
+  it('is rejected', async () => {
+    const storage = new LocalWorkoutStorage();
+    await expect(storage.importData({ hello: 'world' })).rejects.toThrow();
+  });
+
+  it('leaves existing data untouched', async () => {
+    const storage = new LocalWorkoutStorage();
+    await populate(storage);
+
+    await expect(
+      storage.importData({ workouts: [{ id: 1, date: 'nope' }], preferences: {} }),
+    ).rejects.toThrow();
+
+    // Validation happens before any write, so nothing is half-replaced.
+    expect(await storage.getAllWorkouts()).toHaveLength(2);
+    expect(storage.getStreakDays()).toEqual([1, 3, 5]);
+  });
+});
+
+describe('backup file helpers', () => {
+  it('names the file by date', () => {
+    expect(backupFilename(new Date(2026, 6, 25))).toBe('ironpath-backup-2026-07-25.json');
+  });
+
+  it('summarises what a backup holds', () => {
+    expect(describeBackup({ workouts: [1, 2, 3], customTemplates: [1] })).toContain('3 workouts');
+    expect(describeBackup({ workouts: [1, 2, 3], customTemplates: [1] })).toContain(
+      '1 custom template',
+    );
+  });
+
+  it('summarises an empty or unrecognised file without throwing', () => {
+    expect(describeBackup(null)).toContain('0 workouts');
+    expect(describeBackup({})).toContain('0 workouts');
+  });
+
+  it('explains itself when the file is not JSON', async () => {
+    const file = new File(['this is not json'], 'notes.txt', { type: 'text/plain' });
+    await expect(readJsonFile(file)).rejects.toThrow(/JSON backup file/);
+  });
+
+  it('parses a real JSON file', async () => {
+    const file = new File(['{"workouts":[]}'], 'backup.json', { type: 'application/json' });
+    await expect(readJsonFile(file)).resolves.toEqual({ workouts: [] });
+  });
+});

--- a/client/src/lib/backup.ts
+++ b/client/src/lib/backup.ts
@@ -1,0 +1,64 @@
+import { formatLocalDate } from '@/lib/utils';
+
+/** Filename for a backup taken now, e.g. ironpath-backup-2026-07-25.json */
+export function backupFilename(now: Date = new Date()): string {
+  return `ironpath-backup-${formatLocalDate(now)}.json`;
+}
+
+/** Trigger a download of `data` as formatted JSON. */
+export function downloadJson(filename: string, data: unknown): void {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Read and parse a user-selected JSON file.
+ *
+ * Rejects with a message worth showing rather than a raw SyntaxError, since
+ * the most likely cause is picking the wrong file.
+ */
+export async function readJsonFile(file: File): Promise<unknown> {
+  let text: string;
+  try {
+    text = await file.text();
+  } catch {
+    throw new Error("That file couldn't be read.");
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error("That doesn't look like a JSON backup file.");
+  }
+}
+
+/** One-line description of what a backup contains, for the confirm step. */
+export function describeBackup(data: unknown): string {
+  const backup = data as {
+    workouts?: unknown[];
+    customTemplates?: unknown[];
+    exportedAt?: string;
+  } | null;
+
+  const workouts = Array.isArray(backup?.workouts) ? backup!.workouts.length : 0;
+  const templates = Array.isArray(backup?.customTemplates) ? backup!.customTemplates.length : 0;
+
+  const parts = [
+    `${workouts} ${workouts === 1 ? 'workout' : 'workouts'}`,
+    `${templates} custom ${templates === 1 ? 'template' : 'templates'}`,
+  ];
+
+  if (backup?.exportedAt) {
+    const when = new Date(backup.exportedAt);
+    if (!Number.isNaN(when.getTime())) {
+      parts.push(`saved ${when.toLocaleDateString()}`);
+    }
+  }
+
+  return parts.join(', ');
+}

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -77,6 +77,65 @@ const customTemplateSchema = z.object({
   includeInAutoSchedule: z.boolean().optional(),
 });
 
+const exerciseHistorySchema = z.record(
+  z.string(),
+  z.object({
+    sets: z.array(
+      z.object({
+        weight: z.number(),
+        reps: z.number(),
+        rest: z.string().optional(),
+      })
+    ),
+    date: z.string(),
+  })
+);
+
+/**
+ * Shape of an exported backup file.
+ *
+ * Only `workouts` and `preferences` are required, so a file written by an
+ * earlier build still restores — anything it omits is left untouched rather
+ * than reset.
+ */
+const backupSchema = z.object({
+  version: z.number().optional(),
+  exportedAt: z.string().optional(),
+  workouts: z.array(storedWorkoutSchema),
+  preferences: storedPreferencesSchema,
+  customTemplates: z.array(customTemplateSchema).optional(),
+  exerciseHistory: exerciseHistorySchema.optional(),
+  autoScheduleWorkouts: z.array(z.string()).optional(),
+  hiddenPresets: z.record(z.string(), z.boolean()).optional(),
+  presetPrompts: z.record(z.string(), z.boolean()).optional(),
+  streakDays: z.array(z.number().int().min(0).max(6)).optional(),
+  quarantined: z
+    .array(
+      z.object({
+        quarantinedAt: z.string(),
+        reason: z.string(),
+        record: z.unknown(),
+      })
+    )
+    .optional(),
+});
+
+const BACKUP_VERSION = 1;
+
+export interface IronPathBackup {
+  version: number;
+  exportedAt: string;
+  workouts: Workout[];
+  preferences: UserPreferences;
+  customTemplates: CustomWorkoutTemplate[];
+  exerciseHistory: Record<string, ExerciseHistoryEntry>;
+  autoScheduleWorkouts: string[];
+  hiddenPresets: Record<string, boolean>;
+  presetPrompts: Record<string, boolean>;
+  streakDays: number[];
+  quarantined: QuarantinedWorkout[];
+}
+
 export class LocalWorkoutStorage {
   private storageLimit = 5 * 1024 * 1024; // 5MB approximate
   private warningThreshold = 0.8;
@@ -678,27 +737,47 @@ export class LocalWorkoutStorage {
     return updated;
   }
 
-  async exportData(): Promise<{
-    workouts: Workout[];
-    preferences: UserPreferences;
-    customTemplates: CustomWorkoutTemplate[];
-    quarantined: QuarantinedWorkout[];
-  }> {
+  /**
+   * Everything needed to reconstruct this install elsewhere.
+   *
+   * "Backup" previously meant workouts, preferences and templates — which left
+   * out exercise history (what prefills every set), the auto-schedule
+   * rotation, hidden presets and the streak configuration. Restoring from that
+   * would have silently reset half the app.
+   */
+  async exportData(): Promise<IronPathBackup> {
     // `getWorkouts()` runs first so anything unparseable is set aside before
     // the quarantine is read — otherwise an export could miss a record that
     // this very call just rejected. Quarantined records ride along so a
     // recovery is possible from the exported file alone.
     const workouts = this.getWorkouts();
     return {
+      version: BACKUP_VERSION,
+      exportedAt: new Date().toISOString(),
       workouts,
       preferences: await this.getUserPreferences(),
       customTemplates: this.getCustomTemplatesInternal(),
+      exerciseHistory: this.getExerciseHistory(),
+      autoScheduleWorkouts: this.getAutoScheduleWorkouts(),
+      hiddenPresets: this.getHiddenPresets(),
+      presetPrompts: this.getPresetPromptPrefs(),
+      streakDays: this.getStreakDays(),
       quarantined: this.getQuarantinedWorkouts()
     };
   }
 
-  async importData(data: { workouts: Workout[]; preferences: UserPreferences; customTemplates?: CustomWorkoutTemplate[] }): Promise<void> {
-    const workouts = z.array(storedWorkoutSchema).parse(data.workouts).map((workout) => ({
+  /**
+   * Replace this install's data with the contents of a backup.
+   *
+   * Throws if the payload does not validate, before writing anything — a bad
+   * file must not leave storage half-replaced. Every field beyond workouts and
+   * preferences is optional, so a file produced by an older build still
+   * restores; anything it omits is simply left as-is.
+   */
+  async importData(data: unknown): Promise<void> {
+    const backup = backupSchema.parse(data);
+
+    const workouts = backup.workouts.map((workout) => ({
       ...workout,
       completed: Boolean(workout.completed),
       duration: workout.duration ?? null,
@@ -707,25 +786,47 @@ export class LocalWorkoutStorage {
       updatedAt: workout.updatedAt ?? new Date(),
     })) as Workout[];
 
-    const preferences = storedPreferencesSchema.parse(data.preferences);
     const normalizedPreferences: UserPreferences = {
-      id: preferences.id ?? 1,
-      darkMode: preferences.darkMode ?? false,
-      autoIncrement: preferences.autoIncrement ?? false,
-      notifications: preferences.notifications ?? true,
-      updatedAt: preferences.updatedAt ?? new Date(),
+      id: backup.preferences.id ?? 1,
+      darkMode: backup.preferences.darkMode ?? false,
+      autoIncrement: backup.preferences.autoIncrement ?? false,
+      notifications: backup.preferences.notifications ?? true,
+      updatedAt: backup.preferences.updatedAt ?? new Date(),
     };
 
+    // Validation is complete by this point, so the writes below cannot leave a
+    // partially-restored store behind.
     this.saveWorkouts(workouts);
     this.safeSetItem(STORAGE_KEYS.PREFERENCES, JSON.stringify(normalizedPreferences));
 
-    if (data.customTemplates) {
-      const templates = z.array(customTemplateSchema).parse(data.customTemplates).map((template) => ({
-        ...template,
-        abs: template.abs ?? [],
-        includeInAutoSchedule: template.includeInAutoSchedule ?? false,
-      }));
-      this.saveCustomTemplates(templates);
+    if (backup.customTemplates) {
+      this.saveCustomTemplates(
+        backup.customTemplates.map((template) => ({
+          ...template,
+          abs: template.abs ?? [],
+          includeInAutoSchedule: template.includeInAutoSchedule ?? false,
+        }))
+      );
+    }
+    if (backup.exerciseHistory) {
+      this.saveExerciseHistory(backup.exerciseHistory);
+    }
+    if (backup.autoScheduleWorkouts) {
+      this.saveAutoScheduleWorkouts(backup.autoScheduleWorkouts);
+    }
+    if (backup.hiddenPresets) {
+      this.saveHiddenPresets(backup.hiddenPresets);
+    }
+    if (backup.presetPrompts) {
+      this.savePresetPromptPrefs(backup.presetPrompts);
+    }
+    if (backup.streakDays) {
+      this.saveStreakDays(backup.streakDays);
+    }
+    // Carried across so a record set aside on the old device is still
+    // recoverable on the new one rather than quietly disappearing in transit.
+    if (backup.quarantined) {
+      this.safeSetItem(STORAGE_KEYS.QUARANTINE, JSON.stringify(backup.quarantined));
     }
 
     // Update current ID to prevent conflicts

--- a/e2e/backup.spec.ts
+++ b/e2e/backup.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { setNumericValue } from './helpers';
+
+/**
+ * The whole point of a backup is the round trip, so this exercises it end to
+ * end in a browser: log something, export the file, wipe the device, restore
+ * from that exact file, and check what comes back.
+ */
+
+test('a backup exports and restores through the UI', async ({ page }) => {
+  await page.goto('/');
+
+  // Something identifiable to look for after the restore.
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await setNumericValue(page.getByLabel('Weight').first(), '173');
+  await page.getByRole('button', { name: 'Save Workout' }).click();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        (localStorage.getItem('ironpath_workouts') ?? '').includes('"weight":173'),
+      ),
+    )
+    .toBe(true);
+
+  await page.getByRole('button', { name: 'Calendar' }).click();
+
+  // Export, and keep the bytes the browser actually wrote.
+  await page.getByRole('button', { name: 'Settings' }).click();
+  const downloadPromise = page.waitForEvent('download');
+  await page.getByRole('button', { name: 'Export Backup' }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/^ironpath-backup-\d{4}-\d{2}-\d{2}\.json$/);
+  const backupJson = readFileSync((await download.path())!, 'utf8');
+
+  // The backup must be self-sufficient, so wipe everything.
+  await page.evaluate(() => localStorage.clear());
+  await page.reload();
+  await expect(page.getByText('No custom workout scheduled for this date')).toBeVisible();
+
+  // Restore from the exported file.
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await page.locator('#import-file').setInputFiles({
+    name: 'ironpath-backup.json',
+    mimeType: 'application/json',
+    buffer: Buffer.from(backupJson),
+  });
+
+  await expect(page.getByText('Restore this backup?')).toBeVisible();
+  await page.getByRole('button', { name: 'Restore', exact: true }).click();
+
+  // The app reloads itself after a successful restore, and today's workout is
+  // back on the calendar.
+  await expect(page.getByText('No custom workout scheduled for this date')).toHaveCount(0);
+
+  const restoredWeight = await page.evaluate(() => {
+    const stored = JSON.parse(localStorage.getItem('ironpath_workouts') ?? '[]');
+    return stored[0]?.exercises?.[0]?.sets?.[0]?.weight;
+  });
+  expect(restoredWeight).toBe(173);
+});
+
+test('a file that is not a backup is refused without touching anything', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.getByRole('button', { name: 'Calendar' }).click();
+  await expect(page.getByRole('button', { name: /Completed/ })).toBeVisible();
+
+  const before = await page.evaluate(() => localStorage.getItem('ironpath_workouts'));
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+  await page.locator('#import-file').setInputFiles({
+    name: 'holiday-photo.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('definitely not json'),
+  });
+
+  await expect(page.getByText("Couldn't read that file")).toBeVisible();
+  // No confirmation offered, and nothing replaced.
+  await expect(page.getByText('Restore this backup?')).toHaveCount(0);
+  expect(await page.evaluate(() => localStorage.getItem('ironpath_workouts'))).toBe(before);
+});

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -72,8 +72,10 @@ test('a started workout appears on the calendar after navigating back', async ({
   await page.getByRole('button', { name: 'Calendar' }).click();
   await expect(page).toHaveURL(/\/$/);
 
-  // Today's cell carries the pending marker rather than the plain today marker.
-  await expect(page.getByText('🕒').first()).toBeVisible();
+  // The selected day now has a workout attached. Asserting on the 🕒 glyph
+  // would prove nothing — the status legend renders one unconditionally, so
+  // that assertion passed with no workout at all.
+  await expect(page.getByText('No custom workout scheduled for this date')).toHaveCount(0);
 });
 
 test('the workout page is reachable by deep link after a cold start', async ({ page }) => {


### PR DESCRIPTION
## What was broken

**Export Workouts** wrote five CSV columns — id, date, type, completed, duration. Every set, rep, weight and custom template was discarded. The file could not be restored from.

**Import Workouts** opened a file picker and then always answered *"Import not implemented."*

Between them there was no way back from a lost phone, which for a local-only app is the one recovery path that matters. `localWorkoutStorage.importData()` already existed, zod-validated and working — only the UI was unwired.

## The backup was also incomplete

The existing payload covered workouts, preferences and templates. That leaves out:

- **exercise history** — what prefills weight and reps on every set
- the auto-schedule rotation
- hidden presets and their prompt preferences
- the streak-day configuration

Restoring from that would have brought your workouts back and silently reset half the app. All ten stored keys are covered now, including quarantined records, so a record set aside on the old device stays recoverable on the new one instead of disappearing in transit.

## Restore behaviour

- **Validates the entire file before writing anything.** A wrong or corrupt file cannot leave storage half-replaced.
- **Shows what it contains before replacing anything** — "42 workouts, 3 custom templates, saved 12/07/2026" — then asks to confirm.
- **Accepts backups from the older build.** Everything past workouts and preferences is optional, and an absent section is left alone rather than reset.
- Errors say something useful. Picking a text file gets "That doesn't look like a JSON backup file", not a raw `SyntaxError`.

History's "Export to JSON" now produces the same file, so either route gives you something Restore accepts.

## Verification

```
npx tsc --noEmit    -> clean
npx vitest run      -> 83 passed (was 69; 14 new)
npx playwright test -> 38 passed (2 new x 2 viewports)
npm run build       -> ok
```

Three full end-to-end runs, no flakes.

The end-to-end test does the actual round trip in a browser: log a set at 173 lbs, export, read the bytes the browser really wrote to disk, **wipe localStorage entirely**, restore from that exact file, and confirm 173 comes back. The second test feeds it a text file and checks nothing is offered and nothing changes.

Confirmed load-bearing by reverting `storage.ts` and `SettingsDialog.tsx` while keeping the tests: 3 unit tests and both end-to-end tests fail.

## Two things worth flagging

**One a11y change snuck in, deliberately.** The Settings button had no accessible name, so backup was unreachable to both a screen reader and a test. I added `aria-label="Settings"` rather than target it positionally. The other icon-only buttons stay in the a11y pass.

**I fixed a test of mine that proved nothing.** A smoke test asserted the 🕒 glyph was visible after starting a workout — but the status legend renders 🕒 unconditionally, so it passed with no workout at all. Now it checks that "No custom workout scheduled for this date" has gone, which actually depends on the workout existing. Second time this has come up; a green assertion that would be green anyway is worse than no assertion.

## Risk

`exportData()` gained fields (additive). `importData()` now takes `unknown` and validates, replacing a signature that trusted its caller — stricter, not looser. Restore is behind a confirmation, and the only destructive path stays Reset All Data.

The CSV export in History is untouched, for spreadsheets.

## Worth checking

Settings → **Export Backup**, then Settings → **Restore From Backup** with that file. It should tell you what's in it, and after restoring, everything should look exactly as it does now. Worth keeping that file somewhere off the phone.