### PR TITLE
fix: stop a screen of text painting before the app loads

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -15,6 +15,27 @@
     <meta name="description" content="A free workout tracker that works entirely offline. No account, no signup, no server — your training log stays on your phone. Plan a rotation, log every set, keep your history." />
     <link rel="canonical" href="https://ironpath.app/" />
     <meta name="theme-color" content="#14B8A6" />
+
+    <!--
+      Applies the saved theme before the first paint.
+
+      `useTheme` sets this class inside a `useEffect`, which cannot run until
+      the bundle has downloaded and executed — so until then `body` renders
+      `bg-background`, which is white. Every dark-mode user has been getting a
+      full-screen white flash on cold start. Synchronous and inline on purpose:
+      deferring it, or moving it to a file, reintroduces the flash it exists to
+      prevent.
+    -->
+    <script>
+      try {
+        var stored = localStorage.getItem('theme');
+        var dark = stored === 'dark' || (stored !== 'light' &&
+          window.matchMedia('(prefers-color-scheme: dark)').matches);
+        if (dark) document.documentElement.classList.add('dark');
+      } catch (e) {
+        /* Private mode throws on localStorage; light is the safe default. */
+      }
+    </script>
     
     <!-- PWA Meta Tags -->
     <link rel="manifest" href="/manifest.json" />
@@ -93,38 +114,40 @@
   </head>
   <body>
     <!--
-      React replaces everything inside #root on mount, so this is what the app
-      looks like for the ~100ms before the bundle runs — and, more to the point,
-      it is the only thing anything that does not execute JavaScript will ever
-      see. The app is entirely client-rendered, so until this existed the most
-      substantial text on the homepage was a code comment.
+      Empty on purpose. Content used to live here so that crawlers which do not
+      execute JavaScript had something to read, and it worked — but it also
+      painted, because it carries inline styles and therefore needs nothing to
+      render. On a cold start over a slow connection that is a full screen of
+      text before the app appears.
 
-      Styles are inline on purpose: the stylesheet is a separate bundle, so
-      classes would not be applied yet and this would flash unstyled.
-
-      It doubles as the no-JavaScript fallback, which is why it names the one
-      requirement and links somewhere useful.
+      It lives in the noscript block below instead. Agents that do not run
+      JavaScript still read it in the raw HTML, which is the entire audience it
+      was written for; Google renders JavaScript and sees the real app; and the
+      JSON-LD above carries the structured description regardless. Nobody with
+      JavaScript enabled ever sees it, which is the point.
     -->
-    <div id="root">
-      <main style="max-width:34rem;margin:0 auto;padding:3rem 1.5rem;font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;color:#0f172a;line-height:1.6">
+    <div id="root"></div>
+
+    <noscript>
+      <main style="max-width:34rem;margin:0 auto;padding:3rem 1.5rem;font-family:system-ui,-apple-system,'Segoe UI',Roboto,sans-serif;line-height:1.6">
         <h1 style="font-size:1.75rem;font-weight:700;margin:0 0 .5rem">IronPath</h1>
-        <p style="font-size:1.05rem;margin:0 0 1.5rem;color:#334155">
+        <p style="font-size:1.05rem;margin:0 0 1.5rem">
           A free workout tracker that works entirely offline. No account, no signup,
-          no server — your training log stays on your phone.
+          no server &mdash; your training log stays on your phone.
         </p>
-        <ul style="margin:0 0 1.5rem;padding-left:1.1rem;color:#334155">
+        <ul style="margin:0 0 1.5rem;padding-left:1.1rem">
           <li>Plan a rotation on a calendar, or let it schedule itself</li>
           <li>Log weight, reps and rest set by set, prefilled from last time</li>
           <li>Build custom workouts and add your own exercises</li>
           <li>Works with no signal at all, and installs like an app</li>
           <li>Export a full backup whenever you want</li>
         </ul>
-        <p style="font-size:.9rem;color:#64748b;margin:0">
-          IronPath needs JavaScript to run. It is free and open source —
-          <a href="https://github.com/crflanigan/IronPath" style="color:#0d9488">source on GitHub</a>.
+        <p style="font-size:.9rem">
+          IronPath needs JavaScript to run. It is free and open source &mdash;
+          <a href="https://github.com/crflanigan/IronPath">source on GitHub</a>.
         </p>
       </main>
-    </div>
+    </noscript>
     <script type="module" src="/src/main.tsx"></script>
     
     <!--

