### PR TITLE
fix: stop telling iOS Chrome users to use Safari

### DIFF
--- a/client/src/components/InstallGuide.tsx
+++ b/client/src/components/InstallGuide.tsx
@@ -7,6 +7,7 @@ import {
   promptInstall,
   subscribeToInstallability,
 } from '@/lib/install';
+import { iosBrowser } from '@/lib/onboarding';
 
 /**
  * How to install IronPath, wherever that question gets asked.
@@ -28,15 +29,37 @@ export function InstallGuide({ onInstalled }: { onInstalled?: () => void }) {
   if (route === 'none') return null;
 
   if (route === 'ios') {
+    /*
+     * Named the browser you are actually in, or named none at all.
+     *
+     * This used to say "in Safari's toolbar" to every iOS visitor, which is
+     * an instruction a Chrome user cannot follow without leaving the page
+     * first. Chrome, Firefox and Edge on iOS all have the same Share sheet
+     * and most builds offer Add to Home Screen from it — so the honest
+     * advice is to try the browser in hand, with Safari named only as the
+     * fallback that is always there.
+     */
+    const inSafari = iosBrowser() === 'safari';
+
     return (
-      <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
-        Tap
-        {/* The one thing people genuinely cannot find, so it is drawn rather
-            than described. */}
-        <Share className="mx-1 inline h-4 w-4 align-text-bottom" aria-label="the Share button" />
-        in Safari&rsquo;s toolbar, then <strong>Add to Home Screen</strong>. It
-        opens full screen, with no address bar, and works with no signal.
-      </p>
+      <div className="space-y-2">
+        <p className="text-sm leading-relaxed text-gray-600 dark:text-gray-300">
+          Tap
+          {/* The one thing people genuinely cannot find, so it is drawn
+              rather than described. */}
+          <Share className="mx-1 inline h-4 w-4 align-text-bottom" aria-label="the Share button" />
+          {inSafari ? ' in the toolbar' : ' in this browser'}, then{' '}
+          <strong>Add to Home Screen</strong>. It opens full screen, with no
+          address bar, and works with no signal.
+        </p>
+        {!inSafari && (
+          <p className="text-xs leading-relaxed text-gray-500 dark:text-gray-400">
+            No <strong>Add to Home Screen</strong> in that menu? Open{' '}
+            ironpath.app in Safari — iOS only lets Safari do it in some
+            versions.
+          </p>
+        )}
+      </div>
     );
   }
 

