### PR TITLE
fix: refuse custom workout names that a built-in workout already answers to

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -43,6 +43,15 @@ interface CustomWorkoutBuilderModalProps {
     abs: AbsExercise[];
   } | null;
   existingNames: string[];
+  /**
+   * Names the built-in workouts already answer to.
+   *
+   * Templates are looked up by name, and `workoutTemplates[name]` is checked
+   * first — so a custom workout sharing a preset's name is unreachable: choose
+   * it and you silently get the built-in one instead. Cheaper to refuse the
+   * name than to let someone build a workout they can never open.
+   */
+  reservedNames?: string[];
 }
 
 export function CustomWorkoutBuilderModal({
@@ -54,6 +63,7 @@ export function CustomWorkoutBuilderModal({
   template,
   prefill,
   existingNames,
+  reservedNames = [],
 }: CustomWorkoutBuilderModalProps) {
   const { popView } = useViewStack();
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -162,9 +172,12 @@ export function CustomWorkoutBuilderModal({
     });
   };
 
-  const isDuplicate = existingNames
+  const trimmedName = name.trim().toLowerCase();
+  const clashesWithTemplate = existingNames
     .filter(n => !template || n.toLowerCase() !== template.name.toLowerCase())
-    .some(n => n.toLowerCase() === name.trim().toLowerCase());
+    .some(n => n.toLowerCase() === trimmedName);
+  const clashesWithPreset = reservedNames.some(n => n.toLowerCase() === trimmedName);
+  const isDuplicate = clashesWithTemplate || clashesWithPreset;
 
   const handleSave = () => {
     if (name.trim() === '' || selected.size === 0 || isDuplicate) return;
@@ -355,7 +368,12 @@ export function CustomWorkoutBuilderModal({
             />
             <span>Include in auto-schedule</span>
           </label>
-          {isDuplicate && (
+          {clashesWithPreset && (
+            <p className="text-red-600 text-sm">
+              “{name.trim()}” is a built-in workout. Choose a different name.
+            </p>
+          )}
+          {clashesWithTemplate && (
             <p className="text-red-600 text-sm">Workout name must be unique</p>
           )}
           <Button onClick={handleSave} disabled={name.trim() === '' || selected.size === 0 || isDuplicate}>

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -482,6 +482,7 @@ export function CalendarPage() {
             template={templateToEdit ?? undefined}
             prefill={prefillTemplate ?? undefined}
             existingNames={customTemplates.map(t => t.name)}
+            reservedNames={Object.keys(workoutTemplates)}
           />
         </ErrorBoundary>
         <AutoScheduleModal

--- a/e2e/name-collision.spec.ts
+++ b/e2e/name-collision.spec.ts
@@ -1,0 +1,69 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Templates are resolved by name, and `workoutTemplates[name]` is consulted
+ * first — so a custom workout sharing a built-in workout's name can never be
+ * opened. Choosing it hands you the built-in one instead, silently. The
+ * builder refuses those names rather than letting one be created.
+ */
+
+async function openBuilder(page: Page) {
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  const builder = page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' });
+  await expect(builder).toBeVisible();
+  await builder.getByRole('checkbox').first().click();
+  return builder;
+}
+
+test('a built-in workout name is refused', async ({ page }) => {
+  await page.goto('/');
+  const builder = await openBuilder(page);
+
+  await builder.getByLabel('Workout name').fill('Chest Day');
+
+  await expect(builder.getByText('is a built-in workout')).toBeVisible();
+  await expect(builder.getByRole('button', { name: 'Save Workout' })).toBeDisabled();
+});
+
+test('the check ignores case and surrounding spaces', async ({ page }) => {
+  await page.goto('/');
+  const builder = await openBuilder(page);
+
+  await builder.getByLabel('Workout name').fill('  chest day  ');
+
+  await expect(builder.getByText('is a built-in workout')).toBeVisible();
+  await expect(builder.getByRole('button', { name: 'Save Workout' })).toBeDisabled();
+});
+
+test('a name of your own is still accepted', async ({ page }) => {
+  await page.goto('/');
+  const builder = await openBuilder(page);
+
+  await builder.getByLabel('Workout name').fill('Chest Day But Mine');
+
+  await expect(builder.getByText('is a built-in workout')).toHaveCount(0);
+  await expect(builder.getByRole('button', { name: 'Save Workout' })).toBeEnabled();
+
+  await builder.getByRole('button', { name: 'Save Workout' }).click();
+  await expect(builder).toBeHidden();
+  await expect(page.getByRole('button', { name: 'Chest Day But Mine', exact: true })).toBeVisible();
+});
+
+test('renaming an existing template to its own name is still allowed', async ({ page }) => {
+  await page.goto('/');
+  const builder = await openBuilder(page);
+  await builder.getByLabel('Workout name').fill('Keeps Its Name');
+  await builder.getByRole('button', { name: 'Save Workout' }).click();
+  await expect(builder).toBeHidden();
+
+  const row = page.getByRole('button', { name: 'Keeps Its Name', exact: true }).locator('..');
+  await row.getByRole('button', { name: /Options for/ }).click();
+  await page.getByRole('menuitem', { name: 'Edit workout' }).click();
+
+  const editor = page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' });
+  await expect(editor).toBeVisible();
+  // Unchanged name must not be reported as a duplicate of itself.
+  await expect(editor.getByText('must be unique')).toHaveCount(0);
+  await expect(editor.getByRole('button', { name: 'Update Workout' })).toBeEnabled();
+});


### PR DESCRIPTION
## The bug

Templates are resolved by name, and `workoutTemplates[name]` is consulted first. So a custom workout called "Chest Day" could never be opened — selecting it silently created the **built-in** Chest Day instead.

The builder checked new names against your other custom templates, but not against the presets, so nothing stopped one being created. You could spend a minute picking exercises, save it, and get someone else's workout every time you tapped it.

Same root cause as #134: identity by name.

## The fix

The builder now treats the built-in names as reserved, sourced from `Object.keys(workoutTemplates)` — the exact set the lookup can resolve, rather than the hardcoded list the selector happens to display.

The message says which rule was broken. A clash with a preset reads *"'Chest Day' is a built-in workout. Choose a different name."* rather than the generic "Workout name must be unique", which would be baffling when the name appears nowhere in your own list.

## Scope: prevention only, as agreed

An already-saved collision still resolves to the preset. Fixing that means keying template lookup by id across the four creation paths in `calendar.tsx` — worth doing only if a collision actually exists, and not worth the risk otherwise.

Still worth running once on each of your two installs:

```js
JSON.parse(localStorage.ironpath_custom_templates || '[]').map(t => t.name)
```

If nothing there matches Chest Day, Legs, Back & Biceps, Back Biceps & Legs, Chest & Triceps, Chest & Shoulders or Chest Shoulders & Legs, prevention is the whole job.

## Verification

```
npx tsc --noEmit    -> clean
npx vitest run      -> 83 passed
npx playwright test -> 58 passed (4 new x 2 viewports)
npm run build       -> ok
```

Three consecutive full-suite runs, no flakes.

Four new end-to-end tests. The first two — a preset name is refused, and the check ignores case and surrounding whitespace — fail without the change. The other two are guards in the more important direction: an ordinary name still saves, and editing a template without renaming it is not reported as clashing with itself. A validation fix that starts rejecting legitimate names is worse than the bug.

## Risk

One added prop and one extra condition. The only behaviour change is that seven specific names are now rejected in the builder — names that produced an unusable workout anyway.

## What to check

Try to create a custom workout called "Chest Day". Save should stay disabled with an explanation. Anything else should behave exactly as before.