--- a/client/src/hooks/use-theme.tsx
+++ b/client/src/hooks/use-theme.tsx
@@ -1,7 +1,15 @@
 import { useEffect, useState } from 'react';
 
 export function useTheme() {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  // Seeded from the class the inline script in index.html already applied
+  // before first paint. Starting at 'light' regardless meant the toggle showed
+  // the wrong icon until the effect below ran.
+  const [theme, setTheme] = useState<'light' | 'dark'>(() =>
+    typeof document !== 'undefined' &&
+    document.documentElement.classList.contains('dark')
+      ? 'dark'
+      : 'light',
+  );
 
   useEffect(() => {
     // Check localStorage and system preference

--- a/e2e/seo.spec.ts
+++ b/e2e/seo.spec.ts
@@ -16,13 +16,31 @@ test.describe('the crawlable surface', () => {
   test('the homepage HTML describes the app without running JavaScript', async ({ request }) => {
     const html = await (await request.get('/')).text();
 
-    // Content, not markup: an empty #root would satisfy a tag-shaped assertion.
+    // Content, not markup. What matters is that the description is present in
+    // the raw HTML, which is all a non-JS agent ever sees.
     expect(html).toContain('No account, no signup');
     expect(html).toMatch(/works entirely offline/i);
     expect(html).toContain('Log weight, reps and rest set by set');
 
-    // The old failure mode, asserted directly.
-    expect(html).not.toMatch(/<div id="root">\s*<\/div>/);
+    // It lives in <noscript> rather than in #root. An earlier version put it
+    // in #root, where crawlers read it — and so did users, as a full screen of
+    // text during a cold start, because inline styles need nothing to paint.
+    const noscript = html.match(/<noscript>([\s\S]*?)<\/noscript>/);
+    expect(noscript, 'no <noscript> fallback found').not.toBeNull();
+    expect(noscript![1]).toContain('No account, no signup');
+  });
+
+  test('nothing visible paints before the app does', async ({ page }) => {
+    // The regression that prompted this: dark text on a white page, full
+    // screen, for as long as the bundle took to arrive.
+    await page.goto('/', { waitUntil: 'commit' });
+
+    const strayText = await page.evaluate(() => {
+      const root = document.getElementById('root');
+      return (root?.textContent ?? '').trim();
+    });
+
+    expect(strayText, 'markup outside the app is painting on load').toBe('');
   });
 
   test('structured data is present and parses', async ({ request }) => {


### PR DESCRIPTION
Good catch, and you found something I'd measured badly plus a second bug that's older than my work.

## The flash is mine, and my measurement was wrong

That text is the crawler fallback from #147. I claimed it was imperceptible on the strength of **31ms median on localhost with a warm cache** — but that measured *when React replaced the content*, not how long it was on screen, under conditions nothing like a real cold start.

Reproduced properly at **6× CPU throttle on simulated slow 4G**, it's a full screen of body copy:

**Before** — dark text, full screen, on white
**After** — a clean dark screen, correct theme, then the app

The irony: I gave it inline styles specifically so it wouldn't flash *unstyled*. That's exactly what made it paint instantly and be so visible. It needs nothing to render.

**It moves to `<noscript>`.** Agents that don't execute JavaScript still read it in the raw HTML — the entire audience it was written for. Google renders JS and sees the real app either way, and the JSON-LD carries the structured description regardless. Nobody with JavaScript enabled ever sees it again, and none of #147's crawlability is lost.

## The second bug is older, and worse

You said white background. **In dark mode it should never have been white at all.**

`useTheme` applies the `dark` class inside a `useEffect`, which can't run until the bundle has downloaded and executed. Until then `body` renders `bg-background` — white.

**Every dark-mode user has had a full-screen white flash on every cold start since the theme was added.** My fallback text didn't cause it, it just made it impossible to miss.

Fixed with a synchronous inline script in `<head>` that applies the class before the first paint. `useTheme` now seeds its state from that class, so the sun/moon toggle isn't briefly wrong either.

## One more thing I got sloppy

The HTML comment above the fallback contained a literal `<noscript>` string, so the extraction regex in `seo.spec.ts` started matching **inside the comment**. The assertion still passed — the non-greedy match ran on into the real block — but it was passing by accident. Comment reworded.

## Verification

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 126 passed (1 new), run twice, clean both
```

The new guard — *"nothing visible paints before the app does"* — was confirmed load-bearing by putting markup back into `#root` and watching it fail.

Crawler surface re-checked on the built output: `noscript` contains the full description, `#root` is empty, JSON-LD present, theme script sits before `<body>`.

## What to look for

Open it cold on your phone, ideally after force-quitting. **In dark mode you should now see a dark screen briefly rather than a white one** — that gap is the bundle loading and can't be removed without code-splitting, but it should no longer be white or have text in it.