--- a/client/src/lib/onboarding.ts
+++ b/client/src/lib/onboarding.ts
@@ -82,6 +82,30 @@ export function isStandalone(): boolean {
 }
 
 /**
+ * Which browser this is, on iOS.
+ *
+ * Every iOS browser is WebKit underneath, and every one of them reports
+ * `Safari` in its user agent — so the alternatives have to be ruled out
+ * *before* concluding Safari, not after.
+ *
+ * This exists because the install copy used to say "tap Share in Safari's
+ * toolbar" to everyone on iOS, including people reading it in Chrome, which
+ * is an instruction you cannot follow without first leaving the page.
+ */
+export type IOSBrowser = 'safari' | 'other';
+
+export function iosBrowser(): IOSBrowser {
+  try {
+    const ua = navigator.userAgent;
+    // Chrome, Firefox, Edge and Opera on iOS, respectively.
+    if (/CriOS|FxiOS|EdgiOS|OPiOS/.test(ua)) return 'other';
+    return 'safari';
+  } catch {
+    return 'other';
+  }
+}
+
+/**
  * iOS offers no install API at all — `beforeinstallprompt` does not exist
  * there — so the only thing available is telling people where the button is.
  * Every iOS browser is WebKit underneath and shares the same Share-sheet flow.

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -207,3 +207,57 @@ test.describe('the install prompt', () => {
     await expect(page.getByTestId('install-prompt')).toHaveCount(0);
   });
 });
+
+/**
+ * iOS install copy.
+ *
+ * The instructions used to name Safari for every iOS visitor, including
+ * someone reading them in Chrome — an instruction you cannot follow without
+ * leaving the page first. Both user agents below contain the token `Safari`,
+ * which is why detection has to rule out the alternatives before concluding
+ * Safari rather than the other way round.
+ */
+const IOS_SAFARI =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 ' +
+  '(KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1';
+
+const IOS_CHROME =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 ' +
+  '(KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1';
+
+async function openInstallSection(page: Page) {
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Settings' }).click();
+  return page.getByRole('dialog');
+}
+
+test.describe('install instructions on iOS Safari', () => {
+  test.use({ userAgent: IOS_SAFARI });
+
+  test('point at the toolbar, and offer no detour', async ({ page }) => {
+    const dialog = await openInstallSection(page);
+
+    await expect(dialog).toContainText('Add to Home Screen');
+    await expect(dialog).toContainText('in the toolbar');
+    // Already in Safari — sending them to Safari would be nonsense.
+    await expect(dialog).not.toContainText('Open ironpath.app in Safari');
+  });
+});
+
+test.describe('install instructions on iOS Chrome', () => {
+  test.use({ userAgent: IOS_CHROME });
+
+  test('describe the browser in hand, with Safari only as a fallback', async ({ page }) => {
+    const dialog = await openInstallSection(page);
+
+    await expect(dialog).toContainText('in this browser');
+    await expect(dialog).toContainText('Add to Home Screen');
+
+    // The actual complaint: being told to use Safari while holding Chrome.
+    await expect(dialog).not.toContainText("in Safari's toolbar");
+    await expect(dialog).not.toContainText('in Safari’s toolbar');
+
+    // Safari is still mentioned, but as the fallback rather than the first move.
+    await expect(dialog).toContainText('No Add to Home Screen in that menu?');
+  });
+});


### PR DESCRIPTION
You're right, and it's worse than slightly-wrong copy: it's an instruction you **cannot act on without leaving the page first**.

## What it said vs. what it says

**Before**, to every iOS visitor including Chrome users:

> Tap ⬆️ in **Safari's** toolbar, then **Add to Home Screen**.

**Now**, in Chrome / Firefox / Edge on iOS:

> Tap ⬆️ **in this browser**, then **Add to Home Screen**.
>
> *No Add to Home Screen in that menu? Open ironpath.app in Safari — iOS only lets Safari do it in some versions.*

In Safari it says "in the toolbar" and offers no detour, because suggesting Safari to someone already in Safari is nonsense.

Chrome, Firefox and Edge on iOS all present the same Share sheet and most builds do offer Add to Home Screen. So the advice is now: **try the browser you're holding; Safari is the fallback, not the first move.** Your instinct that Safari might be the only way is right for some versions, which is exactly why it's kept — as a footnote in smaller text rather than the headline.

## The trap in the detection

**Every iOS browser reports `Safari` in its user agent.** iOS Chrome sends:

```
Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 …) AppleWebKit/605.1.15
(KHTML, like Gecko) CriOS/120.0.6099.119 Mobile/15E148 Safari/604.1
```

So matching on `Safari` classifies Chrome as Safari — which is presumably how the original bug got written in the first place. `CriOS`, `FxiOS`, `EdgiOS` and `OPiOS` are now ruled out *before* concluding Safari.

## Verification

Two tests driven by real user-agent strings for iOS Safari and iOS Chrome — both containing the token `Safari`, which is the whole point of the exercise.

Confirmed load-bearing two ways:

- **Restore the old copy** → both iOS tests fail
- **Break detection** so `CriOS` falls through as Safari → the Chrome test fails

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 130 passed (2 new), run twice, clean both
build       -> ok
```

## Testing it yourself

Open the deploy preview in **Chrome on your iPhone** → Settings → Install IronPath. It should describe Chrome's own Share menu and mention Safari only as the smaller fallback line. In Safari, the fallback line should be absent entirely.
