### PR TITLE
release: v1.2.0, with the version read from package.json

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -132,7 +132,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
           Storage Usage: {Math.round(usage.percent * 100)}% ({(usage.used / 1024).toFixed(1)} KB of {(usage.limit / 1024).toFixed(1)} KB)
         </div>
         <div className="text-sm text-gray-500 dark:text-gray-400">
-          IronPath v1.1.2<br />
+          IronPath v{__APP_VERSION__}<br />
           Created by Casey Flanigan<br />
           This is an open source project which can be found here: https://github.com/crflanigan/IronPath
         </div>

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Substituted at build time from `package.json`'s `version` field, by the
+ * `define` in vite.config.ts (and mirrored in vitest.config.ts so tests can
+ * render it). See `version.test.ts` for the guard that keeps the two in step.
+ */
+declare const __APP_VERSION__: string;

--- a/client/src/lib/version.test.ts
+++ b/client/src/lib/version.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * The app's version used to live in three places that disagreed: the newest git
+ * tag said v1.1.1, the Settings dialog had "IronPath v1.1.2" typed into it by
+ * hand — a version never tagged — and package.json still said 1.0.0.
+ *
+ * package.json is now the only source. These tests guard both halves of that:
+ * that the build actually substitutes it, and that nobody hardcodes it back.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+
+function packageVersion(): string {
+  const pkg = JSON.parse(
+    readFileSync(path.join(REPO_ROOT, 'package.json'), 'utf-8'),
+  ) as { version: string };
+  return pkg.version;
+}
+
+/** Source text, so a hardcoded version is caught without rendering anything. */
+const CLIENT_SOURCES = import.meta.glob('../**/*.{ts,tsx}', {
+  eager: true,
+  query: '?raw',
+  import: 'default',
+}) as Record<string, string>;
+
+describe('the displayed app version', () => {
+  it('is substituted at build time from package.json', () => {
+    // If the `define` were missing from a config, this would not merely differ
+    // — referencing it would throw.
+    expect(__APP_VERSION__).toBe(packageVersion());
+  });
+
+  it('is a plausible semver, so an empty define cannot pass silently', () => {
+    expect(__APP_VERSION__).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('is not typed by hand anywhere in the client', () => {
+    const offenders = Object.entries(CLIENT_SOURCES)
+      // This file necessarily contains version-shaped text.
+      .filter(([file]) => !file.endsWith('version.test.ts'))
+      .filter(([, source]) =>
+        // "IronPath v1.2.0" or similar sitting in JSX or a string.
+        /IronPath\s+v\d+\.\d+\.\d+/.test(source),
+      )
+      .map(([file]) => file);
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/e2e/version.spec.ts
+++ b/e2e/version.spec.ts
@@ -1,0 +1,41 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// These specs are ESM, so there is no __dirname.
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * The version shown in Settings, checked against a real production build.
+ *
+ * The unit test in `client/src/lib/version.test.ts` runs under vitest, so it
+ * only ever proves vitest.config.ts's `define` is right. The define that
+ * actually ships lives in vite.config.ts, and nothing else exercises it — a
+ * wrong version there would reach users with every other check green.
+ *
+ * Playwright runs against `vite preview` of the real build, so this is the one
+ * place that boundary gets tested.
+ */
+
+const { version } = JSON.parse(
+  readFileSync(path.resolve(HERE, '..', 'package.json'), 'utf-8'),
+) as { version: string };
+
+test('Settings shows the version from package.json', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Settings' }).click();
+
+  await expect(page.getByText(`IronPath v${version}`)).toBeVisible();
+});
+
+test('the built bundle carries no unsubstituted placeholder', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Settings' }).click();
+
+  // A missing define in vite.config.ts leaves the identifier in place, which
+  // would throw at render — but a define set to an empty string would quietly
+  // render "IronPath v". Neither should ever be visible.
+  await expect(page.getByText('__APP_VERSION__')).toHaveCount(0);
+  await expect(page.getByText(/IronPath v\d+\.\d+\.\d+/)).toBeVisible();
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-express",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { readFileSync } from "fs";
 import { fileURLToPath } from "url";
 
 // Node <20 does not include import.meta.dirname. Compute it manually for
@@ -9,7 +10,19 @@ const DIRNAME = typeof import.meta.dirname !== "undefined"
   ? import.meta.dirname
   : path.dirname(fileURLToPath(import.meta.url));
 
+// The version the app displays comes from package.json, substituted at build
+// time. It used to be typed into the Settings dialog by hand, which is how the
+// app came to advertise a v1.1.2 that was never tagged while package.json still
+// said 1.0.0. Importing package.json into the client instead would bundle the
+// whole dependency list, so this is a define rather than an import.
+const { version } = JSON.parse(
+  readFileSync(path.resolve(DIRNAME, "package.json"), "utf-8"),
+) as { version: string };
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   plugins: [
     react(),
   ],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,22 @@
 import { defineConfig } from 'vitest/config';
 import path from 'path';
+import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 
 const DIRNAME = typeof import.meta.dirname !== 'undefined'
   ? import.meta.dirname
   : path.dirname(fileURLToPath(import.meta.url));
 
+// Mirrors the define in vite.config.ts. Without it, anything rendering the
+// version would throw under test with `__APP_VERSION__ is not defined`.
+const { version } = JSON.parse(
+  readFileSync(path.resolve(DIRNAME, 'package.json'), 'utf-8'),
+) as { version: string };
+
 export default defineConfig({
+  define: {
+    __APP_VERSION__: JSON.stringify(version),
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
Prep for cutting **v1.2.0**. You spotted the Settings version string mid-flight — this is that, plus making it impossible to drift again.

## The version disagreed with itself in three places

| Source | Said |
|---|---|
| Newest git tag | `v1.1.1` (July 2025) |
| Settings dialog | `v1.1.2` — **never tagged**, typed in by hand |
| `package.json` | `1.0.0` — never maintained |

**`package.json` is now the only source.** Vite substitutes it at build time through a `define`, so the number in Settings is the number in the package, always.

Importing `package.json` into the client would have bundled your entire dependency list into the browser, which is why this is a define rather than an import. `vitest.config.ts` mirrors it so tests can render the version.

Bumped to **1.2.0** — a minor. Since `v1.1.1` this picked up the custom exercises feature, the whole hardening pass, and the calendar work.

## Three guards, each proven by breaking what it watches

1. **`__APP_VERSION__` matches `package.json`.** Remove the define → fails with *"is not defined"*. Hardcode it wrong → reports the mismatch.
2. **No client source contains a hand-typed `IronPath vX.Y.Z`.** Paste the literal back into `SettingsDialog` → fails.
3. **An end-to-end check against a real production build.**

That third one is worth explaining, because I only added it after the first attempt at a drift test turned out to be tautological.

The unit test runs under vitest, so it can only ever prove **`vitest.config.ts`** is correct. The define that actually ships lives in **`vite.config.ts`**, and nothing exercised it. A wrong version there would reach you with every other check green.

Demonstrated rather than assumed:

```
# wrong version hardcoded in vite.config.ts (the shipping config)
unit:  Tests  3 passed        <- blind to it
e2e:   1 failed, 1 passed     <- catches it
```

Playwright runs against `vite preview` of the real build, so it's the only place that boundary can be tested.

## A correction to #144

That PR's description claimed *"no Drizzle in the built bundle"*, verified with a grep against `dist/public/assets/`. **That path doesn't exist** — the build writes to `dist/assets/` — so the command matched nothing and the `|| echo` fallback printed a pass. It proved nothing.

Re-run against the real path: **0 matches.** The claim was true, it just hadn't been tested. The static guard in `bundle-boundaries.test.ts` was the only thing actually holding that line, and it still is.

## Verification

```
eslint             -> 0 errors, 24 warnings
tsc --noEmit       -> clean
vitest             -> 112 passed (3 new)
playwright         -> 92 passed (4 new), run twice, clean both
npm run build      -> ok
grep dist/assets   -> "1.2.0" present, 0 unsubstituted placeholders,
                      0 drizzle references
```

## After you merge

I'll tag `v1.2.0` at the merge commit and publish the release notes — one new feature, the data-integrity fixes, updates finally reaching installed PWAs, and the calendar work. **I won't tag until you've merged and told me to go**, since publishing a release is outward-facing in the same way merging is.
