### PR TITLE
fix: give every interactive control an accessible name

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -55,7 +55,7 @@ function Header() {
             <h1 className="text-xl font-semibold text-gray-900 dark:text-white">IronPath</h1>
           </div>
           <div className="flex items-center space-x-2">
-            <Button variant="ghost" size="sm" onClick={toggleTheme} className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+            <Button aria-label={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'} variant="ghost" size="sm" onClick={toggleTheme} className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
               {theme === 'dark' ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
             </Button>
             <SettingsDialog>

--- a/client/src/components/AutoScheduleModal.tsx
+++ b/client/src/components/AutoScheduleModal.tsx
@@ -176,7 +176,7 @@ export function AutoScheduleModal({ open, onClose, customTemplates }: AutoSchedu
             <div className="space-y-2">
               {presetNames.map(name => (
                 <label key={name} className="flex items-center space-x-2 text-sm">
-                  <Checkbox checked={selected.has(name)} onCheckedChange={() => toggle(name)} />
+                  <Checkbox aria-label={name} checked={selected.has(name)} onCheckedChange={() => toggle(name)} />
                   <span>{name}</span>
                 </label>
               ))}
@@ -188,7 +188,7 @@ export function AutoScheduleModal({ open, onClose, customTemplates }: AutoSchedu
               <div className="space-y-2">
                 {templates.map(t => (
                   <label key={t.id} className="flex items-center space-x-2 text-sm">
-                    <Checkbox checked={selected.has(t.name)} onCheckedChange={() => toggle(t.name)} />
+                    <Checkbox aria-label={t.name} checked={selected.has(t.name)} onCheckedChange={() => toggle(t.name)} />
                     <span>{t.name}</span>
                   </label>
                 ))}
@@ -218,7 +218,7 @@ export function AutoScheduleModal({ open, onClose, customTemplates }: AutoSchedu
           </AlertDialogDescription>
         </AlertDialogHeader>
         <div className="flex items-center space-x-2 py-2">
-          <Checkbox id="dont-show" checked={dontShowAgain} onCheckedChange={v => setDontShowAgain(!!v)} />
+          <Checkbox id="dont-show" aria-label="Don't show again" checked={dontShowAgain} onCheckedChange={v => setDontShowAgain(!!v)} />
           <label htmlFor="dont-show" className="text-sm">Don't show again</label>
         </div>
         <AlertDialogFooter className="gap-2">

--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -288,6 +288,7 @@ export function CustomWorkoutBuilderModal({
                       <div className="flex items-center gap-1">
                         <div className="flex items-center gap-2 min-w-0">
                           <Checkbox
+                            aria-label={ex.machine}
                             checked={selected.has(ex.machine)}
                             onCheckedChange={() => toggle(ex.machine)}
                           />
@@ -318,6 +319,7 @@ export function CustomWorkoutBuilderModal({
                   <div className="flex items-center gap-1">
                     <div className="flex items-center gap-2 min-w-0">
                       <Checkbox
+                        aria-label={abs.name}
                         checked={selectedAbs.has(abs.name)}
                         onCheckedChange={() => toggleAbs(abs.name)}
                       />
@@ -344,9 +346,10 @@ export function CustomWorkoutBuilderModal({
           {warning15 && (
             <p className="text-red-600 text-sm">🚨 Danger: Too many exercises in one session isn't effective. Consider splitting it up.</p>
           )}
-          <Input placeholder="Workout name" value={name} onChange={e => setName(e.target.value)} />
+          <Input aria-label="Workout name" placeholder="Workout name" value={name} onChange={e => setName(e.target.value)} />
           <label className="flex items-center space-x-2 text-sm">
             <Checkbox
+              aria-label="Include in auto-schedule"
               checked={includeInSchedule}
               onCheckedChange={v => setIncludeInSchedule(!!v)}
             />

--- a/client/src/components/CustomizeStreakModal.tsx
+++ b/client/src/components/CustomizeStreakModal.tsx
@@ -74,6 +74,7 @@ export function CustomizeStreakModal({ open, onClose }: CustomizeStreakModalProp
           {days.map((day, idx) => (
             <label key={day} className="flex items-center space-x-2 text-sm">
               <Checkbox
+                aria-label={day}
                 checked={selected.has(idx)}
                 onCheckedChange={() => toggle(idx)}
               />

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -86,7 +86,7 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
               </Button>
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" size="icon">
+                  <Button aria-label={`Options for ${name}`} variant="ghost" size="icon">
                     <Settings className="h-4 w-4" />
                   </Button>
                 </DropdownMenuTrigger>
@@ -116,6 +116,7 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
               Create Custom Workout
             </Button>
             <Button
+              aria-label="Create Custom Workout"
               variant="ghost"
               size="icon"
               onClick={() => {
@@ -143,7 +144,7 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
                   </Button>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon">
+                      <Button aria-label={`Options for ${t.name}`} variant="ghost" size="icon">
                         <Settings className="h-4 w-4" />
                       </Button>
                     </DropdownMenuTrigger>

--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -113,6 +113,7 @@ export function CalendarGrid({
         <Button
           variant="ghost"
           size="sm"
+          aria-label="Previous month"
           onClick={() => navigateMonth('prev')}
           className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700"
         >
@@ -124,6 +125,7 @@ export function CalendarGrid({
         <Button
           variant="ghost"
           size="sm"
+          aria-label="Next month"
           onClick={() => navigateMonth('next')}
           className="p-2 hover:bg-gray-100 dark:hover:bg-gray-700"
         >

--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -170,7 +170,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                   type="text"
                   inputMode="decimal"
                   pattern="[0-9]*"
-                  aria-label="Weight"
+                  aria-label={`Weight, set ${index + 1}`}
                   value={set.weight ?? ''}
                   onChange={(e) => {
                     const v = e.target.value;
@@ -190,6 +190,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                   type="text"
                   inputMode="decimal"
                   pattern="[0-9]*"
+                  aria-label={`Reps, set ${index + 1}`}
                   value={set.reps ?? ''}
                   onChange={(e) => {
                     const v = e.target.value;
@@ -207,6 +208,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                   type="text"
                   inputMode="numeric"
                   pattern="[0-9:]*"
+                  aria-label={`Rest, set ${index + 1}`}
                   value={set.rest ?? ''}
                   onChange={(e) => {
                     const inputEv = e.nativeEvent as InputEvent;
@@ -239,6 +241,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
                   <Button
                     variant="ghost"
                     size="sm"
+                    aria-label={`Mark set ${index + 1} complete`}
                     onClick={() => markSetComplete(index)}
                     className="text-blue-600 hover:text-blue-800"
                   >

--- a/client/src/components/workout-card.tsx
+++ b/client/src/components/workout-card.tsx
@@ -49,6 +49,7 @@ export function WorkoutCard({ workout, onStart, onView, onDelete }: WorkoutCardP
         <AlertDialog>
           <AlertDialogTrigger asChild>
             <Button
+              aria-label="Delete this workout"
               size="icon"
               variant="ghost"
               className="absolute top-2 left-2 h-6 w-6 p-0 text-red-600 hover:bg-red-100 dark:hover:bg-red-900"

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -350,6 +350,7 @@ export function CalendarPage() {
       <div className="grid grid-cols-3 gap-4">
         <button
           type="button"
+          aria-label={`Completed: ${stats.completedWorkouts} workouts`}
           onClick={() => setLocation('/history')}
           className="rounded-lg border bg-card text-card-foreground shadow-sm p-4 text-center cursor-pointer transition-colors hover:bg-accent/50 active:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
@@ -358,6 +359,7 @@ export function CalendarPage() {
         </button>
         <button
           type="button"
+          aria-label={`Day Streak: ${stats.currentStreak}`}
           onClick={() => setStreakModalOpen(true)}
           className="rounded-lg border bg-card text-card-foreground shadow-sm p-4 text-center cursor-pointer transition-colors hover:bg-accent/50 active:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >
@@ -366,6 +368,7 @@ export function CalendarPage() {
         </button>
         <button
           type="button"
+          aria-label={`Top Streak: ${stats.topStreak}`}
           onClick={() => setLocation('/history')}
           className="rounded-lg border bg-card text-card-foreground shadow-sm p-4 text-center cursor-pointer transition-colors hover:bg-accent/50 active:bg-accent/70 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         >

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -291,6 +291,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
       {/* Header */}
       <div className="flex items-center space-x-3">
         <Button
+          aria-label="Go back"
           variant="ghost"
           size="sm"
           onClick={onNavigateBack}
@@ -361,6 +362,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                             type="text"
                             inputMode="decimal"
                             pattern="[0-9]*"
+                            aria-label={`Reps for ${absExercise.name}`}
                             value={absExercise.reps}
                             onChange={(e) => {
                               const value = e.target.value.trim();
@@ -380,6 +382,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                         <>
                           <Input
                             type="text"
+                            aria-label={`Time for ${absExercise.name}`}
                             value={absExercise.time || ''}
                             onChange={(e) => handleAbsUpdate(index, 'time', e.target.value)}
                             className="w-16 text-sm"
@@ -391,6 +394,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                       <Button
                         variant="ghost"
                         size="sm"
+                        aria-label={`Mark ${absExercise.name} ${absExercise.completed ? 'incomplete' : 'complete'}`}
                         onClick={() =>
                           handleAbsUpdate(index, 'completed', !absExercise.completed)
                         }
@@ -413,6 +417,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                 <Button
                   variant="ghost"
                   size="sm"
+                  aria-label={`Mark cardio ${workout.cardio?.completed ? 'incomplete' : 'complete'}`}
                   onClick={() => handleCardioUpdate('completed', !workout.cardio?.completed)}
                   className={workout.cardio?.completed ? 'text-green-600' : 'text-gray-400'}
                 >
@@ -444,6 +449,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                     <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Duration:</label>
                     <Input
                       type="text"
+                      aria-label="Cardio duration"
                       value={workout.cardio?.duration || ''}
                       onChange={(e) => handleCardioUpdate('duration', e.target.value)}
                       className="w-20 text-sm"
@@ -455,6 +461,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                     <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Distance:</label>
                     <Input
                       type="text"
+                      aria-label="Cardio distance"
                       value={workout.cardio?.distance || ''}
                       onChange={(e) => handleCardioUpdate('distance', e.target.value)}
                       className="w-20 text-sm"

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,0 +1,85 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Every interactive control must expose a name to assistive technology.
+ *
+ * An icon-only button with no `aria-label` is announced as just "button", and
+ * a Radix checkbox renders as a `<button>` — so wrapping it in a `<label>`
+ * does not name it either, which is how a whole screen of exercise
+ * checkboxes ended up anonymous.
+ *
+ * The rule is enforced per screen rather than per component, because the
+ * failure is only visible once a control is rendered in place.
+ */
+
+/** Controls whose accessible name is missing, or is nothing but an emoji. */
+async function unnamedControls(page: Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const offenders: string[] = [];
+    document
+      .querySelectorAll('button, [role="checkbox"], input:not([type="file"])')
+      .forEach(element => {
+        const el = element as HTMLElement;
+        if (el.offsetParent === null) return; // not rendered
+        const name = el.getAttribute('aria-label') || (el.textContent || '').trim();
+        if (name && /[a-zA-Z0-9]/.test(name)) return;
+        offenders.push(el.outerHTML.replace(/\s+/g, ' ').slice(0, 120));
+      });
+    return offenders;
+  });
+}
+
+test('the calendar names every control', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: 'IronPath' })).toBeVisible();
+  expect(await unnamedControls(page)).toEqual([]);
+});
+
+test('the auto-schedule editor names every control', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Customize Auto-Schedule' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  expect(await unnamedControls(page)).toEqual([]);
+});
+
+test('the streak editor names every control', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: /Day Streak/ }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  expect(await unnamedControls(page)).toEqual([]);
+});
+
+test('the template selector names every control', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await expect(page.getByRole('dialog')).toBeVisible();
+  expect(await unnamedControls(page)).toEqual([]);
+});
+
+test('the custom workout builder names every control', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  await expect(page.getByText('Select up to 15 exercises')).toBeVisible();
+  expect(await unnamedControls(page)).toEqual([]);
+});
+
+test('the workout page names every control', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await expect(page.getByText('Main Workout')).toBeVisible();
+  expect(await unnamedControls(page)).toEqual([]);
+});
+
+test('set inputs are distinguishable from each other', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+
+  // Previously only the weight field carried a label, so reps and rest were
+  // announced identically to every other unlabelled box on the page.
+  await expect(page.getByLabel('Weight, set 1').first()).toBeVisible();
+  await expect(page.getByLabel('Reps, set 1').first()).toBeVisible();
+  await expect(page.getByLabel('Rest, set 1').first()).toBeVisible();
+});

--- a/e2e/auto-schedule.spec.ts
+++ b/e2e/auto-schedule.spec.ts
@@ -30,7 +30,7 @@ async function closeTemplateSelector(page: Page) {
 
 async function createCustomWorkout(page: Page, name: string) {
   await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
-  await page.getByRole('button', { name: 'Create Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
 
   const builder = builderDialog(page);
   await expect(builder).toBeVisible();


### PR DESCRIPTION
## Surveyed, not guessed

Rather than reading markup, I walked each screen in a real browser and counted controls whose accessible name was missing or was nothing but an emoji:

```
Calendar            3
Template selector  11
Builder            62   (11 buttons, 50 checkboxes, 1 input)
Workout page       59   (2 buttons, 44 inputs, 13 emoji-only)
```

A screen reader announced most of these as "button", or as "◯".

## Two structural causes

**Icon-only buttons have no text and had no `aria-label`** — theme toggle, month navigation, the per-template menus, delete-workout.

**Radix renders a checkbox as a `<button>`, so wrapping it in a `<label>` does not name it.** That is why every exercise and core-exercise checkbox in the builder was anonymous, along with the auto-schedule and streak-day pickers. Worth knowing: it looks correct in the markup, and it is not.

Also labelled the set fields. Only **weight** had a label, so reps and rest were announced identically to every other unlabelled box on a page containing 44 of them. All three now name their set number — "Weight, set 2", "Reps, set 2", "Rest, set 2".

## Guarded

New end-to-end suite walks all six screens and asserts zero unnamed controls, failing with the offending markup so the next one is obvious. All seven tests fail without this change — verified by stashing the source and re-running.

```
npx tsc --noEmit    -> clean
npx vitest run      -> 83 passed
npx playwright test -> 50 passed (7 new x 2 viewports)
npm run build       -> ok
```

Four consecutive full-suite runs, no flakes.

## The interesting failure

My first attempt broke six existing tests. Adding names created **substring collisions**: "Back to calendar" contains the Calendar nav button's name, and the stat tiles' "View history." contains History's, so `getByRole` matched two elements.

That is not just a test problem. A control whose name contains another control's name is genuinely ambiguous to a screen reader — "Calendar" and "Back to calendar" in the same view is exactly the confusion this PR exists to remove. Renamed to "Go back", and the tiles to "Completed: N workouts" / "Day Streak: N" / "Top Streak: N", which also reads better than the current "0Completed".

I would not have caught it by inspecting the markup. The suite failing is what surfaced it.

## Deliberately not included: pinch-zoom

The viewport still sets `maximum-scale=1`, which blocks pinch-zoom — the last item on the a11y list, and I want your call rather than my guess.

Removing it alone has a side effect: iOS auto-zooms whenever an input smaller than 16px takes focus, and the set fields are 14px (`text-sm`). So you would gain pinch-zoom and simultaneously get an unwanted zoom every time you tapped a weight box mid-set — plausibly worse than today.

Doing it properly means bumping those inputs to 16px, which makes the weight/reps/rest row visibly larger and risks wrapping on a narrow phone. That is a layout change on the screen you actually use, so:

1. **Leave it** — pinch-zoom stays blocked. Zero risk.
2. **Remove `maximum-scale` and bump the set inputs to 16px** — pinch-zoom works, no iOS auto-zoom, but the logging row gets taller. I would build it and you would judge it on the preview.

If you are not on iOS, option 2's downside largely evaporates and it is straightforwardly the right change.

## Risk

Attribute-only changes plus three renamed labels. No behaviour, no layout, no logic. The one non-attribute edit is `.first()` on a test locator, because the "Create Custom Workout" gear duplicates the button beside it — same handler, so I gave it the same name rather than inventing a false distinction. That redundant gear is worth removing at some point, but not in an a11y PR.

## What to check

Nothing should look any different. If you use VoiceOver or TalkBack, the builder's exercise list is the place to notice the change — it previously announced fifty consecutive unnamed checkboxes.