### PR TITLE
fix: the tour no longer strands the page where it scrolled to

### DIFF
--- a/client/src/components/AppTour.tsx
+++ b/client/src/components/AppTour.tsx
@@ -113,6 +113,18 @@ export function AppTour({ onClose }: { onClose: () => void }) {
     setRect({ top: r.top, left: r.left, width: r.width, height: r.height });
   }, [step.target]);
 
+  /*
+   * Where the page was before the tour touched it.
+   *
+   * Captured in a layout effect declared *ahead* of the one that scrolls,
+   * because effects run in declaration order and a plain `useEffect` would
+   * read the position after the first step had already moved it.
+   */
+  const scrollOnOpen = useRef(0);
+  useLayoutEffect(() => {
+    scrollOnOpen.current = window.scrollY;
+  }, []);
+
   // Bring the target into the part of the screen the panel is not covering.
   //
   // `scrollIntoView({ block: 'center' })` is the obvious approach and it is
@@ -139,18 +151,41 @@ export function AppTour({ onClose }: { onClose: () => void }) {
       const visibleHeight = Math.max(window.innerHeight - panelHeight, 120);
       const box = el.getBoundingClientRect();
       const delta = box.top + box.height / 2 - visibleHeight / 2;
-      window.scrollBy({ top: delta, behavior: 'smooth' });
+      // Instant, not smooth. A smooth scroll is an animation still in flight
+      // when someone taps Skip a moment later, and it lands *after* the
+      // restore below has run — so a quick dismissal stranded the page
+      // part-scrolled with the header off the top. Instant also makes the
+      // halo measurement deterministic instead of racing a settle timer.
+      window.scrollBy({ top: delta });
     }
 
-    // The scroll listener keeps the halo tracking during the smooth scroll;
-    // this is the settle-time backstop.
-    const timer = window.setTimeout(measure, 400);
+    // The scroll is instant, so the target is already in place; one frame is
+    // enough for layout to settle before measuring.
+    const frame = window.requestAnimationFrame(measure);
 
     return () => {
-      window.clearTimeout(timer);
+      window.cancelAnimationFrame(frame);
       document.body.style.paddingBottom = previousPadding;
     };
   }, [step.target, measure]);
+
+  /*
+   * Put the page back where it was found.
+   *
+   * The tour scrolls to bring each target clear of its panel and used to
+   * abandon the page wherever the last step dragged it. Dismissing part-way
+   * through left the header scrolled off the top, while the body padding
+   * lifting on unmount shrank the content underneath — dead space below.
+   *
+   * A `useEffect` on purpose: its cleanup runs after every layout-effect
+   * cleanup, so the padding is already gone and the page is back to its real
+   * height before the scroll position is set.
+   */
+  useEffect(() => {
+    return () => {
+      window.scrollTo({ top: scrollOnOpen.current, behavior: 'auto' });
+    };
+  }, []);
 
   useEffect(() => {
     window.addEventListener('resize', measure);

--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -121,6 +121,39 @@ test.describe('the first-run tour', () => {
     }
   });
 
+  test('puts the page back where it found it, whenever you leave', async ({ page }) => {
+    // Reported from real use: dismissing part-way through left the header
+    // scrolled off the top with dead space below. The tour scrolls to bring
+    // each target clear of its panel and used to abandon the page there,
+    // while the body padding lifting on unmount shrank the content underneath.
+    for (const stepsToAdvance of [0, 1, 2]) {
+      await asNewVisitor(page);
+      const tour = page.getByTestId('app-tour');
+
+      for (let i = 0; i < stepsToAdvance; i++) {
+        await tour.getByRole('button', { name: 'Next' }).click();
+        await page.waitForTimeout(700);
+      }
+      await tour.getByRole('button', { name: 'Skip' }).click();
+      await expect(tour).toHaveCount(0);
+      await page.waitForTimeout(300);
+
+      const state = await page.evaluate(() => ({
+        scrollY: Math.round(window.scrollY),
+        headerBottom:
+          document.querySelector('header')?.getBoundingClientRect().bottom ?? -1,
+        padding: document.body.style.paddingBottom,
+      }));
+
+      expect(state.scrollY, `dismissed after ${stepsToAdvance} steps`).toBe(0);
+      expect(
+        state.headerBottom,
+        `header scrolled off after dismissing at step ${stepsToAdvance + 1}`,
+      ).toBeGreaterThan(0);
+      expect(state.padding === '' || state.padding === '0px').toBe(true);
+    }
+  });
+
   test('does not come back on the next visit', async ({ page }) => {
     await asNewVisitor(page);
     await page.getByTestId('app-tour').getByRole('button', { name: 'Skip' }).click();


### PR DESCRIPTION
Both your symptoms — dead space at the bottom, top cut off — are one cause. **The tour scrolls the page and never puts it back.**

## What happens

The tour scrolls to lift each target clear of its own panel. Dismiss part-way through and you're left wherever the last step dragged you, header above the fold. At that same moment the body padding lifts on unmount, so the content shrinks underneath and the leftover scroll reads as blank space below the app.

Measured on a Pixel 7 viewport, dismissing on step two:

```
scrollY: 200   maxScroll: 200   headerVisible: false
```

Pinned to the absolute bottom with the header off screen.

## Why you couldn't reproduce it

**The tour only runs once.** Having seen it, you cannot trigger the path again — so from your side it looks like a ghost. Every new visitor can still hit it, which is why your instinct that it was "still there" was right.

I also measured the page at rest and found **0px of dead space**, which confirms it's purely the dismissal path rather than something structural.

## Two fixes, because my first one only worked if you were slow

**1. Restore the scroll position on unmount.** Captured in a layout effect declared *ahead* of the one that scrolls — effects run in declaration order, and a plain `useEffect` reads the position after the first step has already moved it. Restored from a `useEffect` cleanup, which runs after every layout-effect cleanup, so the padding is gone and the page is back to real height first.

**2. Scroll instantly rather than smoothly.** This is the one I nearly missed. A smooth scroll is an animation *still in flight* when someone taps Skip a second later — it completes **after** the restore and overwrites it. My first fix passed when I hand-tested with a 500ms pause and failed in the test suite, which clicks immediately. The suite was right: most people dismiss a tour fast.

Instant scrolling removes the race entirely, and as a bonus makes the halo measurement deterministic — the 400ms settle timer becomes a single animation frame.

## Verification

The new test dismisses at each of the first three steps and asserts the page is back at the top with the header on screen. Confirmed load-bearing twice:

| Regression reintroduced | Result |
|---|---|
| Remove the scroll restore | `scrollY: 187`, header off screen |
| Put smooth scrolling back | `scrollY: 52` |

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 128 passed, run three times, clean each time
build       -> ok
```

## Note

Stacked behind #151, which is still open. This branches from `main`, so the two don't conflict — merge in either order.
