### PR TITLE
fix: explain installing where people actually look

### DIFF
--- a/client/src/components/AppTour.tsx
+++ b/client/src/components/AppTour.tsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Button } from '@/components/ui/button';
-import { markTourSeen } from '@/lib/onboarding';
+import { isStandalone, markTourSeen } from '@/lib/onboarding';
+import { InstallGuide } from '@/components/InstallGuide';
 
 /**
- * A three-step first-run tour.
+ * The first-run tour: three steps, plus an install step for anyone not
+ * already running from a home screen.
  *
  * Two decisions worth knowing before changing this:
  *
@@ -16,19 +18,20 @@ import { markTourSeen } from '@/lib/onboarding';
  *    Screenshots of your own UI rot; the calendar changed the week this was
  *    written. Pointing at the real button cannot go stale and weighs nothing.
  *
- * Installing the app is deliberately *not* a step here. Asking someone to
- * install before they have used anything converts badly — see InstallPrompt,
- * which waits for a second visit.
+ * See INSTALL_STEP below for why installing ended up here rather than in a
+ * separately timed prompt.
  */
 
 interface Step {
-  /** Matches a `data-tour` attribute. Absent means a centred card. */
+  /** Matches a `data-tour` attribute. Absent dims the whole screen. */
   target?: string;
   title: string;
   body: string;
+  /** Renders the platform-specific install instructions under the body. */
+  install?: boolean;
 }
 
