### PR TITLE
polish: stop marking every day and let the calendar be read at a glance

### DIFF
--- a/client/src/components/calendar-grid.test.tsx
+++ b/client/src/components/calendar-grid.test.tsx
@@ -18,6 +18,7 @@ vi.mock('@/lib/utils', async importActual => {
 });
 
 import { CalendarGrid } from './calendar-grid';
+import { formatLocalDate } from '@/lib/utils';
 
 const props = {
   currentDate: new Date(2026, 6, 1),
@@ -53,9 +54,36 @@ describe('the 42-cell day grid', () => {
     expect(formatCalls.n).toBeGreaterThan(afterFirst);
   });
 
-  it("still marks today's cell", () => {
+  // Today used to be marked with a 📅 glyph, and the teal fill it also had was
+  // suppressed whenever the day happened to be selected — which it is by
+  // default. Dropping the glyph therefore only works if the fill is
+  // unconditional, so that is what these two assert.
+  it("marks today's cell with the primary fill", () => {
     const now = new Date();
     const { container } = render(<CalendarGrid {...props} currentDate={now} />);
-    expect(container.textContent).toContain('📅');
+
+    const today = container.querySelector(`[data-today="true"]`);
+    expect(today).not.toBeNull();
+    expect(today!.className).toContain('bg-primary');
+    // The base classes carry `dark:bg-gray-800`, which tailwind-merge keys
+    // separately from an unprefixed `bg-primary` — so without an explicit dark
+    // variant, today renders unmarked in dark mode. It did.
+    expect(today!.className).toContain('dark:bg-primary');
+  });
+
+  it("keeps today's fill when today is the selected day", () => {
+    const now = new Date();
+    const { container } = render(
+      <CalendarGrid {...props} currentDate={now} selectedDate={formatLocalDate(now)} />,
+    );
+
+    const today = container.querySelector(`[data-today="true"]`);
+    expect(today!.className).toContain('bg-primary');
+  });
+
+  it('leaves days without a completed workout unmarked', () => {
+    const { container } = render(<CalendarGrid {...props} />);
+    expect(container.textContent).not.toContain('🕒');
+    expect(container.textContent).not.toContain('📅');
   });
 });

--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -160,14 +160,6 @@ export function CalendarGrid({
             );
           }
 
-          const status = isCompleted
-            ? '✅'
-            : dayData.isToday
-              ? '📅'
-              : hasWorkout
-                ? '🕒'
-                : '';
-
           if (hasWorkout) {
             return (
               <Button
@@ -176,17 +168,32 @@ export function CalendarGrid({
                 className={cn(
                   sharedClasses,
                   'bg-white dark:bg-gray-800 border hover:shadow-md transition-shadow',
+                  // A completed day is washed green, not just checked, so a
+                  // month can be read at a glance instead of hunting for a
+                  // 12px glyph cell by cell.
+                  isCompleted &&
+                    'bg-green-50 dark:bg-green-900/30 border-green-300 dark:border-green-700',
+                  // Selection must outrank the completed border, so it comes after.
                   isSelected
                     ? 'border-primary ring-2 ring-primary'
-                    : 'border-gray-200 dark:border-gray-700',
-                  dayData.isToday && !isSelected
-                    ? 'bg-primary text-white hover:bg-primary/90'
-                    : ''
+                    : !isCompleted && 'border-gray-200 dark:border-gray-700',
+                  // Today is filled whether or not it is selected. It used to
+                  // drop the fill the moment you selected it, which left the
+                  // 📅 glyph as its only marker — and that glyph is now gone.
+                  //
+                  // `dark:bg-primary` is load-bearing: the base classes carry
+                  // `dark:bg-gray-800`, and tailwind-merge keys variants
+                  // separately, so a bare `bg-primary` never collides with it
+                  // and loses the cascade. Without this, today is unmarked in
+                  // dark mode.
+                  dayData.isToday &&
+                    'bg-primary dark:bg-primary text-white hover:bg-primary/90',
                 )}
+                data-today={dayData.isToday || undefined}
                 onClick={() => onSelectDate(dayData.date)}
               >
                 <div className="text-base font-semibold leading-none">{dayData.day}</div>
-                {status && <div className="text-xs">{status}</div>}
+                {isCompleted && <div className="text-xs">✅</div>}
               </Button>
             );
           }
@@ -202,10 +209,10 @@ export function CalendarGrid({
                   : '',
                 isSelected && 'border-2 border-primary'
               )}
+              data-today={dayData.isToday || undefined}
               onClick={() => onSelectDate(dayData.date)}
             >
               <span className="text-base font-semibold leading-none">{dayData.day}</span>
-              {dayData.isToday && <div className="text-xs">📅</div>}
             </Button>
           );
         })}

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -325,26 +325,22 @@ export function CalendarPage() {
       />
 
 
-      {/* Workout Legend */}
-      <Card>
-        <CardContent className="p-4">
-          <h3 className="font-semibold text-gray-900 dark:text-white mb-3">Workout Status</h3>
-          <div className="flex justify-center space-x-6">
-            <div className="flex items-center space-x-1">
-              <span className="text-green-600">✅</span>
-              <span className="text-sm text-gray-600 dark:text-gray-400">Completed</span>
-            </div>
-            <div className="flex items-center space-x-1">
-              <span className="text-orange-600">🕒</span>
-              <span className="text-sm text-gray-600 dark:text-gray-400">Pending</span>
-            </div>
-            <div className="flex items-center space-x-1">
-              <span className="text-blue-600">📅</span>
-              <span className="text-sm text-gray-600 dark:text-gray-400">Today</span>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+      {/* Two states left to explain, so this is a line rather than a card. It
+          used to be a full bordered card teaching three, one of which ("Pending")
+          was on literally every day and so distinguished nothing. Shrinking it
+          pulls Start Today's Workout back above the fold. The Today swatch is a
+          teal square because that is exactly what the calendar draws — a legend
+          that shows the real mark beats one that describes it. */}
+      <div className="flex justify-center items-center gap-6 text-sm text-gray-600 dark:text-gray-400">
+        <span className="flex items-center gap-1.5">
+          <span aria-hidden="true">✅</span>
+          Completed
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span aria-hidden="true" className="h-3 w-3 rounded-sm bg-primary" />
+          Today
+        </span>
+      </div>
 
       {/* Selected Workout Details */}
       {selectedDate && (
@@ -383,7 +379,15 @@ export function CalendarPage() {
               </p>
             )}
 
-            <Button className="w-full" onClick={() => openTemplateSelector(selectedDate)}>
+            {/* Outlined, not filled. This and Start Today's Workout were two
+                identical teal slabs competing for the same attention, when one
+                is the 95% action and this is occasional. Same colour, less ink —
+                the hierarchy comes from turning this down, not from shouting. */}
+            <Button
+              className="w-full border-primary text-primary hover:bg-primary/10 hover:text-primary"
+              variant="outline"
+              onClick={() => openTemplateSelector(selectedDate)}
+            >
               Create or Edit Custom Workout
             </Button>
 

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -44,6 +44,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   const [workout, setWorkout] = useState<Workout>(initialWorkout);
   const [currentExerciseIndex, setCurrentExerciseIndex] = useState(0);
   const [autoSaveEnabled] = useState(true);
+  const [lastSavedAt, setLastSavedAt] = useState<Date | null>(null);
   const [celebrated, setCelebrated] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
   const [successMessage, setSuccessMessage] = useState<typeof successMessages[number]>(successMessages[0]);
@@ -91,6 +92,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
       });
 
       lastSavedRef.current = serialized;
