### PR TITLE
feat: a first-run tour, and an install prompt that waits its turn

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -61,7 +61,7 @@ function Header() {
               {/* Named here because backup/restore lives behind this button and
                   is otherwise unreachable to a screen reader or a test. The
                   remaining icon-only buttons are handled in the a11y pass. */}
-              <Button aria-label="Settings" variant="ghost" size="sm" className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
+              <Button data-tour="settings" aria-label="Settings" variant="ghost" size="sm" className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                 <Settings className="h-4 w-4" />
               </Button>
             </SettingsDialog>

--- a/client/src/components/AppTour.tsx
+++ b/client/src/components/AppTour.tsx
@@ -1,0 +1,225 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { markTourSeen } from '@/lib/onboarding';
+
+/**
+ * A three-step first-run tour.
+ *
+ * Two decisions worth knowing before changing this:
+ *
+ * 1. **The explanation sits at the bottom, not next to the target.** An
+ *    anchored tooltip on a 375px screen covers the thing it is pointing at —
+ *    highlight a calendar cell and the tooltip eats half the calendar. A fixed
+ *    bottom panel can never overlap the element above it.
+ *
+ * 2. **It highlights the live element rather than showing a screenshot.**
+ *    Screenshots of your own UI rot; the calendar changed the week this was
+ *    written. Pointing at the real button cannot go stale and weighs nothing.
+ *
+ * Installing the app is deliberately *not* a step here. Asking someone to
+ * install before they have used anything converts badly — see InstallPrompt,
+ * which waits for a second visit.
+ */
+
+interface Step {
+  /** Matches a `data-tour` attribute. Absent means a centred card. */
+  target?: string;
+  title: string;
+  body: string;
+}
+
+const STEPS: Step[] = [
+  {
+    target: 'calendar',
+    title: 'Your month at a glance',
+    body: 'Tap any day to see what is scheduled and start it. Days you finish turn green, so a glance tells you how the month went.',
+  },
+  {
+    target: 'custom-workout',
+    title: 'Build your own',
+    body: 'Make a workout from the exercise library, or add exercises it does not have — bear crawls, deadlifts, whatever you actually do.',
+  },
+  {
+    target: 'settings',
+    title: 'Keep a backup',
+    body: 'IronPath has no account and no server, so your history lives only on this device. Export a backup from Settings — if you clear your browser or change phones, it is the only way back.',
+  },
+];
+
+/** Padding around the highlighted element, in px. */
+const HALO = 6;
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+export function AppTour({ onClose }: { onClose: () => void }) {
+  const [index, setIndex] = useState(0);
+  const [rect, setRect] = useState<Rect | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  const step = STEPS[index];
+  const isLast = index === STEPS.length - 1;
+
+  const finish = useCallback(() => {
+    markTourSeen();
+    onClose();
+  }, [onClose]);
+
+  // Measure the target. A missing target is not an error: the step simply
+  // renders as a centred card rather than throwing on a page that does not
+  // contain it.
+  const measure = useCallback(() => {
+    if (!step.target) {
+      setRect(null);
+      return;
+    }
+    const el = document.querySelector(`[data-tour="${step.target}"]`);
+    if (!el) {
+      setRect(null);
+      return;
+    }
+    const r = el.getBoundingClientRect();
+    setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
+  }, [step.target]);
+
+  // Bring the target into the part of the screen the panel is not covering.
+  //
+  // `scrollIntoView({ block: 'center' })` is the obvious approach and it is
+  // wrong here: it centres within the *viewport*, and the bottom third of the
+  // viewport is this component's own panel. The second step scrolled its
+  // button to a position underneath the panel, so the halo was drawn but
+  // invisible — the step looked like it had simply failed.
+  //
+  // Padding the body by the panel height guarantees there is always enough
+  // scroll room to lift a target clear, even one at the very bottom of the
+  // page. Restored on unmount.
+  useLayoutEffect(() => {
+    const panel = panelRef.current;
+    const panelHeight = panel?.offsetHeight ?? 0;
+
+    const previousPadding = document.body.style.paddingBottom;
+    document.body.style.paddingBottom = `${panelHeight}px`;
+
+    const el = step.target
+      ? document.querySelector(`[data-tour="${step.target}"]`)
+      : null;
+
+    if (el) {
+      const visibleHeight = Math.max(window.innerHeight - panelHeight, 120);
+      const box = el.getBoundingClientRect();
+      const delta = box.top + box.height / 2 - visibleHeight / 2;
+      window.scrollBy({ top: delta, behavior: 'smooth' });
+    }
+
+    // The scroll listener keeps the halo tracking during the smooth scroll;
+    // this is the settle-time backstop.
+    const timer = window.setTimeout(measure, 400);
+
+    return () => {
+      window.clearTimeout(timer);
+      document.body.style.paddingBottom = previousPadding;
+    };
+  }, [step.target, measure]);
+
+  useEffect(() => {
+    window.addEventListener('resize', measure);
+    window.addEventListener('scroll', measure, true);
+    return () => {
+      window.removeEventListener('resize', measure);
+      window.removeEventListener('scroll', measure, true);
+    };
+  }, [measure]);
+
+  // Escape closes, and focus moves to the panel so the controls are reachable
+  // by keyboard without hunting.
+  useEffect(() => {
+    panelRef.current?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') finish();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [finish]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Welcome tour"
+      data-testid="app-tour"
+    >
+      {/*
+        The dimming and the hole in it are the same element. An enormous spread
+        on the box-shadow paints everything outside the halo, which avoids
+        stacking four separate overlay panels and keeps the cutout exactly
+        aligned with the target while it scrolls.
+      */}
+      {rect ? (
+        <div
+          className="pointer-events-none absolute rounded-xl transition-all duration-200"
+          style={{
+            top: rect.top - HALO,
+            left: rect.left - HALO,
+            width: rect.width + HALO * 2,
+            height: rect.height + HALO * 2,
+            // Both the outline and the dimming, in one shadow. Tailwind's
+            // `ring-2` is itself a box-shadow, so an inline boxShadow silently
+            // replaces it — the ring never rendered at all until this was
+            // written out longhand. It matters most in dark mode, where
+            // dimming an already-dark page barely reads.
+            boxShadow: '0 0 0 2px var(--primary), 0 0 0 9999px rgba(0, 0, 0, 0.7)',
+          }}
+        />
+      ) : (
+        <div className="absolute inset-0 bg-black/65" />
+      )}
+
+      <div
+        ref={panelRef}
+        tabIndex={-1}
+        data-testid="app-tour-panel"
+        className="absolute inset-x-0 bottom-0 rounded-t-2xl bg-white p-5 shadow-2xl outline-none dark:bg-gray-800"
+      >
+        <div className="mx-auto max-w-md space-y-3">
+          <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
+            Step {index + 1} of {STEPS.length}
+          </p>
+          <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
+            {step.title}
+          </h2>
+          <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+            {step.body}
+          </p>
+
+          <div className="flex items-center justify-between pt-1">
+            <Button variant="ghost" size="sm" onClick={finish}>
+              Skip
+            </Button>
+            <div className="flex items-center gap-2">
+              {index > 0 && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIndex(i => i - 1)}
+                >
+                  Back
+                </Button>
+              )}
+              <Button
+                size="sm"
+                onClick={() => (isLast ? finish() : setIndex(i => i + 1))}
+              >
+                {isLast ? 'Got it' : 'Next'}
+              </Button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/InstallPrompt.tsx
+++ b/client/src/components/InstallPrompt.tsx
@@ -1,0 +1,128 @@
+import { useEffect, useState } from 'react';
+import { Download, Share, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  dismissInstall,
+  hasDismissedInstall,
+  hasSeenTour,
+  isIOS,
+  isStandalone,
+  visitCount,
+} from '@/lib/onboarding';
+
+/**
+ * "Add to home screen", for people who do not know that is a thing.
+ *
+ * Not being in an app store reads to a lot of people as the app not being
+ * real, and the install affordance is buried — on iOS it is inside the Share
+ * sheet, which nobody finds by accident.
+ *
+ * Timing is deliberate: this waits for a **second visit**. Asking someone to
+ * install before they have used anything converts badly, and it is also the
+ * point at which the ask stops being pushy and starts being useful.
+ */
+
+/** Chrome's install event, which is not in lib.dom. */
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+function shouldConsiderPrompting(): boolean {
+  // Already installed, already said no, or still finding their feet.
+  if (isStandalone()) return false;
+  if (hasDismissedInstall()) return false;
+  if (!hasSeenTour()) return false;
+  return visitCount() >= 2;
+}
+
+export function InstallPrompt() {
+  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (!shouldConsiderPrompting()) return;
+
+    // iOS has no install API whatsoever, so instructions are the only option.
+    if (isIOS()) {
+      setVisible(true);
+      return;
+    }
+
+    const onBeforeInstall = (e: Event) => {
+      // Suppress Chrome's own mini-infobar so this is the only ask.
+      e.preventDefault();
+      setDeferred(e as BeforeInstallPromptEvent);
+      setVisible(true);
+    };
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstall);
+    return () => window.removeEventListener('beforeinstallprompt', onBeforeInstall);
+  }, []);
+
+  const close = () => {
+    dismissInstall();
+    setVisible(false);
+  };
+
+  const install = async () => {
+    if (!deferred) return;
+    try {
+      await deferred.prompt();
+      await deferred.userChoice;
+    } catch {
+      // The browser refused to show it — nothing useful to do, and certainly
+      // nothing worth breaking the page over.
+    }
+    close();
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className="rounded-lg border border-primary/30 bg-primary/5 p-4 dark:bg-primary/10"
+      data-testid="install-prompt"
+    >
+      <div className="flex items-start gap-3">
+        <Download className="mt-0.5 h-5 w-5 shrink-0 text-primary" />
+        <div className="min-w-0 flex-1 space-y-2">
+          <p className="text-sm font-medium text-gray-900 dark:text-white">
+            Install IronPath
+          </p>
+
+          {isIOS() ? (
+            <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+              Tap
+              {/* The Share glyph is the one thing people genuinely cannot find,
+                  so it is drawn inline rather than described. */}
+              <Share className="mx-1 inline h-4 w-4 align-text-bottom" aria-label="Share" />
+              in Safari&rsquo;s toolbar, then <strong>Add to Home Screen</strong>.
+              It opens full screen and works with no signal.
+            </p>
+          ) : (
+            <>
+              <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+                Add it to your home screen. It opens full screen and works with
+                no signal.
+              </p>
+              <Button size="sm" onClick={install}>
+                Install
+              </Button>
+            </>
+          )}
+        </div>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Dismiss install prompt"
+          onClick={close}
+          className="-mr-2 -mt-2 h-8 w-8 shrink-0 p-0"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -7,6 +7,7 @@ import { localWorkoutStorage } from '@/lib/storage';
 import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { toast } from '@/hooks/use-toast';
 import { backupFilename, describeBackup, downloadJson, readJsonFile } from '@/lib/backup';
+import { resetTour } from '@/lib/onboarding';
 
 export function SettingsDialog({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false);
@@ -127,6 +128,20 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
             </AlertDialogContent>
           </AlertDialog>
         </div>
+        <Separator />
+        {/* Replaces a "don't show this again" checkbox on the tour itself.
+            Skipping already means never again, so the only control worth
+            having is the one that brings it back. */}
+        <Button
+          variant="outline"
+          className="w-full"
+          onClick={() => {
+            resetTour();
+            window.location.reload();
+          }}
+        >
+          Replay welcome tour
+        </Button>
         <Separator />
         <div className="text-sm text-gray-500 dark:text-gray-400">
           Storage Usage: {Math.round(usage.percent * 100)}% ({(usage.used / 1024).toFixed(1)} KB of {(usage.limit / 1024).toFixed(1)} KB)

--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -132,7 +132,7 @@ export function CalendarGrid({
         </Button>
       </div>
 
-      <div className="grid grid-cols-7 gap-1">
+      <div className="grid grid-cols-7 gap-1" data-tour="calendar">
         {daysOfWeek.map(day => (
           <div key={day} className="text-center text-xs font-medium text-gray-500 dark:text-gray-400 p-2">
             {day}

--- a/client/src/lib/onboarding.ts
+++ b/client/src/lib/onboarding.ts
@@ -1,0 +1,98 @@
+/**
+ * First-run state for the tour and the install prompt.
+ *
+ * Kept out of `storage.ts` on purpose. That module owns workout data and has a
+ * quota-cleanup path; these are three trivial UI flags, and a failure to read
+ * one should never be able to disturb anything that matters. Every accessor
+ * here swallows errors and returns a safe default, because Safari in private
+ * mode throws on `localStorage` access rather than returning null.
+ */
+
+const KEYS = {
+  TOUR_SEEN: 'ironpath_tour_seen',
+  VISITS: 'ironpath_visits',
+  INSTALL_DISMISSED: 'ironpath_install_dismissed',
+} as const;
+
+function read(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
+}
+
+function write(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Full or unavailable storage means the tour shows again next time. That
+    // is a far better failure than an exception on boot.
+  }
+}
+
+export function hasSeenTour(): boolean {
+  return read(KEYS.TOUR_SEEN) === '1';
+}
+
+export function markTourSeen(): void {
+  write(KEYS.TOUR_SEEN, '1');
+}
+
+/** Used by the Replay tour button in Settings. */
+export function resetTour(): void {
+  try {
+    localStorage.removeItem(KEYS.TOUR_SEEN);
+  } catch {
+    // Nothing to do; the button simply will not have taken effect.
+  }
+}
+
+/** Counts this page load and returns the new total. Saturates, never wraps. */
+export function recordVisit(): number {
+  const parsed = Number.parseInt(read(KEYS.VISITS) ?? '0', 10);
+  const previous = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  const next = Math.min(previous + 1, 9999);
+  write(KEYS.VISITS, String(next));
+  return next;
+}
+
+export function visitCount(): number {
+  const parsed = Number.parseInt(read(KEYS.VISITS) ?? '0', 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+export function hasDismissedInstall(): boolean {
+  return read(KEYS.INSTALL_DISMISSED) === '1';
+}
+
+export function dismissInstall(): void {
+  write(KEYS.INSTALL_DISMISSED, '1');
+}
+
+/** True when the app is already installed, so nothing should nag about it. */
+export function isStandalone(): boolean {
+  try {
+    if (window.matchMedia('(display-mode: standalone)').matches) return true;
+    // iOS predates the display-mode media query for home-screen apps.
+    return (window.navigator as { standalone?: boolean }).standalone === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * iOS offers no install API at all — `beforeinstallprompt` does not exist
+ * there — so the only thing available is telling people where the button is.
+ * Every iOS browser is WebKit underneath and shares the same Share-sheet flow.
+ */
+export function isIOS(): boolean {
+  try {
+    const ua = navigator.userAgent;
+    if (/iPad|iPhone|iPod/.test(ua)) return true;
+    // iPadOS 13+ reports itself as a Mac; the touch points give it away.
+    return navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1;
+  } catch {
+    return false;
+  }
+}

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -16,6 +16,12 @@ import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { CustomizeStreakModal } from '@/components/CustomizeStreakModal';
 import type { Workout, Exercise, AbsExercise } from '@shared/schema';
 import { CustomWorkoutTemplate, localWorkoutStorage } from '@/lib/storage';
+import { AppTour } from '@/components/AppTour';
+import { InstallPrompt } from '@/components/InstallPrompt';
+import { hasSeenTour, recordVisit } from '@/lib/onboarding';
+
+/** One visit per page load, not per mount. See the effect that reads it. */
+let visitRecorded = false;
 
 export function CalendarPage() {
   const [currentDate, setCurrentDate] = useState(new Date());
@@ -30,6 +36,9 @@ export function CalendarPage() {
   const [templateToEdit, setTemplateToEdit] = useState<CustomWorkoutTemplate | null>(null);
   const [prefillTemplate, setPrefillTemplate] = useState<{ name: string; exercises: Exercise[]; abs: AbsExercise[] } | null>(null);
   const [dateForCreation, setDateForCreation] = useState<string | null>(null);
+  // Read once at mount rather than on every render: finishing the tour writes
+  // the flag, and re-reading it would tear the overlay down mid-transition.
+  const [showTour, setShowTour] = useState(() => !hasSeenTour());
   const {
     workouts,
     getWorkoutByDate,
@@ -43,6 +52,16 @@ export function CalendarPage() {
     customTemplates,
     loading
   } = useWorkoutStorage();
+
+  // Counts this page load, which is what gates the install prompt to a second
+  // visit. Module-scoped so React's development double-invoke of effects does
+  // not count one load twice.
+  useEffect(() => {
+    if (!visitRecorded) {
+      visitRecorded = true;
+      recordVisit();
+    }
+  }, []);
 
   useEffect(() => {
     if (selectedDate) {
@@ -284,6 +303,9 @@ export function CalendarPage() {
 
   return (
     <div className="max-w-md mx-auto p-4 space-y-6">
+      {showTour && <AppTour onClose={() => setShowTour(false)} />}
+      <InstallPrompt />
+
       {/* Stats Overview */}
       <div className="grid grid-cols-3 gap-4">
         <button
@@ -384,6 +406,7 @@ export function CalendarPage() {
                 is the 95% action and this is occasional. Same colour, less ink —
                 the hierarchy comes from turning this down, not from shouting. */}
             <Button
+              data-tour="custom-workout"
               className="w-full border-primary text-primary hover:bg-primary/10 hover:text-primary"
               variant="outline"
               onClick={() => openTemplateSelector(selectedDate)}

--- a/e2e/backup.spec.ts
+++ b/e2e/backup.spec.ts
@@ -35,7 +35,15 @@ test('a backup exports and restores through the UI', async ({ page }) => {
   const backupJson = readFileSync((await download.path())!, 'utf8');
 
   // The backup must be self-sufficient, so wipe everything.
-  await page.evaluate(() => localStorage.clear());
+  //
+  // Wiping the device also wipes the flag that suppresses the first-run tour,
+  // which is correct behaviour — someone who clears their data really is a new
+  // visitor again — but this test is about the backup round trip, and the tour
+  // would sit over the controls it needs. Put the flag back, and only it.
+  await page.evaluate(() => {
+    localStorage.clear();
+    localStorage.setItem('ironpath_tour_seen', '1');
+  });
   await page.reload();
   await expect(page.getByText('No custom workout scheduled for this date')).toBeVisible();
 

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,169 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * The first-run tour and the install prompt.
+ *
+ * Every other spec runs with `ironpath_tour_seen` pre-set by the Playwright
+ * config, because the tour is a full-screen overlay that would otherwise
+ * intercept the first click of every test. This file is the exception: it
+ * clears that flag and exercises the path a genuinely new visitor takes.
+ *
+ * The load-bearing test here is the last one. A tour that traps someone in an
+ * overlay, or that leaves the page padded after it closes, is worse than no
+ * tour at all — this app gets used mid-workout.
+ */
+
+/**
+ * Start as someone who has never opened the app, and land on the page.
+ *
+ * Deliberately not `addInitScript`: that re-runs on *every* navigation, so a
+ * later reload would wipe the very flag under test and the tour would appear
+ * to come back. Clearing once and reloading gives a genuinely fresh visitor
+ * whose subsequent navigations behave normally.
+ */
+async function asNewVisitor(page: Page) {
+  await page.goto('/');
+  await page.evaluate(() => {
+    try {
+      localStorage.clear();
+    } catch {
+      /* private mode */
+    }
+  });
+  await page.reload();
+}
+
+test.describe('the first-run tour', () => {
+  test('greets a new visitor and walks three steps', async ({ page }) => {
+    await asNewVisitor(page);
+
+    const tour = page.getByTestId('app-tour');
+    await expect(tour).toBeVisible();
+    await expect(tour.getByText('Step 1 of 3')).toBeVisible();
+    await expect(tour.getByRole('heading', { name: 'Your month at a glance' })).toBeVisible();
+
+    // Scoped to the tour: a bare "Next" also matches the calendar's
+    // "Next month" button.
+    await tour.getByRole('button', { name: 'Next' }).click();
+    await expect(tour.getByRole('heading', { name: 'Build your own' })).toBeVisible();
+
+    await tour.getByRole('button', { name: 'Next' }).click();
+    await expect(tour.getByRole('heading', { name: 'Keep a backup' })).toBeVisible();
+
+    // The step that exists because most users have no backup and no way back.
+    await expect(tour).toContainText('only on this device');
+
+    await tour.getByRole('button', { name: 'Got it' }).click();
+    await expect(tour).toHaveCount(0);
+  });
+
+  test('keeps every highlight clear of its own panel', async ({ page }) => {
+    await asNewVisitor(page);
+
+    const tour = page.getByTestId('app-tour');
+    const halo = tour.locator('div[style*="box-shadow"]').first();
+    const panel = page.getByTestId('app-tour-panel');
+
+    // Step two shipped broken the first time: the halo was drawn, and moved,
+    // and was completely invisible because it sat underneath the panel. An
+    // earlier version of this test only checked that the halo *moved* between
+    // steps, which the broken code also did — so it caught nothing. What
+    // matters is that the highlight is somewhere a person can actually see.
+    for (let step = 1; step <= 3; step++) {
+      await expect(halo).toBeVisible();
+      await page.waitForTimeout(700); // smooth-scroll settle
+
+      const h = await halo.boundingBox();
+      const p = await panel.boundingBox();
+      expect(h, `step ${step}: no halo`).not.toBeNull();
+      expect(p, `step ${step}: no panel`).not.toBeNull();
+
+      expect(
+        h!.y + h!.height,
+        `step ${step}: highlight is hidden behind the tour panel`,
+      ).toBeLessThanOrEqual(p!.y + 1);
+
+      expect(h!.y, `step ${step}: highlight is above the viewport`)
+        .toBeGreaterThanOrEqual(-1);
+
+      if (step < 3) {
+        await tour.getByRole('button', { name: 'Next' }).click();
+      }
+    }
+  });
+
+  test('does not come back on the next visit', async ({ page }) => {
+    await asNewVisitor(page);
+    await page.getByTestId('app-tour').getByRole('button', { name: 'Skip' }).click();
+    await expect(page.getByTestId('app-tour')).toHaveCount(0);
+
+    await page.reload();
+    await expect(page.getByRole('button', { name: "Start Today's Workout" })).toBeVisible();
+    await expect(page.getByTestId('app-tour')).toHaveCount(0);
+  });
+
+  test('can be replayed from Settings', async ({ page }) => {
+    // Starts as a returning user, per the config default.
+    await page.goto('/');
+    await expect(page.getByTestId('app-tour')).toHaveCount(0);
+
+    await page.getByRole('button', { name: 'Settings' }).click();
+    await page.getByRole('button', { name: 'Replay welcome tour' }).click();
+
+    await expect(page.getByTestId('app-tour')).toBeVisible();
+  });
+
+  test('leaves the page usable after it closes', async ({ page }) => {
+    await asNewVisitor(page);
+
+    const tour = page.getByTestId('app-tour');
+    await tour.getByRole('button', { name: 'Skip' }).click();
+    await expect(tour).toHaveCount(0);
+
+    // The tour pads the body so it can scroll a target clear of its own
+    // panel. Failing to undo that would leave dead space below the app
+    // forever, on a page nobody would think to blame the tour for.
+    const padding = await page.evaluate(() => document.body.style.paddingBottom);
+    expect(padding === '' || padding === '0px').toBe(true);
+
+    // And the app still works.
+    await page.getByRole('button', { name: "Start Today's Workout" }).click();
+    await expect(page).toHaveURL(/\/workout\/\d+$/);
+    await expect(page.getByLabel('Weight').first()).toBeVisible();
+  });
+});
+
+test.describe('the install prompt', () => {
+  test('stays quiet on a first visit', async ({ page }) => {
+    await asNewVisitor(page);
+
+    // Asking someone to install before they have used anything converts
+    // badly, so this waits for a second visit even once the tour is done.
+    await page.getByTestId('app-tour').getByRole('button', { name: 'Skip' }).click();
+    await expect(page.getByTestId('install-prompt')).toHaveCount(0);
+  });
+
+  test('never appears when the app is already installed', async ({ page }) => {
+    await page.addInitScript(() => {
+      const real = window.matchMedia.bind(window);
+      window.matchMedia = (q: string) =>
+        q.includes('display-mode: standalone')
+          ? ({
+              matches: true,
+              media: q,
+              onchange: null,
+              addEventListener() {},
+              removeEventListener() {},
+              addListener() {},
+              removeListener() {},
+              dispatchEvent: () => false,
+            } as unknown as MediaQueryList)
+          : real(q);
+      localStorage.setItem('ironpath_visits', '9');
+    });
+
+    await page.goto('/');
+    await page.goto('/');
+    await expect(page.getByTestId('install-prompt')).toHaveCount(0);
+  });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,26 @@ export default defineConfig({
     baseURL: BASE_URL,
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
+
+    /**
+     * Every spec except onboarding.spec.ts tests the app as a *returning*
+     * user, so the first-run tour is marked as already seen here.
+     *
+     * This is not papering over anything: the tour is a full-screen overlay,
+     * and without this it intercepts the first click of every test. Adding a
+     * dismissal step to each of a hundred specs would put the tour on the
+     * critical path of tests that have nothing to do with it. The first-run
+     * path is covered directly in onboarding.spec.ts, which clears this.
+     */
+    storageState: {
+      cookies: [],
+      origins: [
+        {
+          origin: BASE_URL,
+          localStorage: [{ name: 'ironpath_tour_seen', value: '1' }],
+        },
+      ],
+    },
   },
 
   projects: [


### PR DESCRIPTION
The first-run tour, plus a separate install prompt. Built as two pieces because they want different timing.

## The tour — three steps, once

Highlights the **live element**, not a screenshot. Screenshots of your own UI rot; the calendar changed the week this was written. Pointing at the real button can't go stale and weighs nothing.

The explanation sits in a fixed panel at the bottom rather than in a tooltip anchored to the target — at 375px an anchored tooltip covers the thing it's pointing at.

| Step | |
|---|---|
| 1 | Tap any day — completed days turn green |
| 2 | Build your own workouts and exercises *(two taps deep, easy to miss)* |
| 3 | **Your history lives only on this device — export a backup** |

**Step 3 is why this exists.** Most of your users have no backup and no way back if they clear their browser, and nothing in the app has ever told them.

## The install prompt — separate, and it waits

Not part of the tour. Asking someone to install before they've used anything converts badly, so this waits for a **second visit**, and stays silent for anyone already running standalone.

Android gets a real one-tap `beforeinstallprompt` button. iOS has no install API at all, so it gets the Share glyph drawn inline and the two steps to follow — that asymmetry is Apple's.

## No "don't show again" checkbox

Skipping already means never again, so the only control worth having is **Replay welcome tour** in Settings. One less thing on screen, same outcome.

## Three things I got wrong first — all found by looking, not reasoning

**Step 2 highlighted nothing.** `scrollIntoView({ block: 'center' })` centres within the *viewport*, and the bottom third of the viewport is the tour's own panel. The halo was drawn, and moved correctly, and was completely invisible underneath the panel. The body is now padded by the panel height so there's always room to lift a target clear.

**There was never a ring.** Tailwind's `ring-2` is itself a box-shadow, so my inline `boxShadow` carrying the dimming silently replaced it. What looked like a ring in the first screenshot was just the button's own border. Both are now written out longhand — it matters most in dark mode, where dimming an already-dark page barely registers.

**My own test proved nothing.** It asserted the halo *moved* between steps — which the broken version also did. Rewritten to assert the halo is never below the top of the panel, which is the property that was actually broken. Verified by reverting the fix and watching it fail with `step 1: highlight is hidden behind the tour panel`.

## The part worth your attention

**The overlay intercepts clicks, and 76 existing specs failed on their first click.**

Rather than bolt a dismissal step onto a hundred tests that have nothing to do with onboarding, the Playwright config now marks the tour as seen by default, and `onboarding.spec.ts` clears it to cover the first-run path directly.

One real interaction: `backup.spec.ts` wipes storage on purpose to prove the backup is self-sufficient, which also wiped the tour flag — so the tour reappeared and its smooth scroll made the Settings button "not stable." It now restores just that one flag. Worth noting the underlying behaviour is **correct**: someone who genuinely clears their data is a new visitor and should see the tour again.

## Verification

```
eslint      -> 0 errors, 25 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 120 passed (7 new), run twice, clean both
build       -> ok
```

Checked visually at a phone viewport in **both themes**. Each guard confirmed load-bearing by reintroducing its regression — unrestored body padding, the old scroll call, a tour that never records being seen — and watching the matching test fail.

## What to look at when you test it

This is the first change that alters what **every** user sees on load, so it deserves more than a glance:

1. **Open it fresh** — tour should appear, three steps, each highlighting something visible
2. **Skip on step 1** — should never return, and the page should have no dead space at the bottom
3. **Settings → Replay welcome tour** — should bring it back
4. **Then just use the app normally.** That's the one that matters.

Your existing install will show the tour once, since you've never seen it. So will your wife's. That's intended — you both have months of data and no backup.
