### PR TITLE
feat: let users add their own exercises

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -10,14 +10,26 @@ import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import type { Exercise, AbsExercise } from '@shared/schema';
-import { CustomWorkoutTemplate } from '@/lib/storage';
+import { CustomWorkoutTemplate, localWorkoutStorage, type CustomExercise } from '@/lib/storage';
 import { exerciseLibrary } from '@/lib/exercise-library';
 import { ExerciseOption } from '@/lib/exercise-library';
-import { absLibrary } from '@/lib/abs-library';
+import { absLibrary, type AbsExerciseOption } from '@/lib/abs-library';
+import { hasExerciseImage } from '@/lib/exercise-images';
+import { NewExerciseForm } from './NewExerciseForm';
 import { useViewStack } from './view-stack-provider';
 import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { cn } from '@/lib/utils';
 import { ErrorBoundary } from './ErrorBoundary';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
 
 interface CustomWorkoutBuilderModalProps {
   open: boolean;
@@ -73,19 +85,10 @@ export function CustomWorkoutBuilderModal({
   const [previewExercise, setPreviewExercise] = useState<string | null>(null);
   const [showPreview, setShowPreview] = useState(false);
   const [equipmentFilter, setEquipmentFilter] = useState<'freeweight' | 'machine' | 'both'>('both');
+  const [customExercises, setCustomExercises] = useState<CustomExercise[]>([]);
+  const [addingExercise, setAddingExercise] = useState(false);
+  const [pendingRemoval, setPendingRemoval] = useState<CustomExercise | null>(null);
 
-  const noPreviewAbs = new Set([
-    'Cross-Leg Crunch',
-    'Jack Knife',
-    'Legs-Up Vertical Crunch',
-    'Side Oblique Crunch',
-    'Side Oblique Leg Raise',
-    'Crunch',
-    'Knee Raise',
-    'Reverse Crunch',
-    'Side Oblique Knee Raise',
-    'Straight Leg Thrust',
-  ]);
 
   const cycleFilter = () => {
     setEquipmentFilter(prev =>
@@ -129,6 +132,8 @@ export function CustomWorkoutBuilderModal({
 
   useEffect(() => {
     if (open) {
+      setCustomExercises(localWorkoutStorage.getCustomExercises());
+      setAddingExercise(false);
       if (template) {
         setName(template.name);
         setSelected(new Set(template.exercises.map(e => e.machine)));
@@ -172,6 +177,56 @@ export function CustomWorkoutBuilderModal({
     });
   };
 
+  /**
+   * What the builder can offer, and what it must not lose.
+   *
+   * Built-in library, plus the user's own exercises, plus anything the
+   * template being edited already references. That last part matters: the
+   * save path looks each selected exercise up here, and previously dropped
+   * whatever it could not find — so editing a template after an exercise was
+   * renamed or deleted silently removed it from the workout.
+   */
+  const availableExercises: ExerciseOption[] = useMemo(() => {
+    const merged = new Map<string, ExerciseOption>();
+    exerciseLibrary.forEach(e => merged.set(e.machine, e));
+    customExercises
+      .filter(e => e.block === 'main')
+      .forEach(e =>
+        merged.set(e.name, {
+          machine: e.name,
+          region: e.region ?? 'Other',
+          equipment: e.equipment ?? 'both',
+        }),
+      );
+    (template?.exercises ?? []).forEach(e => {
+      if (!merged.has(e.machine)) {
+        merged.set(e.machine, { machine: e.machine, region: e.region, equipment: e.equipment });
+      }
+    });
+    return Array.from(merged.values());
+  }, [customExercises, template]);
+
+  const availableAbs: AbsExerciseOption[] = useMemo(() => {
+    const merged = new Map<string, AbsExerciseOption>();
+    absLibrary.forEach(a => merged.set(a.name, a));
+    customExercises
+      .filter(e => e.block === 'warmup')
+      .forEach(e => merged.set(e.name, { name: e.name, reps: e.defaultReps, time: e.defaultTime }));
+    (template?.abs ?? []).forEach(a => {
+      if (!merged.has(a.name)) merged.set(a.name, { name: a.name, reps: a.reps, time: a.time });
+    });
+    return Array.from(merged.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [customExercises, template]);
+
+  const customByName = useMemo(
+    () => new Map(customExercises.map(e => [e.name, e])),
+    [customExercises],
+  );
+
+  /** Only offer a preview when there is actually a photo behind it. */
+  const previewable = (exerciseName: string) =>
+    hasExerciseImage(exerciseName, customByName.get(exerciseName)?.imageSlug);
+
   const trimmedName = name.trim().toLowerCase();
   const clashesWithTemplate = existingNames
     .filter(n => !template || n.toLowerCase() !== template.name.toLowerCase())
@@ -183,7 +238,7 @@ export function CustomWorkoutBuilderModal({
     if (name.trim() === '' || selected.size === 0 || isDuplicate) return;
     const exercises: Exercise[] = [];
     Array.from(selected).forEach(m => {
-      const info = exerciseLibrary.find(e => e.machine === m);
+      const info = availableExercises.find(e => e.machine === m);
       if (!info) {
         console.warn(`Unknown exercise machine: ${m}`);
         return;
@@ -204,7 +259,7 @@ export function CustomWorkoutBuilderModal({
 
     const abs: AbsExercise[] = [];
     Array.from(selectedAbs).forEach(n => {
-      const info = absLibrary.find(a => a.name === n);
+      const info = availableAbs.find(a => a.name === n);
       if (!info) {
         console.warn(`Unknown abs exercise: ${n}`);
         return;
@@ -226,16 +281,16 @@ export function CustomWorkoutBuilderModal({
     onClose();
   };
 
-  const handlePreview = (name: string) => {
-    if (noPreviewAbs.has(name)) return;
-    setPreviewExercise(name);
+  const handlePreview = (exerciseName: string) => {
+    if (!previewable(exerciseName)) return;
+    setPreviewExercise(exerciseName);
     setShowPreview(true);
   };
 
   const warning12 = selected.size >= 12 && selected.size < 15;
   const warning15 = selected.size === 15;
 
-  const filteredExercises = exerciseLibrary.filter(e => {
+  const filteredExercises = availableExercises.filter(e => {
     if (equipmentFilter === 'both') return true;
     if (equipmentFilter === 'machine') return e.equipment !== 'freeweight';
     return e.equipment !== 'machine';
@@ -272,10 +327,24 @@ export function CustomWorkoutBuilderModal({
         <DialogHeader className="space-y-1">
           <DialogTitle>{template ? 'Edit Custom Workout' : 'Create Custom Workout'}</DialogTitle>
           <DialogDescription className="text-left">Select up to 15 exercises and name your workout.</DialogDescription>
-          <p className="text-sm text-muted-foreground text-left">Tap any exercise name to preview it.</p>
+          <p className="text-sm text-muted-foreground text-left">Tap an exercise name to preview it.</p>
         </DialogHeader>
         
-        <div className="flex justify-end -mt-3">
+        <div className="flex items-center justify-between gap-2 -mt-3">
+          {/* Placed first so the filter toggle stays flush right exactly where
+              it was; it keeps its fixed width and this button does the
+              shrinking if space runs short. The label stays put when the form
+              is open — a second button reading "Cancel" beside the form's own
+              would be ambiguous to read and to announce. */}
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="min-w-0 shrink"
+            onClick={() => setAddingExercise(v => !v)}
+          >
+            <span className="truncate">+ New exercise</span>
+          </Button>
           <button
             type="button"
             onClick={cycleFilter}
@@ -285,6 +354,28 @@ export function CustomWorkoutBuilderModal({
             <span className="leading-none">{filterLabel[equipmentFilter].label}</span>
           </button>
         </div>
+
+        {addingExercise && (
+          <NewExerciseForm
+            regions={regionOrder}
+            takenNames={[
+              ...availableExercises.map(e => e.machine),
+              ...availableAbs.map(a => a.name),
+            ]}
+            onCancel={() => setAddingExercise(false)}
+            onCreate={created => {
+              const saved = localWorkoutStorage.addCustomExercise(created);
+              setCustomExercises(localWorkoutStorage.getCustomExercises());
+              setAddingExercise(false);
+              // Tick it straight away — you added it because you want it.
+              if (saved.block === 'main') {
+                setSelected(prev => (prev.size < 15 ? new Set(prev).add(saved.name) : prev));
+              } else {
+                setSelectedAbs(prev => new Set(prev).add(saved.name));
+              }
+            }}
+          />
+        )}
         
         <div className="space-y-4 -mt-2">
           {orderedGroups.map(([region, exercises]) => (
@@ -305,15 +396,33 @@ export function CustomWorkoutBuilderModal({
                             checked={selected.has(ex.machine)}
                             onCheckedChange={() => toggle(ex.machine)}
                           />
-                          <button
-                            type="button"
-                            onClick={() => handlePreview(ex.machine)}
-                            className="truncate text-sm text-left hover:text-primary"
-                            title={ex.machine}
-                          >
-                            {ex.machine}
-                          </button>
+                          {previewable(ex.machine) ? (
+                            <button
+                              type="button"
+                              onClick={() => handlePreview(ex.machine)}
+                              className="truncate text-sm text-left hover:text-primary"
+                              title={ex.machine}
+                            >
+                              {ex.machine}
+                            </button>
+                          ) : (
+                            <span className="truncate text-sm text-left" title={ex.machine}>
+                              {ex.machine}
+                            </span>
+                          )}
                         </div>
+                        {customByName.has(ex.machine) && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            aria-label={`Remove ${ex.machine}`}
+                            className="ml-auto h-6 px-2 text-xs text-muted-foreground"
+                            onClick={() => setPendingRemoval(customByName.get(ex.machine)!)}
+                          >
+                            Remove
+                          </Button>
+                        )}
                       </div>
                     </div>
                   );
@@ -325,7 +434,7 @@ export function CustomWorkoutBuilderModal({
         <div className="border rounded p-2">
           <div className="font-medium mb-2">Add Core Exercises (Optional)</div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
-            {absLibrary.map(abs => {
+            {availableAbs.map(abs => {
               const isLong = abs.name.length > 30;
               return (
                 <div key={abs.name} className={cn(isLong && 'sm:col-span-2')}>
@@ -336,15 +445,33 @@ export function CustomWorkoutBuilderModal({
                         checked={selectedAbs.has(abs.name)}
                         onCheckedChange={() => toggleAbs(abs.name)}
                       />
-                      <button
-                        type="button"
-                        onClick={() => handlePreview(abs.name)}
-                        className="truncate text-sm text-left hover:text-primary"
-                        title={abs.name}
-                      >
-                        {abs.name}
-                      </button>
+                      {previewable(abs.name) ? (
+                        <button
+                          type="button"
+                          onClick={() => handlePreview(abs.name)}
+                          className="truncate text-sm text-left hover:text-primary"
+                          title={abs.name}
+                        >
+                          {abs.name}
+                        </button>
+                      ) : (
+                        <span className="truncate text-sm text-left" title={abs.name}>
+                          {abs.name}
+                        </span>
+                      )}
                     </div>
+                    {customByName.has(abs.name) && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        aria-label={`Remove ${abs.name}`}
+                        className="ml-auto h-6 px-2 text-xs text-muted-foreground"
+                        onClick={() => setPendingRemoval(customByName.get(abs.name)!)}
+                      >
+                        Remove
+                      </Button>
+                    )}
                   </div>
                 </div>
               );
@@ -385,9 +512,38 @@ export function CustomWorkoutBuilderModal({
     </Dialog>
     <ExerciseImageDialog
       exerciseName={previewExercise || ''}
+      imageSlug={previewExercise ? customByName.get(previewExercise)?.imageSlug : undefined}
       open={showPreview}
       onOpenChange={setShowPreview}
     />
+    <AlertDialog
+      open={pendingRemoval !== null}
+      onOpenChange={isOpen => !isOpen && setPendingRemoval(null)}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove “{pendingRemoval?.name}”?</AlertDialogTitle>
+          <AlertDialogDescription>
+            It stops appearing in this list. Workouts and templates that already
+            include it are unaffected — they keep their own copy.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-red-600 text-white hover:bg-red-700"
+            onClick={() => {
+              if (!pendingRemoval) return;
+              localWorkoutStorage.deleteCustomExercise(pendingRemoval.id);
+              setCustomExercises(localWorkoutStorage.getCustomExercises());
+              setPendingRemoval(null);
+            }}
+          >
+            Remove
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
     </>
   );
 }

--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -123,6 +123,7 @@ export function CustomWorkoutBuilderModal({
     'Biceps',
     'Triceps',
     'Forearms',
+    'Core',
     'Legs',
     'Thighs',
     'Hamstrings',
@@ -367,6 +368,9 @@ export function CustomWorkoutBuilderModal({
               const saved = localWorkoutStorage.addCustomExercise(created);
               setCustomExercises(localWorkoutStorage.getCustomExercises());
               setAddingExercise(false);
+              // Otherwise adding a machine while the filter reads "Weights"
+              // files it away out of sight and it looks like it failed to save.
+              setEquipmentFilter('both');
               // Tick it straight away — you added it because you want it.
               if (saved.block === 'main') {
                 setSelected(prev => (prev.size < 15 ? new Set(prev).add(saved.name) : prev));
@@ -432,7 +436,7 @@ export function CustomWorkoutBuilderModal({
           ))}
         </div>
         <div className="border rounded p-2">
-          <div className="font-medium mb-2">Add Core Exercises (Optional)</div>
+          <div className="font-medium mb-2">Add Warm-up Exercises (Optional)</div>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-4 gap-y-3">
             {availableAbs.map(abs => {
               const isLong = abs.name.length > 30;

--- a/client/src/components/ExerciseImageDialog.tsx
+++ b/client/src/components/ExerciseImageDialog.tsx
@@ -5,31 +5,32 @@ import {
   DialogHeader,
   DialogTitle
 } from '@/components/ui/dialog';
+import { exerciseImageSrc } from '@/lib/exercise-images';
 
 interface ExerciseImageDialogProps {
   exerciseName: string;
+  /** Set for a user-added exercise that borrowed one of the bundled photos. */
+  imageSlug?: string | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
 export function ExerciseImageDialog({
   exerciseName,
+  imageSlug,
   open,
   onOpenChange
 }: ExerciseImageDialogProps) {
-  const [error, setError] = useState(false);
-  useEffect(() => {
-    setError(false);
-  }, [exerciseName]);
-  const slug = exerciseName
-    .toLowerCase()
-    .replace(/\(.*?\)/g, '')
-    .trim()
-    .replace(/\s+/g, '-')
-    .replace(/[^a-z0-9\-]/g, '');
-  const src = `/exercise-images/${slug}.jpg`;
+  const [failedToLoad, setFailedToLoad] = useState(false);
 
-  const handleError = () => setError(true);
+  useEffect(() => {
+    setFailedToLoad(false);
+  }, [exerciseName, imageSlug]);
+
+  // Callers only offer the preview when a photo exists, so this is a
+  // belt-and-braces fallback rather than the common case it used to be.
+  const src = exerciseImageSrc(exerciseName, imageSlug);
+  const showPlaceholder = failedToLoad || src === null;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -37,18 +38,18 @@ export function ExerciseImageDialog({
         <DialogHeader className="p-4 pb-0">
           <DialogTitle>{exerciseName}</DialogTitle>
         </DialogHeader>
-        {!error ? (
+        {showPlaceholder ? (
           <img
-            src={src}
-            alt={exerciseName}
-            onError={handleError}
-            className="w-full h-auto object-contain"
+            src="/exercise-images/placeholder.svg"
+            alt=""
+            className="w-full h-auto object-contain p-6"
           />
         ) : (
           <img
-            src="/exercise-images/placeholder.svg"
-            alt="Placeholder"
-            className="w-full h-auto object-contain p-6"
+            src={src as string}
+            alt={`Reference photo for ${exerciseName}`}
+            onError={() => setFailedToLoad(true)}
+            className="w-full h-auto object-contain"
           />
         )}
       </DialogContent>

--- a/client/src/components/NewExerciseForm.tsx
+++ b/client/src/components/NewExerciseForm.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { cn } from '@/lib/utils';
+import { EXERCISE_IMAGE_SLUGS } from '@/lib/exercise-images';
+import type { CustomExercise } from '@/lib/storage';
+
+type Block = 'main' | 'warmup';
+type Equipment = 'machine' | 'freeweight' | 'both';
+
+interface NewExerciseFormProps {
+  regions: string[];
+  /** Names already in use — built-ins and previously added exercises alike. */
+  takenNames: string[];
+  onCancel: () => void;
+  onCreate: (exercise: Omit<CustomExercise, 'id' | 'createdAt'>) => void;
+}
+
+const EQUIPMENT_CHOICES: { value: Equipment; label: string }[] = [
+  { value: 'freeweight', label: 'Weights' },
+  { value: 'machine', label: 'Machine' },
+  { value: 'both', label: 'Both' },
+];
+
+function slugLabel(slug: string): string {
+  return slug.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+}
+
+export function NewExerciseForm({
+  regions,
+  takenNames,
+  onCancel,
+  onCreate,
+}: NewExerciseFormProps) {
+  const [name, setName] = useState('');
+  const [block, setBlock] = useState<Block>('main');
+  const [equipment, setEquipment] = useState<Equipment>('freeweight');
+  const [region, setRegion] = useState(regions[0] ?? 'Other');
+  const [imageSlug, setImageSlug] = useState<string | null>(null);
+  const [browsingImages, setBrowsingImages] = useState(false);
+
+  const trimmed = name.trim();
+  const isDuplicate = takenNames.some(n => n.toLowerCase() === trimmed.toLowerCase());
+  const canSave = trimmed !== '' && !isDuplicate;
+
+  const submit = () => {
+    if (!canSave) return;
+    onCreate(
+      block === 'main'
+        ? { name: trimmed, block, equipment, region, imageSlug }
+        : { name: trimmed, block, imageSlug },
+    );
+  };
+
+  return (
+    <div className="border rounded p-3 space-y-3 bg-muted/30">
+      <div className="font-medium">New exercise</div>
+
+      <Input
+        aria-label="Exercise name"
+        placeholder="Exercise name"
+        value={name}
+        onChange={e => setName(e.target.value)}
+      />
+      {isDuplicate && (
+        <p className="text-red-600 text-sm">“{trimmed}” already exists. Choose another name.</p>
+      )}
+
+      <fieldset className="space-y-1">
+        <legend className="text-sm text-muted-foreground">Where does it go?</legend>
+        <div className="grid grid-cols-2 gap-2">
+          {(
+            [
+              ['main', 'Main workout', 'Sets, weight and reps'],
+              ['warmup', 'Warm-up', 'Reps or time, no weight'],
+            ] as const
+          ).map(([value, label, hint]) => (
+            <button
+              key={value}
+              type="button"
+              aria-pressed={block === value}
+              onClick={() => setBlock(value)}
+              className={cn(
+                'rounded-md border p-2 text-left text-sm transition-colors',
+                block === value ? 'border-primary bg-accent' : 'hover:bg-muted/50',
+              )}
+            >
+              <div className="font-medium">{label}</div>
+              <div className="text-xs text-muted-foreground">{hint}</div>
+            </button>
+          ))}
+        </div>
+      </fieldset>
+
+      {block === 'main' && (
+        <>
+          <fieldset className="space-y-1">
+            <legend className="text-sm text-muted-foreground">Equipment</legend>
+            <div className="grid grid-cols-3 gap-2">
+              {EQUIPMENT_CHOICES.map(choice => (
+                <button
+                  key={choice.value}
+                  type="button"
+                  aria-pressed={equipment === choice.value}
+                  onClick={() => setEquipment(choice.value)}
+                  className={cn(
+                    'rounded-md border p-2 text-sm transition-colors',
+                    equipment === choice.value ? 'border-primary bg-accent' : 'hover:bg-muted/50',
+                  )}
+                >
+                  {choice.label}
+                </button>
+              ))}
+            </div>
+          </fieldset>
+
+          <label className="block space-y-1">
+            <span className="text-sm text-muted-foreground">Muscle group</span>
+            <select
+              aria-label="Muscle group"
+              value={region}
+              onChange={e => setRegion(e.target.value)}
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-base"
+            >
+              {regions.map(r => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+              <option value="Other">Other</option>
+            </select>
+          </label>
+        </>
+      )}
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-muted-foreground">
+            Photo: {imageSlug ? slugLabel(imageSlug) : 'none'}
+          </span>
+          <div className="flex gap-2">
+            {imageSlug && (
+              <Button type="button" variant="ghost" size="sm" onClick={() => setImageSlug(null)}>
+                Remove
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setBrowsingImages(v => !v)}
+            >
+              {browsingImages ? 'Done' : 'Choose a photo'}
+            </Button>
+          </div>
+        </div>
+
+        {/* Only fetched once the user asks — otherwise adding an exercise would
+            pull down every bundled photo for no reason. */}
+        {browsingImages && (
+          <div className="grid grid-cols-3 gap-2 max-h-56 overflow-y-auto p-1">
+            {EXERCISE_IMAGE_SLUGS.map(slug => (
+              <button
+                key={slug}
+                type="button"
+                aria-label={slugLabel(slug)}
+                aria-pressed={imageSlug === slug}
+                onClick={() => {
+                  setImageSlug(slug);
+                  setBrowsingImages(false);
+                }}
+                className={cn(
+                  'rounded border overflow-hidden',
+                  imageSlug === slug ? 'ring-2 ring-primary' : 'hover:opacity-80',
+                )}
+              >
+                <img
+                  src={`/exercise-images/${slug}.jpg`}
+                  alt={slugLabel(slug)}
+                  loading="lazy"
+                  className="w-full h-16 object-cover"
+                />
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="flex gap-2">
+        <Button type="button" onClick={submit} disabled={!canSave}>
+          Add exercise
+        </Button>
+        <Button type="button" variant="secondary" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/NewExerciseForm.tsx
+++ b/client/src/components/NewExerciseForm.tsx
@@ -127,7 +127,6 @@ export function NewExerciseForm({
                   {r}
                 </option>
               ))}
-              <option value="Other">Other</option>
             </select>
           </label>
         </>

--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -7,6 +7,8 @@ import { Check, Clock, HelpCircle } from 'lucide-react';
 import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { useToast } from '@/hooks/use-toast';
 import { useCursorEndOnFocus } from '@/hooks/use-cursor-end-on-focus';
+import { hasExerciseImage } from '@/lib/exercise-images';
+import { localWorkoutStorage } from '@/lib/storage';
 
 interface ExerciseFormProps {
   exercise: Exercise;
@@ -22,6 +24,12 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
   const [showHelp, setShowHelp] = useState(false);
   const { toast } = useToast();
   const focusToEnd = useCursorEndOnFocus();
+
+  // No point offering help that resolves to a placeholder.
+  const hasReferencePhoto = hasExerciseImage(
+    localExercise.machine,
+    localWorkoutStorage.getCustomExercises().find(e => e.name === localExercise.machine)?.imageSlug,
+  );
 
   const isSetComplete = (set: ExerciseSet) =>
     set.weight !== undefined && set.reps !== undefined;
@@ -124,14 +132,16 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
             </p>
           </div>
           <div className="flex items-center space-x-2">
-            <button
-              type="button"
-              onClick={() => setShowHelp(true)}
-              className="text-gray-500 hover:text-primary"
-            >
-              <HelpCircle className="h-5 w-5" />
-              <span className="sr-only">Help</span>
-            </button>
+            {hasReferencePhoto && (
+              <button
+                type="button"
+                onClick={() => setShowHelp(true)}
+                className="text-gray-500 hover:text-primary"
+              >
+                <HelpCircle className="h-5 w-5" />
+                <span className="sr-only">{`Show reference photo for ${localExercise.machine}`}</span>
+              </button>
+            )}
             {localExercise.completed && <Check className="h-5 w-5 text-green-500" />}
             {isActive && !localExercise.completed && <Clock className="h-5 w-5 text-blue-500" />}
           </div>

--- a/client/src/lib/custom-exercises.test.ts
+++ b/client/src/lib/custom-exercises.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LocalWorkoutStorage } from './storage';
+
+/**
+ * Exercises the user adds themselves. `block` decides how they are logged:
+ * main entries are sets x weight x reps, warm-up entries join the core block,
+ * which takes reps or a duration and has no weight.
+ */
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+const deadlift = {
+  name: 'Deadlift',
+  block: 'main' as const,
+  equipment: 'freeweight' as const,
+  region: 'Back',
+};
+
+const bearCrawl = {
+  name: 'Bear Crawl',
+  block: 'warmup' as const,
+  defaultReps: 2,
+};
+
+describe('adding an exercise', () => {
+  it('stores it and gives it an id', () => {
+    const storage = new LocalWorkoutStorage();
+    const created = storage.addCustomExercise(deadlift);
+
+    expect(created.id).toBeGreaterThan(0);
+    expect(created.createdAt).toBeTruthy();
+    expect(storage.getCustomExercises()).toHaveLength(1);
+  });
+
+  it('keeps ids distinct as more are added', () => {
+    const storage = new LocalWorkoutStorage();
+    const a = storage.addCustomExercise(deadlift);
+    const b = storage.addCustomExercise(bearCrawl);
+
+    expect(a.id).not.toBe(b.id);
+  });
+
+  it('survives a reload', () => {
+    new LocalWorkoutStorage().addCustomExercise(deadlift);
+    expect(new LocalWorkoutStorage().getCustomExercises()[0].name).toBe('Deadlift');
+  });
+
+  it('defaults to no image', () => {
+    const storage = new LocalWorkoutStorage();
+    expect(storage.addCustomExercise(deadlift).imageSlug).toBeUndefined();
+  });
+
+  it('keeps an image when one was chosen', () => {
+    const storage = new LocalWorkoutStorage();
+    const created = storage.addCustomExercise({ ...deadlift, imageSlug: 'body-squat' });
+    expect(storage.getCustomExercises()[0].imageSlug).toBe('body-squat');
+    expect(created.imageSlug).toBe('body-squat');
+  });
+});
+
+describe('warm-up entries', () => {
+  it('need no equipment or weight', () => {
+    const storage = new LocalWorkoutStorage();
+    storage.addCustomExercise(bearCrawl);
+
+    const [stored] = storage.getCustomExercises();
+    expect(stored.block).toBe('warmup');
+    expect(stored.equipment).toBeUndefined();
+    expect(stored.defaultWeight).toBeUndefined();
+  });
+
+  it('can be measured by time instead of reps', () => {
+    const storage = new LocalWorkoutStorage();
+    storage.addCustomExercise({ name: 'Plank', block: 'warmup', defaultTime: '1:00' });
+
+    expect(storage.getCustomExercises()[0].defaultTime).toBe('1:00');
+  });
+});
+
+describe('editing and removing', () => {
+  it('updates in place', () => {
+    const storage = new LocalWorkoutStorage();
+    const created = storage.addCustomExercise(deadlift);
+
+    storage.updateCustomExercise(created.id, { ...deadlift, name: 'Romanian Deadlift' });
+
+    expect(storage.getCustomExercises()[0].name).toBe('Romanian Deadlift');
+    expect(storage.getCustomExercises()).toHaveLength(1);
+  });
+
+  it('reports an unknown id rather than inventing one', () => {
+    const storage = new LocalWorkoutStorage();
+    expect(storage.updateCustomExercise(999, deadlift)).toBeUndefined();
+    expect(storage.deleteCustomExercise(999)).toBe(false);
+  });
+
+  it('removes only the one asked for', () => {
+    const storage = new LocalWorkoutStorage();
+    const a = storage.addCustomExercise(deadlift);
+    storage.addCustomExercise(bearCrawl);
+
+    expect(storage.deleteCustomExercise(a.id)).toBe(true);
+    expect(storage.getCustomExercises().map(e => e.name)).toEqual(['Bear Crawl']);
+  });
+});
+
+describe('bad data', () => {
+  it('skips unreadable entries instead of losing the list', () => {
+    localStorage.setItem(
+      'ironpath_custom_exercises',
+      JSON.stringify([{ id: 1, name: 'Fine', block: 'main' }, { nonsense: true }]),
+    );
+
+    expect(new LocalWorkoutStorage().getCustomExercises().map(e => e.name)).toEqual(['Fine']);
+  });
+
+  it('tolerates the key holding something that is not a list', () => {
+    localStorage.setItem('ironpath_custom_exercises', '"nope"');
+    expect(new LocalWorkoutStorage().getCustomExercises()).toEqual([]);
+  });
+});
+
+describe('backup', () => {
+  it('carries custom exercises across', async () => {
+    const storage = new LocalWorkoutStorage();
+    storage.addCustomExercise(deadlift);
+    storage.addCustomExercise(bearCrawl);
+
+    const backup = await storage.exportData();
+    expect(backup.customExercises).toHaveLength(2);
+
+    localStorage.clear();
+    await storage.importData(backup);
+
+    expect(storage.getCustomExercises().map(e => e.name)).toEqual(['Deadlift', 'Bear Crawl']);
+  });
+
+  it('is cleared by a full reset', async () => {
+    const storage = new LocalWorkoutStorage();
+    storage.addCustomExercise(deadlift);
+
+    await storage.clearAllData();
+
+    expect(storage.getCustomExercises()).toEqual([]);
+  });
+});

--- a/client/src/lib/exercise-images.test.ts
+++ b/client/src/lib/exercise-images.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EXERCISE_IMAGE_SLUGS,
+  exerciseImageSrc,
+  hasExerciseImage,
+  slugForExercise,
+} from './exercise-images';
+import { exerciseLibrary } from './exercise-library';
+// @ts-expect-error - vite raw import
+import SW_SRC from '../../public/sw.js?raw';
+
+const IMAGE_FILES = import.meta.glob('../../public/exercise-images/*', { eager: false });
+
+function filesOnDisk(): string[] {
+  return Object.keys(IMAGE_FILES)
+    .map(path => (path.split('/').pop() as string).replace(/\.[a-z]+$/, ''))
+    .filter(slug => slug !== 'placeholder')
+    .sort();
+}
+
+describe('the slug list matches what is actually shipped', () => {
+  it('lists every photo in public/exercise-images', () => {
+    expect([...EXERCISE_IMAGE_SLUGS].sort()).toEqual(filesOnDisk());
+  });
+
+  it('is the same set the service worker precaches', () => {
+    const precached = Array.from(
+      (SW_SRC as string).matchAll(/'\/exercise-images\/([^']+)'/g),
+      (m: RegExpMatchArray) => m[1].replace(/\.[a-z]+$/, ''),
+    )
+      .filter(slug => slug !== 'placeholder')
+      .sort();
+
+    // An exercise with a photo that is not precached would be missing exactly
+    // when it is most wanted: offline, in front of an unfamiliar machine.
+    expect(precached).toEqual([...EXERCISE_IMAGE_SLUGS].sort());
+  });
+});
+
+describe('slugForExercise', () => {
+  it('matches the naming the files already use', () => {
+    expect(slugForExercise('Seated Chest Press')).toBe('seated-chest-press');
+    expect(slugForExercise('45 Degree Leg Press')).toBe('45-degree-leg-press');
+  });
+
+  it('drops parenthesised qualifiers, as the files do', () => {
+    expect(slugForExercise('Standing Calf Raise (1-DB)')).toBe('standing-calf-raise');
+  });
+
+  it('survives punctuation and stray spacing', () => {
+    expect(slugForExercise('  Bear   Crawl!  ')).toBe('bear-crawl');
+  });
+});
+
+describe('image availability', () => {
+  it('resolves a photo that exists', () => {
+    expect(exerciseImageSrc('Seated Row')).toBe('/exercise-images/seated-row.jpg');
+    expect(hasExerciseImage('Seated Row')).toBe(true);
+  });
+
+  it('reports nothing for an exercise with no photo', () => {
+    expect(exerciseImageSrc('Bear Crawl')).toBeNull();
+    expect(hasExerciseImage('Bear Crawl')).toBe(false);
+  });
+
+  it('honours an explicitly chosen photo', () => {
+    expect(exerciseImageSrc('Bear Crawl', 'push-up')).toBe('/exercise-images/push-up.jpg');
+    expect(hasExerciseImage('Bear Crawl', 'push-up')).toBe(true);
+  });
+
+  it('reports nothing when the chosen photo does not exist', () => {
+    expect(hasExerciseImage('Bear Crawl', 'not-a-real-photo')).toBe(false);
+  });
+
+  it('covers most of the built-in library', () => {
+    const withPhotos = exerciseLibrary.filter(e => hasExerciseImage(e.machine));
+    expect(withPhotos.length).toBeGreaterThan(exerciseLibrary.length * 0.8);
+  });
+});

--- a/client/src/lib/exercise-images.ts
+++ b/client/src/lib/exercise-images.ts
@@ -1,0 +1,79 @@
+/**
+ * Which exercises actually have a reference photo.
+ *
+ * Previously every exercise name was tappable and the dialog fell back to a
+ * placeholder for the ones with no photo, with a hand-maintained list of ten
+ * core exercises excluded by name. Knowing up front what exists lets the
+ * affordance simply not appear, and replaces that list with something derived.
+ *
+ * Kept in step with `client/public/exercise-images/` by a test, which also
+ * checks the service worker precaches exactly this set.
+ */
+export const EXERCISE_IMAGE_SLUGS: readonly string[] = [
+  '1-arm-curl-with-twist',
+  '45-degree-leg-press',
+  'abductor',
+  'adductor',
+  'adjustable-cable-crossover',
+  'bar-curl',
+  'bent-over-rear-deltoid',
+  'body-squat',
+  'cable-front-deltoid-raise',
+  'close-grip-pulldown',
+  'glute-machine',
+  'high-pulley-kick-back',
+  'kick-back',
+  'lateral-raise',
+  'lateral-raise-machine',
+  'low-pulley-1-arm-curl',
+  'low-pulley-straight-bar-curl',
+  'pec-fly',
+  'preacher-curl',
+  'push-up',
+  'seated-back-extension',
+  'seated-chest-press',
+  'seated-dip',
+  'seated-lateral-raise',
+  'seated-leg-curl',
+  'seated-leg-extension',
+  'seated-leg-press',
+  'seated-row',
+  'seated-shoulder-press',
+  'seated-shrug',
+  'standing-1-leg-calf-raise',
+  'standing-barbell-shrug',
+  'standing-calf-raise',
+  'standing-shrug',
+  'standing-wrist-curl-with-extension',
+  'straight-bar-pushdown',
+  'v-bar-pushdown',
+  'wide-grip-pulldown',
+];
+
+const SLUG_SET = new Set(EXERCISE_IMAGE_SLUGS);
+
+/**
+ * Filename an exercise's photo would use.
+ *
+ * Unchanged from what the image dialog already did: lowercase, drop anything
+ * parenthesised, hyphenate, strip the rest.
+ */
+export function slugForExercise(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/\(.*?\)/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9\-]/g, '');
+}
+
+/** Path to a photo, or null when there is no photo for this exercise. */
+export function exerciseImageSrc(name: string, explicitSlug?: string | null): string | null {
+  const slug = explicitSlug ?? slugForExercise(name);
+  return SLUG_SET.has(slug) ? `/exercise-images/${slug}.jpg` : null;
+}
+
+/** Whether there is anything worth showing if the user taps this exercise. */
+export function hasExerciseImage(name: string, explicitSlug?: string | null): boolean {
+  return exerciseImageSrc(name, explicitSlug) !== null;
+}

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -25,8 +25,33 @@ const STORAGE_KEYS = {
   HIDDEN_PRESETS: 'ironpath_hidden_presets',
   PRESET_PROMPTS: 'ironpath_preset_prompts',
   STREAK_DAYS: 'ironpath_streak_days',
-  QUARANTINE: 'ironpath_quarantined_workouts'
+  QUARANTINE: 'ironpath_quarantined_workouts',
+  CUSTOM_EXERCISES: 'ironpath_custom_exercises'
 } as const;
+
+/**
+ * An exercise the user added themselves.
+ *
+ * `block` decides which half of a workout it belongs to, and therefore how it
+ * is logged. A main exercise is sets x weight x reps like everything in the
+ * built-in library. A warm-up entry joins the core block, which records reps
+ * *or* a duration and has no weight at all — the right home for a bear crawl
+ * or a carry, which the weighted model only fits by pretending the load is 0.
+ */
+export interface CustomExercise {
+  id: number;
+  name: string;
+  block: 'main' | 'warmup';
+  equipment?: 'machine' | 'freeweight' | 'both';
+  region?: string;
+  defaultWeight?: number;
+  defaultReps?: number;
+  defaultRest?: string;
+  defaultTime?: string;
+  /** Chosen from the bundled photos; absent means no image, which is the default. */
+  imageSlug?: string | null;
+  createdAt?: string;
+}
 
 /** A stored record that could not be parsed, kept so it is not simply lost. */
 export interface QuarantinedWorkout {
@@ -77,6 +102,20 @@ const customTemplateSchema = z.object({
   includeInAutoSchedule: z.boolean().optional(),
 });
 
+const customExerciseSchema = z.object({
+  id: z.number().int().positive(),
+  name: z.string().min(1),
+  block: z.enum(['main', 'warmup']),
+  equipment: z.enum(['machine', 'freeweight', 'both']).optional(),
+  region: z.string().optional(),
+  defaultWeight: z.number().optional(),
+  defaultReps: z.number().optional(),
+  defaultRest: z.string().optional(),
+  defaultTime: z.string().optional(),
+  imageSlug: z.string().nullable().optional(),
+  createdAt: z.string().optional(),
+});
+
 const exerciseHistorySchema = z.record(
   z.string(),
   z.object({
@@ -109,6 +148,7 @@ const backupSchema = z.object({
   hiddenPresets: z.record(z.string(), z.boolean()).optional(),
   presetPrompts: z.record(z.string(), z.boolean()).optional(),
   streakDays: z.array(z.number().int().min(0).max(6)).optional(),
+  customExercises: z.array(customExerciseSchema).optional(),
   quarantined: z
     .array(
       z.object({
@@ -134,6 +174,7 @@ export interface IronPathBackup {
   presetPrompts: Record<string, boolean>;
   streakDays: number[];
   quarantined: QuarantinedWorkout[];
+  customExercises: CustomExercise[];
 }
 
 export class LocalWorkoutStorage {
@@ -707,6 +748,58 @@ export class LocalWorkoutStorage {
     return updated;
   }
 
+  getCustomExercises(): CustomExercise[] {
+    try {
+      const stored = this.safeGetItem(STORAGE_KEYS.CUSTOM_EXERCISES);
+      const parsed = stored ? JSON.parse(stored) : [];
+      if (!Array.isArray(parsed)) return [];
+      // Skip anything unreadable rather than losing the whole list to one bad
+      // entry; these are cheap to recreate, unlike logged workouts.
+      return parsed.flatMap(candidate => {
+        const validated = customExerciseSchema.safeParse(candidate);
+        return validated.success ? [validated.data as CustomExercise] : [];
+      });
+    } catch {
+      return [];
+    }
+  }
+
+  private saveCustomExercises(exercises: CustomExercise[]): void {
+    this.safeSetItem(STORAGE_KEYS.CUSTOM_EXERCISES, JSON.stringify(exercises));
+  }
+
+  addCustomExercise(exercise: Omit<CustomExercise, 'id' | 'createdAt'>): CustomExercise {
+    const existing = this.getCustomExercises();
+    const created: CustomExercise = {
+      ...exercise,
+      id: existing.length > 0 ? Math.max(...existing.map(e => e.id)) + 1 : 1,
+      createdAt: new Date().toISOString(),
+    };
+    this.saveCustomExercises([...existing, created]);
+    return created;
+  }
+
+  updateCustomExercise(
+    id: number,
+    updates: Omit<CustomExercise, 'id' | 'createdAt'>,
+  ): CustomExercise | undefined {
+    const existing = this.getCustomExercises();
+    const index = existing.findIndex(e => e.id === id);
+    if (index === -1) return undefined;
+    const updated = { ...existing[index], ...updates };
+    existing[index] = updated;
+    this.saveCustomExercises(existing);
+    return updated;
+  }
+
+  deleteCustomExercise(id: number): boolean {
+    const existing = this.getCustomExercises();
+    const remaining = existing.filter(e => e.id !== id);
+    if (remaining.length === existing.length) return false;
+    this.saveCustomExercises(remaining);
+    return true;
+  }
+
   async getUserPreferences(): Promise<UserPreferences> {
     const stored = this.safeGetItem(STORAGE_KEYS.PREFERENCES);
     const defaultPrefs: UserPreferences = {
@@ -762,7 +855,8 @@ export class LocalWorkoutStorage {
       hiddenPresets: this.getHiddenPresets(),
       presetPrompts: this.getPresetPromptPrefs(),
       streakDays: this.getStreakDays(),
-      quarantined: this.getQuarantinedWorkouts()
+      quarantined: this.getQuarantinedWorkouts(),
+      customExercises: this.getCustomExercises()
     };
   }
 
@@ -825,6 +919,9 @@ export class LocalWorkoutStorage {
     }
     // Carried across so a record set aside on the old device is still
     // recoverable on the new one rather than quietly disappearing in transit.
+    if (backup.customExercises) {
+      this.saveCustomExercises(backup.customExercises as CustomExercise[]);
+    }
     if (backup.quarantined) {
       this.safeSetItem(STORAGE_KEYS.QUARANTINE, JSON.stringify(backup.quarantined));
     }

--- a/e2e/custom-exercises.spec.ts
+++ b/e2e/custom-exercises.spec.ts
@@ -146,3 +146,61 @@ test('removing one does not strip it from a template that already uses it', asyn
   );
   expect(stored[0].exercises.map((e: { machine: string }) => e.machine)).toContain('Deadlift');
 });
+
+test('a weighted core machine keeps its weight and lands under Core', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+
+  // The muscle-group list had no core entry, so this had nowhere to go but a
+  // catch-all — and filing it with the warm-up exercises would have dropped
+  // the weight, which is the whole point of a machine.
+  await panel.getByRole('button', { name: '+ New exercise' }).click();
+  await panel.getByLabel('Exercise name').fill('Ab Machine');
+  await panel.getByRole('button', { name: 'Main workout' }).click();
+  await panel.getByRole('button', { name: 'Machine', exact: true }).click();
+  await panel.getByLabel('Muscle group').selectOption('Core');
+  await panel.getByRole('button', { name: 'Add exercise' }).click();
+
+  await expect(panel.getByText('Core', { exact: true })).toBeVisible();
+
+  await panel.getByLabel('Workout name').fill('Core Day');
+  await panel.getByRole('button', { name: 'Save Workout' }).click();
+  await expect(panel).toBeHidden();
+
+  const stored = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('ironpath_custom_templates') ?? '[]'),
+  );
+  const exercise = stored[0].exercises.find((e: { machine: string }) => e.machine === 'Ab Machine');
+  expect(exercise.region).toBe('Core');
+  expect(exercise.equipment).toBe('machine');
+  // Recorded as a weighted exercise: three sets in the main list, rather than
+  // a warm-up entry with no sets and nowhere to put a load.
+  expect(exercise.sets).toHaveLength(3);
+  expect(stored[0].abs.map((a: { name: string }) => a.name)).not.toContain('Ab Machine');
+});
+
+test('there is no catch-all muscle group left to fall into', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+  await panel.getByRole('button', { name: '+ New exercise' }).click();
+
+  const options = await panel.getByLabel('Muscle group').locator('option').allTextContents();
+  expect(options).toContain('Core');
+  expect(options).not.toContain('Other');
+});
+
+test('a new exercise is visible whatever the filter was set to', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+
+  // Park the filter on Weights, then add a machine.
+  const filter = panel.locator('button:has(> span.text-2xl)');
+  await filter.click();
+  await panel.getByRole('button', { name: '+ New exercise' }).click();
+  await panel.getByLabel('Exercise name').fill('Ab Machine');
+  await panel.getByRole('button', { name: 'Machine', exact: true }).click();
+  await panel.getByRole('button', { name: 'Add exercise' }).click();
+
+  // Filtered out, it would look like it never saved.
+  await expect(panel.getByRole('checkbox', { name: 'Ab Machine' })).toBeVisible();
+});

--- a/e2e/custom-exercises.spec.ts
+++ b/e2e/custom-exercises.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Adding your own exercises. The built-in library is a gym-circuit list —
+ * 43 machine entries against 16 free-weight — so the gaps are things like
+ * deadlifts and bear crawls.
+ */
+
+function builder(page: Page) {
+  return page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' });
+}
+
+async function openBuilder(page: Page) {
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  await expect(builder(page)).toBeVisible();
+  return builder(page);
+}
+
+async function addExercise(
+  page: Page,
+  name: string,
+  block: 'Main workout' | 'Warm-up' = 'Main workout',
+) {
+  const panel = builder(page);
+  await panel.getByRole('button', { name: '+ New exercise' }).click();
+  await panel.getByLabel('Exercise name').fill(name);
+  await panel.getByRole('button', { name: block }).click();
+  await panel.getByRole('button', { name: 'Add exercise' }).click();
+}
+
+test('a main exercise can be added and used', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+
+  await addExercise(page, 'Deadlift');
+
+  // Added exercises are ticked straight away — you added it to use it.
+  await expect(panel.getByRole('checkbox', { name: 'Deadlift' })).toBeChecked();
+
+  await panel.getByLabel('Workout name').fill('Pull Day');
+  await panel.getByRole('button', { name: 'Save Workout' }).click();
+  await expect(panel).toBeHidden();
+
+  const stored = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('ironpath_custom_templates') ?? '[]'),
+  );
+  expect(stored[0].exercises.map((e: { machine: string }) => e.machine)).toContain('Deadlift');
+});
+
+test('a warm-up exercise joins the core block instead', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+
+  await addExercise(page, 'Bear Crawl', 'Warm-up');
+
+  await expect(panel.getByRole('checkbox', { name: 'Bear Crawl' })).toBeChecked();
+
+  await panel.getByRole('checkbox').first().click();
+  await panel.getByLabel('Workout name').fill('Crawl Day');
+  await panel.getByRole('button', { name: 'Save Workout' }).click();
+  await expect(panel).toBeHidden();
+
+  const stored = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('ironpath_custom_templates') ?? '[]'),
+  );
+  // Recorded as a core entry, which carries no weight at all.
+  expect(stored[0].abs.map((a: { name: string }) => a.name)).toContain('Bear Crawl');
+  expect(JSON.stringify(stored[0].abs)).not.toContain('weight');
+});
+
+test('it survives a reload', async ({ page }) => {
+  await page.goto('/');
+  await openBuilder(page);
+  await addExercise(page, 'Deadlift');
+
+  await page.reload();
+  const panel = await openBuilder(page);
+
+  await expect(panel.getByRole('checkbox', { name: 'Deadlift' })).toBeVisible();
+});
+
+test('a duplicate name is refused', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+
+  await panel.getByRole('button', { name: '+ New exercise' }).click();
+  await panel.getByLabel('Exercise name').fill('Seated Row');
+
+  await expect(panel.getByText('already exists')).toBeVisible();
+  await expect(panel.getByRole('button', { name: 'Add exercise' })).toBeDisabled();
+});
+
+test('an exercise with no photo is not tappable, one with a photo still is', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+  await addExercise(page, 'Deadlift');
+
+  // No photo ships for a deadlift, so there is nothing to preview.
+  await expect(panel.getByRole('button', { name: 'Deadlift', exact: true })).toHaveCount(0);
+  await expect(panel.getByText('Deadlift', { exact: true })).toBeVisible();
+
+  // A built-in that does have one keeps working exactly as before.
+  await panel.getByRole('button', { name: 'Seated Row', exact: true }).click();
+  await expect(page.getByRole('dialog').filter({ hasText: 'Seated Row' })).toBeVisible();
+});
+
+test('an added exercise can be removed again', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+  await addExercise(page, 'Deadlift');
+
+  await panel.getByRole('button', { name: 'Remove Deadlift' }).click();
+  await page.getByRole('button', { name: 'Remove', exact: true }).click();
+
+  await expect(panel.getByRole('checkbox', { name: 'Deadlift' })).toHaveCount(0);
+});
+
+test('removing one does not strip it from a template that already uses it', async ({ page }) => {
+  await page.goto('/');
+  const panel = await openBuilder(page);
+  await addExercise(page, 'Deadlift');
+  await panel.getByLabel('Workout name').fill('Pull Day');
+  await panel.getByRole('button', { name: 'Save Workout' }).click();
+  await expect(panel).toBeHidden();
+
+  // Saving returns to the template selector, so reopen the builder from there
+  // rather than from the calendar behind it.
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  await expect(builder(page)).toBeVisible();
+  await builder(page).getByRole('button', { name: 'Remove Deadlift' }).click();
+  await page.getByRole('button', { name: 'Remove', exact: true }).click();
+  await builder(page).getByRole('button', { name: 'Close', exact: true }).click();
+  await expect(builder(page)).toBeHidden();
+
+  const row = page.getByRole('button', { name: 'Pull Day', exact: true }).locator('..');
+  await row.getByRole('button', { name: /Options for/ }).click();
+  await page.getByRole('menuitem', { name: 'Edit workout' }).click();
+  await expect(builder(page)).toBeVisible();
+  await builder(page).getByRole('button', { name: 'Update Workout' }).click();
+
+  // The save path used to look each selected exercise up in the library and
+  // silently drop anything missing.
+  const stored = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('ironpath_custom_templates') ?? '[]'),
+  );
+  expect(stored[0].exercises.map((e: { machine: string }) => e.machine)).toContain('Deadlift');
+});

--- a/e2e/toggle-geometry.spec.ts
+++ b/e2e/toggle-geometry.spec.ts
@@ -1,0 +1,84 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+/**
+ * The equipment filter toggle was awkward to get right across screen sizes, so
+ * anything added to its row has to leave it exactly where it was.
+ *
+ * Measurements have to wait for the dialog's open animation to finish. It
+ * scales in from 95%, so sampling too early reports a box up to a pixel narrow
+ * and several pixels off vertically — enough noise to hide a real regression
+ * and to invent ones that are not there.
+ */
+const WIDTHS = [320, 375, 414, 768, 1280];
+
+async function settledBox(locator: Locator) {
+  let previous = await locator.boundingBox();
+  for (let attempt = 0; attempt < 25; attempt++) {
+    await new Promise(resolve => setTimeout(resolve, 60));
+    const current = await locator.boundingBox();
+    if (
+      previous &&
+      current &&
+      Math.abs(previous.width - current.width) < 0.01 &&
+      Math.abs(previous.y - current.y) < 0.01
+    ) {
+      return current;
+    }
+    previous = current;
+  }
+  throw new Error('element never settled');
+}
+
+async function openBuilder(page: Page) {
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  await expect(page.getByText('Select up to 15 exercises')).toBeVisible();
+}
+
+for (const width of WIDTHS) {
+  test(`the filter toggle keeps its place at ${width}px`, async ({ page }) => {
+    await page.setViewportSize({ width, height: 900 });
+    await page.goto('/');
+    await openBuilder(page);
+
+    const toggle = page.locator('button:has(> span.text-2xl)').first();
+    const addButton = page.getByRole('button', { name: '+ New exercise' });
+    const box = await settledBox(toggle);
+    const addBox = await settledBox(addButton);
+    const row = (await toggle.locator('..').boundingBox())!;
+
+    // Still its own fixed size, not squeezed by the new neighbour.
+    expect(box.width).toBeGreaterThan(76);
+    expect(box.width).toBeLessThan(82);
+
+    // Still flush with the right-hand end of its row.
+    expect(Math.abs(row.x + row.width - (box.x + box.width))).toBeLessThan(1);
+
+    // Still on one line: the row must not wrap at any width, and the new
+    // button sits to its left rather than displacing it.
+    expect(Math.abs(addBox.y - box.y)).toBeLessThan(box.height);
+    expect(addBox.x).toBeLessThan(box.x);
+
+    // Nothing on the row may overflow it. This is the assertion that actually
+    // bites: a neighbour too wide to shrink pushes the row past the dialog,
+    // which widens the content box, re-wraps the text above and shifts the
+    // toggle vertically — while its own size and right-alignment still look
+    // perfectly correct in isolation.
+    const rowOverflow = await toggle
+      .locator('..')
+      .evaluate(el => el.scrollWidth - el.clientWidth);
+    expect(rowOverflow).toBeLessThanOrEqual(1);
+
+    const dialogOverflow = await page
+      .getByRole('dialog')
+      .first()
+      .evaluate(el => el.scrollWidth - el.clientWidth);
+    expect(dialogOverflow).toBeLessThanOrEqual(1);
+
+    // eslint-disable-next-line no-console
+    console.log(
+      `GEOM ${width} w=${box.width.toFixed(2)} h=${box.height.toFixed(2)} ` +
+        `top=${box.y.toFixed(1)} rightAlign=${(row.x + row.width - (box.x + box.width)).toFixed(2)}`,
+    );
+  });
+}


### PR DESCRIPTION
The built-in library is a gym-circuit list — **43 machine entries against 16 free-weight** — so the gaps are exactly the movements you named. Neither "deadlift" nor "bear crawl" appears anywhere in it.

## What it does

A **+ New exercise** button sits on the same row as the equipment toggle, as you pictured. It opens a panel inline at the top of the list rather than a second dialog — the builder is already a tall scrolling modal and nesting one inside it invites trouble.

Added exercises are stored in `ironpath_custom_exercises`, merge into the builder's list, and flow through the rest of the app without further work: the equipment filter, region grouping, history prefill and progress stats all key off the exercise name. They ride along in backup/restore and are cleared by Reset All Data.

## Main or warm-up, instead of a set count

You landed on this before suggesting the checkbox, and I think it was the better instinct. A bear crawl is distance or time; the weighted model only fits it by pretending the load is 0.

The warm-up block already stores **reps *or* a duration, with no weight**. So the form asks which half of the workout an exercise belongs to and files it accordingly. Main exercises keep the fixed three sets everything else uses — no picker, no special cases.

A test asserts a warm-up entry is stored with no `weight` key anywhere in it.

## Photos

Nothing selected by default. An optional picker offers the 39 bundled images, **fetched only when you ask for them** — otherwise adding an exercise would pull down 1.6 MB for nothing.

On your point about the popup: the affordance now follows the photo. An exercise without one isn't tappable in the builder and shows no "?" in a workout, rather than opening a placeholder. Both surfaces keep working exactly as before for the 39 that have photos.

That rule also retires `noPreviewAbs` — a hand-maintained list of ten core exercises that encoded the same thing by hand.

## A pre-existing bug this would have made worse

The save path looked each selected exercise up in the library and **silently dropped anything it could not find**. That already bites — machine names were renamed once (`Converging Chest Press` → `Seated Chest Press`) — and once you can delete a custom exercise, deleting one would quietly strip it from every template that used it, the next time you edited them.

The builder now seeds its list from the template's own exercises as well. There is an end-to-end test for exactly that sequence: create an exercise, build a template with it, delete the exercise, edit the template, save, and check it is still there.

## The toggle

Untouched, and measured rather than asserted. The new button is the row's **first** child with the row switched to `justify-between`: with one child under `justify-end` and two under `justify-between`, the last child lands in the same place.

Measured on `main` and on this branch, at five widths:

```
320   w=80.00 h=46.00 rightAlign=0.00   top=160    identical
375   w=80.00 h=46.00 rightAlign=0.00   top=160    identical
414   w=80.00 h=46.00 rightAlign=0.00   top=140    identical
768   w=80.00 h=46.00 rightAlign=0.00   top=140    identical
1280  w=80.00 h=46.00 rightAlign=0.00   top=140    identical
```

**My first attempt at measuring this was wrong** and worth flagging. The dialog animates in from 95%, so sampling too early reported `w=76.45` one run and `78.30` the next on unchanged code — I nearly "found" a regression that was pure animation noise. The test now waits for the box to stop moving before reading it, which is what makes those numbers reproducible.

**And my first guard was too weak.** I gave the button a deliberate 260px min-width to check the test would catch a regression — and it passed. Width, height and right-alignment all still looked perfect; what actually moved was the toggle's vertical position, because an unshrinkable neighbour overflows the row, widens the dialog's content box and re-wraps the text above. The test now asserts the row and dialog cannot overflow horizontally, and I confirmed it fails at 320 and 375 in that broken state and passes when restored.

## Verification

```
npx tsc --noEmit    -> clean
npx vitest run      -> 107 passed (was 83; 24 new)
npx playwright test -> 82 passed (12 new x 2 viewports)
npm run build       -> ok
```

Three consecutive full-suite runs, no flakes. Screenshots checked at 320, 375 and 768 — the form fits without wrapping at the narrowest.

## Worth checking

Add "Deadlift" as a main exercise and "Bear Crawl" as a warm-up, then build a workout with both and start it. The deadlift should behave like any other lift; the bear crawl should appear in the warm-up block with no weight field and no "?" icon.

Then confirm the equipment toggle still feels right on your phone — that is the part I would most want a human eye on, measurements notwithstanding.

## Not included

Editing an exercise after creation — only add and remove. Renaming would want the same identity care as #134, and I would rather see whether you actually want it than guess.