+      setLastSavedAt(new Date());
 
       if (autoSaveEnabledRef.current) {
         if (toastIdRef.current) {
@@ -324,9 +326,23 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                   {stats.completedItems}/{stats.totalItems} items
                 </span>
               </div>
+              {/* Was a hardcoded ✅ — a status light with one possible state,
+                  in the most valuable strip of the workout screen. A green
+                  check also reads as "just saved" rather than "autosave is on".
+                  The clock time is the thing you would actually want to know,
+                  and it needs no ticking timer to stay true. */}
               <div className="flex items-center space-x-1">
-                <span className="text-sm text-gray-600 dark:text-gray-400">Auto-save:</span>
-                <span className="text-sm text-green-600">✅</span>
+                <span className="text-sm text-gray-600 dark:text-gray-400">
+                  {lastSavedAt ? 'Saved' : 'Auto-save on'}
+                </span>
+                {lastSavedAt && (
+                  <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    {lastSavedAt.toLocaleTimeString([], {
+                      hour: 'numeric',
+                      minute: '2-digit',
+                    })}
+                  </span>
+                )}
               </div>
             </div>
           </div>


### PR DESCRIPTION
The calendar polish from last night's design pass. **Visual only** — no logic, no storage, no schema.

## The clock was the whole problem

Every day in the month carried a 🕒. A marker on *everything* distinguishes nothing, and it was competing directly with the ✅ that does carry information. **Pending is now simply the absence of a mark.**

## Completed days are washed green

Your instinct — drop the clock so the check stands out — was right, and this takes it one step further. A 12px glyph has to be hunted cell by cell. A tinted cell lets you read a whole month in peripheral vision, which is the one thing a calendar grid is uniquely good at. "How did July go?" is now answered in about half a second.

## Today is filled teal, always — and a correction

**I told you last night that today already had a teal ring, so the 📅 was redundant. That was wrong, and you should know why before you look at this.**

The ring I saw in the screenshot was the **selected**-day treatment, not a today treatment. Today's real marker was `bg-primary` — but gated behind `&& !isSelected`, and today *is* the selected day when the app opens. So in the default view the fill never applied and 📅 genuinely was today's only marker. Removing it as I described would have lost information, not redundancy.

The fix makes my original claim true rather than working around it: **today's fill is now unconditional**, so it is marked whether selected or not, and the glyph can go. Selection's ring composes on top.

### And that surfaced a real bug

Checking it in dark mode, **today was not marked at all** — no fill, in either the old code or my first cut.

The base classes carry `dark:bg-gray-800`. tailwind-merge keys `dark:bg-*` and `bg-primary` as *different* properties, so they never collide, and the dark variant wins the cascade. An unprefixed `bg-primary` simply lost. Fixed with an explicit `dark:bg-primary`, and a test now requires that class so it can't silently regress.

This is why the screenshots were worth taking — no test I would have thought to write was going to catch it.

## The legend is a line, not a card

With one glyph left to explain, a full bordered card with a heading no longer earns the space between the calendar and the button people actually came to press. **Start Today's Workout moves back above the fold.**

The Today swatch is a small teal square rather than an emoji, because showing the real mark beats describing it — the legend now looks like the thing it explains.

## Button hierarchy

**Create or Edit Custom Workout is outlined instead of filled.** It and Start Today's Workout were two identical teal slabs competing for the same attention, when one is the 95% action and the other is occasional.

You said you didn't want it obnoxious, and that's exactly why it's done this way: the hierarchy comes from turning the *secondary* down, not the primary up. Same colour, **less** total ink than before.

## `Auto-save: ✅` → `Saved 12:57 PM`

The check was hardcoded — always on, always green. A status light with one possible state, in the most valuable strip of the workout screen. A green check there also reads as *"just saved"* rather than *"autosave is enabled"*.

It now shows the actual save time, and `Auto-save on` before the first save. No ticking timer — it updates only when a save happens, so it can't drift or cost renders mid-workout.

## Verification

```
eslint             -> 0 errors, 24 warnings
tsc --noEmit       -> clean
vitest             -> 109 passed (2 new)
playwright         -> 88 passed, run twice, clean both times
npm run build      -> ok
```

Checked visually at a phone viewport in **both light and dark**, with six completed days seeded so the green wash had something to render.

Both new calendar guards were confirmed load-bearing the usual way — I reintroduced each regression (restored `&& !isSelected`, then put the 🕒 back) and watched the matching test fail, then restored and watched it pass.

## Two taste calls

The **green wash** and the **outlined button** are the two places where taste matters more than correctness. They're independent — if you dislike either in the preview, say which and it comes out without touching the rest.

Everything else here (dropping the clock, the compact legend, the save time, the dark-mode fix) I'd argue for regardless.