-const STEPS: Step[] = [
+const BASE_STEPS: Step[] = [
   {
     target: 'calendar',
     title: 'Your month at a glance',
@@ -46,6 +49,28 @@ const STEPS: Step[] = [
   },
 ];
 
+/**
+ * Installing is the last step rather than a separate well-timed prompt.
+ *
+ * The original design split it out, on the reasoning that install asks
+ * convert better once someone has got value from the app. That optimised the
+ * wrong thing: the actual problem is not conversion, it is that people see no
+ * app store listing, assume the app is not real, and have to be *told* this
+ * can live on a home screen. That is explanation, and explanation belongs
+ * where people are already looking.
+ *
+ * Skipped entirely for anyone already running standalone.
+ */
+const INSTALL_STEP: Step = {
+  title: 'Keep it on your home screen',
+  body: 'IronPath is not in an app store — it installs straight from the browser, which is why there is nothing to download and nothing to update.',
+  install: true,
+};
+
+function buildSteps(): Step[] {
+  return isStandalone() ? BASE_STEPS : [...BASE_STEPS, INSTALL_STEP];
+}
+
 /** Padding around the highlighted element, in px. */
 const HALO = 6;
 
@@ -60,9 +85,11 @@ export function AppTour({ onClose }: { onClose: () => void }) {
   const [index, setIndex] = useState(0);
   const [rect, setRect] = useState<Rect | null>(null);
   const panelRef = useRef<HTMLDivElement>(null);
+  // Fixed at mount: the step list must not change length underneath an index.
+  const [steps] = useState(buildSteps);
 
-  const step = STEPS[index];
-  const isLast = index === STEPS.length - 1;
+  const step = steps[index];
+  const isLast = index === steps.length - 1;
 
   const finish = useCallback(() => {
     markTourSeen();
@@ -187,7 +214,7 @@ export function AppTour({ onClose }: { onClose: () => void }) {
       >
         <div className="mx-auto max-w-md space-y-3">
           <p className="text-xs font-medium uppercase tracking-wide text-gray-500 dark:text-gray-400">
-            Step {index + 1} of {STEPS.length}
+            Step {index + 1} of {steps.length}
           </p>
           <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
             {step.title}
@@ -195,6 +222,7 @@ export function AppTour({ onClose }: { onClose: () => void }) {
           <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
             {step.body}
           </p>
+          {step.install && <InstallGuide />}
 
           <div className="flex items-center justify-between pt-1">
             <Button variant="ghost" size="sm" onClick={finish}>

--- a/client/src/components/InstallGuide.tsx
+++ b/client/src/components/InstallGuide.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import { Share } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+  canPromptInstall,
+  installRoute,
+  promptInstall,
+  subscribeToInstallability,
+} from '@/lib/install';
+
+/**
+ * How to install IronPath, wherever that question gets asked.
+ *
+ * Used in three places on purpose — the last tour step, a permanent entry in
+ * Settings, and the second-visit banner — because "why isn't this in the app
+ * store, how do I get it" is a question people ask at unpredictable moments,
+ * and the first version of this had exactly one answer point that was gated
+ * behind a visit count. Someone who skipped the tour, or whose browser never
+ * fires `beforeinstallprompt`, had nowhere to find out.
+ */
+export function InstallGuide({ onInstalled }: { onInstalled?: () => void }) {
+  const [, force] = useState(0);
+
+  // The install event can land after this renders.
+  useEffect(() => subscribeToInstallability(() => force(n => n + 1)), []);
+
+  const route = installRoute();
+  if (route === 'none') return null;
+
+  if (route === 'ios') {
+    return (
+      <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+        Tap
+        {/* The one thing people genuinely cannot find, so it is drawn rather
+            than described. */}
+        <Share className="mx-1 inline h-4 w-4 align-text-bottom" aria-label="the Share button" />
+        in Safari&rsquo;s toolbar, then <strong>Add to Home Screen</strong>. It
+        opens full screen, with no address bar, and works with no signal.
+      </p>
+    );
+  }
+
+  if (route === 'manual') {
+    return (
+      <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+        Open your browser&rsquo;s menu and choose{' '}
+        <strong>Install app</strong> or <strong>Add to Home screen</strong>. It
+        opens full screen, with no address bar, and works with no signal.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+        Add IronPath to your home screen. It opens full screen, with no address
+        bar, and works with no signal.
+      </p>
+      <Button
+        size="sm"
+        onClick={async () => {
+          const shown = await promptInstall();
+          if (shown) onInstalled?.();
+        }}
+        disabled={!canPromptInstall()}
+      >
+        Install IronPath
+      </Button>
+    </div>
+  );
+}

--- a/client/src/components/InstallPrompt.tsx
+++ b/client/src/components/InstallPrompt.tsx
@@ -1,83 +1,47 @@
 import { useEffect, useState } from 'react';
-import { Download, Share, X } from 'lucide-react';
+import { Download, X } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { InstallGuide } from '@/components/InstallGuide';
 import {
   dismissInstall,
   hasDismissedInstall,
   hasSeenTour,
-  isIOS,
   isStandalone,
   visitCount,
 } from '@/lib/onboarding';
+import { installRoute, subscribeToInstallability } from '@/lib/install';
 
 /**
- * "Add to home screen", for people who do not know that is a thing.
+ * A second-visit reminder, for people who skipped the tour.
  *
- * Not being in an app store reads to a lot of people as the app not being
- * real, and the install affordance is buried — on iOS it is inside the Share
- * sheet, which nobody finds by accident.
- *
- * Timing is deliberate: this waits for a **second visit**. Asking someone to
- * install before they have used anything converts badly, and it is also the
- * point at which the ask stops being pushy and starts being useful.
+ * This used to be the *only* place installing was explained, which was the
+ * wrong call: gated behind a visit count and behind Chrome firing
+ * `beforeinstallprompt`, it was invisible exactly when someone went looking.
+ * The tour now covers it and Settings keeps a permanent copy; this is the
+ * backstop for whoever skipped both.
  */
-
-/** Chrome's install event, which is not in lib.dom. */
-interface BeforeInstallPromptEvent extends Event {
-  prompt: () => Promise<void>;
-  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
-}
-
-function shouldConsiderPrompting(): boolean {
-  // Already installed, already said no, or still finding their feet.
+function shouldShow(): boolean {
   if (isStandalone()) return false;
   if (hasDismissedInstall()) return false;
+  // Whoever sat through the tour has already been told.
   if (!hasSeenTour()) return false;
   return visitCount() >= 2;
 }
 
 export function InstallPrompt() {
-  const [deferred, setDeferred] = useState<BeforeInstallPromptEvent | null>(null);
-  const [visible, setVisible] = useState(false);
+  const [visible, setVisible] = useState(shouldShow);
+  const [, force] = useState(0);
 
-  useEffect(() => {
-    if (!shouldConsiderPrompting()) return;
+  // `beforeinstallprompt` can land after this mounts, which changes the guide
+  // from written instructions to a one-tap button.
+  useEffect(() => subscribeToInstallability(() => force(n => n + 1)), []);
 
-    // iOS has no install API whatsoever, so instructions are the only option.
-    if (isIOS()) {
-      setVisible(true);
-      return;
-    }
-
-    const onBeforeInstall = (e: Event) => {
-      // Suppress Chrome's own mini-infobar so this is the only ask.
-      e.preventDefault();
-      setDeferred(e as BeforeInstallPromptEvent);
-      setVisible(true);
-    };
-
-    window.addEventListener('beforeinstallprompt', onBeforeInstall);
-    return () => window.removeEventListener('beforeinstallprompt', onBeforeInstall);
-  }, []);
+  if (!visible || installRoute() === 'none') return null;
 
   const close = () => {
     dismissInstall();
     setVisible(false);
   };
-
-  const install = async () => {
-    if (!deferred) return;
-    try {
-      await deferred.prompt();
-      await deferred.userChoice;
-    } catch {
-      // The browser refused to show it — nothing useful to do, and certainly
-      // nothing worth breaking the page over.
-    }
-    close();
-  };
-
-  if (!visible) return null;
 
   return (
     <div
@@ -90,29 +54,8 @@ export function InstallPrompt() {
           <p className="text-sm font-medium text-gray-900 dark:text-white">
             Install IronPath
           </p>
-
-          {isIOS() ? (
-            <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
-              Tap
-              {/* The Share glyph is the one thing people genuinely cannot find,
-                  so it is drawn inline rather than described. */}
-              <Share className="mx-1 inline h-4 w-4 align-text-bottom" aria-label="Share" />
-              in Safari&rsquo;s toolbar, then <strong>Add to Home Screen</strong>.
-              It opens full screen and works with no signal.
-            </p>
-          ) : (
-            <>
-              <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
-                Add it to your home screen. It opens full screen and works with
-                no signal.
-              </p>
-              <Button size="sm" onClick={install}>
-                Install
-              </Button>
-            </>
-          )}
+          <InstallGuide onInstalled={close} />
         </div>
-
         <Button
           variant="ghost"
           size="sm"

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -8,6 +8,24 @@ import { AutoScheduleModal } from '@/components/AutoScheduleModal';
 import { toast } from '@/hooks/use-toast';
 import { backupFilename, describeBackup, downloadJson, readJsonFile } from '@/lib/backup';
 import { resetTour } from '@/lib/onboarding';
+import { InstallGuide } from '@/components/InstallGuide';
+import { installRoute } from '@/lib/install';
+
+/** Hidden entirely once the app is installed, rather than shown as a no-op. */
+function InstallSection() {
+  if (installRoute() === 'none') return null;
+  return (
+    <>
+      <div className="space-y-2">
+        <p className="text-sm font-medium text-gray-900 dark:text-white">
+          Install IronPath
+        </p>
+        <InstallGuide />
+      </div>
+      <Separator />
+    </>
+  );
+}
 
 export function SettingsDialog({ children }: { children: React.ReactNode }) {
   const [open, setOpen] = useState(false);
@@ -129,6 +147,11 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
           </AlertDialog>
         </div>
         <Separator />
+        {/* The permanent answer to "how do I get this on my phone?".
+            Renders nothing once the app is installed. The tour covers this
+            too, but a tour is seen once and skippable — this is where someone
+            looks a week later, or when a friend asks them. */}
+        <InstallSection />
         {/* Replaces a "don't show this again" checkbox on the tour itself.
             Skipping already means never again, so the only control worth
             having is the one that brings it back. */}

--- a/client/src/lib/install.ts
+++ b/client/src/lib/install.ts
@@ -1,0 +1,75 @@
+import { isIOS, isStandalone } from '@/lib/onboarding';
+
+/**
+ * Chrome's install event, captured once and shared.
+ *
+ * `beforeinstallprompt` fires early and only fires once, so whichever
+ * component happens to mount first would otherwise swallow it and every other
+ * place that offers installing would silently have no button. Listening here,
+ * at module scope, means the event is captured before any component renders
+ * and all of them can use it.
+ */
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+let deferred: BeforeInstallPromptEvent | null = null;
+const listeners = new Set<() => void>();
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeinstallprompt', event => {
+    // Suppress Chrome's own mini-infobar so ours is the only ask.
+    event.preventDefault();
+    deferred = event as BeforeInstallPromptEvent;
+    listeners.forEach(fn => fn());
+  });
+
+  window.addEventListener('appinstalled', () => {
+    deferred = null;
+    listeners.forEach(fn => fn());
+  });
+}
+
+export function canPromptInstall(): boolean {
+  return deferred !== null;
+}
+
+export function subscribeToInstallability(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => listeners.delete(fn);
+}
+
+/** Returns true if the browser actually showed its install dialog. */
+export async function promptInstall(): Promise<boolean> {
+  if (!deferred) return false;
+  try {
+    await deferred.prompt();
+    await deferred.userChoice;
+    deferred = null;
+    listeners.forEach(fn => fn());
+    return true;
+  } catch {
+    // The browser declined to show it. Nothing useful to do, and certainly
+    // nothing worth throwing over.
+    return false;
+  }
+}
+
+export type InstallRoute = 'none' | 'prompt' | 'ios' | 'manual';
+
+/**
+ * How this particular browser can install the app.
+ *
+ * `manual` is the case that made the first version of this useless: Firefox
+ * and Samsung Internet install PWAs perfectly well but implement no
+ * `beforeinstallprompt`, so anything keyed solely on that event shows nothing
+ * at all and the user concludes it cannot be done.
+ */
+export function installRoute(): InstallRoute {
+  if (isStandalone()) return 'none';
+  if (isIOS()) return 'ios';
+  if (deferred) return 'prompt';
+  return 'manual';
+}

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -8,9 +8,9 @@ import { test, expect, type Page } from '@playwright/test';
  * intercept the first click of every test. This file is the exception: it
  * clears that flag and exercises the path a genuinely new visitor takes.
  *
- * The load-bearing test here is the last one. A tour that traps someone in an
- * overlay, or that leaves the page padded after it closes, is worse than no
- * tour at all — this app gets used mid-workout.
+ * The load-bearing one is "leaves the page usable after it closes". A tour
+ * that traps someone in an overlay, or that leaves the page padded after it
+ * closes, is worse than no tour at all — this app gets used mid-workout.
  */
 
 /**
@@ -34,12 +34,12 @@ async function asNewVisitor(page: Page) {
 }
 
 test.describe('the first-run tour', () => {
-  test('greets a new visitor and walks three steps', async ({ page }) => {
+  test('greets a new visitor and walks every step', async ({ page }) => {
     await asNewVisitor(page);
 
     const tour = page.getByTestId('app-tour');
     await expect(tour).toBeVisible();
-    await expect(tour.getByText('Step 1 of 3')).toBeVisible();
+    await expect(tour.getByText('Step 1 of 4')).toBeVisible();
     await expect(tour.getByRole('heading', { name: 'Your month at a glance' })).toBeVisible();
 
     // Scoped to the tour: a bare "Next" also matches the calendar's
@@ -53,8 +53,35 @@ test.describe('the first-run tour', () => {
     // The step that exists because most users have no backup and no way back.
     await expect(tour).toContainText('only on this device');
 
+    // And the one that exists because "why isn't this in the app store" is
+    // the question its author keeps having to answer in person.
+    await tour.getByRole('button', { name: 'Next' }).click();
+    await expect(tour.getByRole('heading', { name: 'Keep it on your home screen' })).toBeVisible();
+    await expect(tour).toContainText('not in an app store');
+    await expect(tour).toContainText(/Add to Home [Ss]creen|Install app|Install IronPath/);
+
     await tour.getByRole('button', { name: 'Got it' }).click();
     await expect(tour).toHaveCount(0);
+  });
+
+  test('drops the install step when already installed', async ({ page }) => {
+    await asNewVisitor(page);
+    await page.addInitScript(() => {
+      const real = window.matchMedia.bind(window);
+      window.matchMedia = (q: string) =>
+        q.includes('display-mode: standalone')
+          ? ({
+              matches: true, media: q, onchange: null,
+              addEventListener() {}, removeEventListener() {},
+              addListener() {}, removeListener() {},
+              dispatchEvent: () => false,
+            } as unknown as MediaQueryList)
+          : real(q);
+    });
+    await page.reload();
+
+    // Telling someone who already installed it how to install it is noise.
+    await expect(page.getByTestId('app-tour').getByText('Step 1 of 3')).toBeVisible();
   });
 
   test('keeps every highlight clear of its own panel', async ({ page }) => {
@@ -69,6 +96,8 @@ test.describe('the first-run tour', () => {
     // earlier version of this test only checked that the halo *moved* between
     // steps, which the broken code also did — so it caught nothing. What
     // matters is that the highlight is somewhere a person can actually see.
+    // Only the first three steps point at something; the install step
+    // deliberately has no target and dims the whole screen instead.
     for (let step = 1; step <= 3; step++) {
       await expect(halo).toBeVisible();
       await page.waitForTimeout(700); // smooth-scroll settle
@@ -100,6 +129,17 @@ test.describe('the first-run tour', () => {
     await page.reload();
     await expect(page.getByRole('button', { name: "Start Today's Workout" })).toBeVisible();
     await expect(page.getByTestId('app-tour')).toHaveCount(0);
+  });
+
+  test('Settings explains installing, permanently', async ({ page }) => {
+    // The durable answer, for someone who skipped the tour or is asked by a
+    // friend a week later. The tour is seen once; this never goes away.
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Settings' }).click();
+
+    const dialog = page.getByRole('dialog');
+    await expect(dialog.getByText('Install IronPath', { exact: true })).toBeVisible();
+    await expect(dialog).toContainText(/Add to Home [Ss]creen|Install app/);
   });
 
   test('can be replayed from Settings', async ({ page }) => {


### PR DESCRIPTION
Follow-up to #148. You merged before I pushed this, so it's a separate PR — the commit only ever landed on the already-merged branch, never on `main`.

**Installing was the pain point the tour was meant to solve, and it was the one thing you couldn't find.** Three reasons, all mine:

1. **Gated behind `visits >= 2`** — so on the exact visit where you saw the tour, it was guaranteed to stay silent.
2. **Required Chrome to fire `beforeinstallprompt`** — Firefox and Samsung Internet install PWAs perfectly well and implement no such event. For those users, nothing would *ever* have appeared.
3. **No permanent place to look.** Skip the tour and the subject never came up again.

## The underlying mistake

I argued for splitting install out of the tour because install *asks* convert better once someone has got value from the app. That's true, and it's the wrong frame.

Your problem isn't conversion. It's **explanation** — people see no app store listing, assume the app isn't real, and have to be told it can live on a home screen. You've been answering that question in person. Explanation belongs where people are already looking, not behind a timer.

## Three places, one shared component

| Where | Who it's for |
|---|---|
| **Last tour step** | Everyone, once. Opens with *"IronPath is not in an app store"* — the actual question people ask |
| **Settings → Install IronPath** | Someone a week later, or when a friend asks them. Permanent |
| **Second-visit banner** | Whoever skipped the tour |

All three disappear once the app is running standalone.

## `lib/install.ts`

`beforeinstallprompt` fires once, and early. Whichever component mounted first would swallow it and the other two would silently render no button — so it's captured at module scope and shared.

It also adds a **`manual` route**: written instructions for browsers with no install API at all. That's the case that made the original version useless, and you can see it working in practice — headless Chromium never fires the event, so the tour step correctly falls back to *"Open your browser's menu and choose Install app or Add to Home screen."*

## Verification

Re-run from scratch on top of current `main` rather than trusting the earlier run:

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 124 passed, run twice, clean both
build       -> ok
```

Both new guards confirmed load-bearing by removing the install step and the Settings section in turn and watching the matching test fail.

## Worth knowing when you test

**The tour is 4 steps for you and 3 for anyone already running it from a home screen.** If your phone has IronPath installed, you'll see three — that's intended.

You've already seen the tour once from #148, so it won't reappear on its own. **Settings → Replay welcome tour** to get to step 4.
