### PR TITLE
fix: save on the way out instead of discarding the last edit

### DIFF
--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -75,7 +75,12 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     autoSaveEnabledRef.current = autoSaveEnabled;
   }, [autoSaveEnabled]);
 
-  const handleSave = useCallback(async () => {
+  /**
+   * `silent` is for the flush paths below — leaving the page or backgrounding
+   * the app. Those save on the way out, and a toast that lands on the screen
+   * you just navigated to is noise about something the user did not ask for.
+   */
+  const handleSave = useCallback(async ({ silent = false } = {}) => {
     const currentWorkout = workoutRef.current;
     if (!currentWorkout?.id) return;
 
@@ -94,7 +99,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
       lastSavedRef.current = serialized;
       setLastSavedAt(new Date());
 
-      if (autoSaveEnabledRef.current) {
+      if (autoSaveEnabledRef.current && !silent) {
         if (toastIdRef.current) {
           dismiss(toastIdRef.current);
         }
@@ -121,6 +126,48 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     const timeoutId = setTimeout(handleSave, 2000);
     return () => clearTimeout(timeoutId);
   }, [workout, autoSaveEnabled, handleSave]);
+
+  /*
+   * Save on the way out.
+   *
+   * Autosave is a trailing 2s debounce and the effect above *cancels* it on
+   * cleanup — which is right while the timer is merely being restarted by the
+   * next keystroke, and wrong when the component is going away for good. Log a
+   * set and leave within two seconds and the write never happened: measured at
+   * 700ms after an edit the value was gone, at 2500ms it was saved.
+   *
+   * `pagehide` and `visibilitychange` cover the phone being locked or the app
+   * being switched away from, which on a phone in a gym is the single most
+   * common way a workout screen stops being looked at. Neither was handled
+   * anywhere before this — an earlier check of mine claimed otherwise and was
+   * measuring the debounce firing on its own.
+   *
+   * `handleSave` returns early when the serialised workout matches the last
+   * write, so calling it on every one of these is a no-op when nothing changed.
+   */
+  const flushRef = useRef(handleSave);
+  useEffect(() => {
+    flushRef.current = handleSave;
+  }, [handleSave]);
+
+  useEffect(() => {
+    const flush = () => {
+      void flushRef.current({ silent: true });
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === 'hidden') flush();
+    };
+
+    window.addEventListener('pagehide', flush);
+    document.addEventListener('visibilitychange', onVisibility);
+
+    return () => {
+      window.removeEventListener('pagehide', flush);
+      document.removeEventListener('visibilitychange', onVisibility);
+      // Unmounting: navigating away, in-app back, or the route changing.
+      flush();
+    };
+  }, []);
 
 
   useEffect(() => {
@@ -509,7 +556,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
       {/* Action Buttons */}
       <div className="space-y-3" ref={completeRef}>
         <Button
-          onClick={handleSave}
+          onClick={() => handleSave()}
           className="w-full bg-gray-600 hover:bg-gray-700 text-white py-3 px-4 rounded-lg font-medium transition-colors"
         >
           <Save className="h-4 w-4 mr-2" />

--- a/e2e/autosave-flush.spec.ts
+++ b/e2e/autosave-flush.spec.ts
@@ -99,3 +99,57 @@ test('leaving without changing anything writes nothing and says nothing', async 
   expect(after).toBe(before);
   await expect(page.getByText('Auto-saved')).toHaveCount(0);
 });
+
+test('the flush cannot undo a completed workout', async ({ page }) => {
+  // This exists because the flush is a *write* on the way out, and completing
+  // a workout also navigates away. If the ref the flush reads were stale, the
+  // save-on-exit would quietly overwrite `completed: true` with false and the
+  // session would stop counting — a regression introduced by the fix itself.
+  const today = new Date();
+  const date = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+
+  await page.addInitScript(([d]) => {
+    const workout = {
+      id: 1,
+      date: d,
+      type: 'Chest Day',
+      exercises: [{
+        code: 'S24', machine: 'Adjustable Cable Crossover', region: 'Chest Pecs',
+        feel: 'Medium',
+        sets: [{ weight: 60, reps: 15, rest: '1:00', completed: true }],
+        bestWeight: 90, bestReps: 15, completed: true,
+      }],
+      abs: [],
+      cardio: { type: 'Treadmill', duration: '15:00', distance: '1', completed: true },
+      completed: false,
+      duration: null,
+    };
+    localStorage.setItem('ironpath_workouts', JSON.stringify([workout]));
+    localStorage.setItem('ironpath_current_id', '1');
+    localStorage.setItem('ironpath_tour_seen', '1');
+  }, [date]);
+
+  await page.goto('/workout/1');
+
+  // A workout seeded at 100% fires the celebration dialog on mount, which
+  // sits over the page. Worth noting in its own right: the celebration is
+  // reached without the workout being recorded as completed (#162).
+  const close = page.getByRole('button', { name: 'Close', exact: true });
+  if (await close.count()) {
+    await close.click();
+  }
+
+  await page.getByRole('button', { name: 'Complete Workout' }).click();
+
+  // It navigates back on a timer; wait for that, plus the flush behind it.
+  await expect(page).toHaveURL(/\/$/, { timeout: 15000 });
+  await page.waitForTimeout(600);
+
+  const stored = await page.evaluate(() => {
+    const list = JSON.parse(localStorage.getItem('ironpath_workouts') ?? '[]');
+    return { completed: list[0]?.completed, duration: list[0]?.duration };
+  });
+
+  expect(stored.completed, 'the save-on-exit reverted the completion').toBe(true);
+  expect(stored.duration).not.toBeNull();
+});

--- a/e2e/autosave-flush.spec.ts
+++ b/e2e/autosave-flush.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setNumericValue } from './helpers';
+
+/**
+ * Autosave must not lose the last thing you logged.
+ *
+ * The debounce is trailing and 2s long, and the effect that owns it cancels
+ * the pending timer on cleanup. That is correct while the timer is merely
+ * being restarted by the next keystroke, and wrong when the screen is going
+ * away — so every exit path dropped the write.
+ *
+ * Measured before the fix: 700ms after an edit the value was gone, 2500ms
+ * after it was saved. Every test here edits and leaves well inside that
+ * window, which is exactly what "log the set, pocket the phone" looks like.
+ */
+
+const WINDOW_MS = 600; // comfortably inside the 2s debounce
+
+async function openWorkoutAndEdit(page: Page, value: string) {
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  // Let the initial save settle so we are measuring the edit, not the create.
+  await page.waitForTimeout(2600);
+
+  await setNumericValue(page.getByLabel('Weight').first(), value);
+  await page.waitForTimeout(WINDOW_MS);
+}
+
+function persisted(page: Page, value: string) {
+  return page.evaluate(
+    v => (localStorage.getItem('ironpath_workouts') ?? '').includes(`"weight":${v}`),
+    value,
+  );
+}
+
+test('the in-app back arrow does not discard the last edit', async ({ page }) => {
+  await openWorkoutAndEdit(page, '185');
+  await page.getByRole('button', { name: 'Go back' }).click();
+  await expect(page).toHaveURL(/\/$/);
+
+  expect(await persisted(page, '185'), 'edit lost on in-app back').toBe(true);
+});
+
+test('browser back does not discard the last edit', async ({ page }) => {
+  await openWorkoutAndEdit(page, '186');
+  await page.goBack();
+  await expect(page).toHaveURL(/\/$/);
+
+  expect(await persisted(page, '186'), 'edit lost on browser back').toBe(true);
+});
+
+test('backgrounding the app does not discard the last edit', async ({ page }) => {
+  // A phone being locked or the app being switched away from — on a phone in
+  // a gym this is the most common way the workout screen stops being watched.
+  await openWorkoutAndEdit(page, '187');
+  await page.evaluate(() => {
+    Object.defineProperty(document, 'visibilityState', {
+      value: 'hidden',
+      configurable: true,
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+  });
+  await page.waitForTimeout(200);
+
+  expect(await persisted(page, '187'), 'edit lost when backgrounded').toBe(true);
+});
+
+test('a completed set survives leaving immediately', async ({ page }) => {
+  // Ticking a set is a change like any other, and the tick is the last thing
+  // you do before putting the phone down.
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await page.waitForTimeout(2600);
+
+  const before = await page.evaluate(() => localStorage.getItem('ironpath_workouts'));
+  await page.locator('button[aria-label^="Mark set"]').first().click();
+  await page.waitForTimeout(WINDOW_MS);
+  await page.getByRole('button', { name: 'Go back' }).click();
+  await expect(page).toHaveURL(/\/$/);
+
+  const after = await page.evaluate(() => localStorage.getItem('ironpath_workouts'));
+  expect(after, 'completed set lost on leaving').not.toBe(before);
+});
+
+test('leaving without changing anything writes nothing and says nothing', async ({ page }) => {
+  // The flush must be a no-op when there is nothing to save, or it would
+  // rewrite storage and raise a toast every time you back out of a workout.
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await page.waitForTimeout(2600);
+
+  const before = await page.evaluate(() => localStorage.getItem('ironpath_workouts'));
+  await page.getByRole('button', { name: 'Go back' }).click();
+  await expect(page).toHaveURL(/\/$/);
+  await page.waitForTimeout(400);
+
+  const after = await page.evaluate(() => localStorage.getItem('ironpath_workouts'));
+  expect(after).toBe(before);
+  await expect(page.getByText('Auto-saved')).toHaveCount(0);
+});


### PR DESCRIPTION
Closes #159 — the one where you log a set, pocket the phone, and it was never written.

## The bug

Autosave is a trailing 2s debounce, and the effect that owns it **cancels** the pending timer on cleanup. Correct while the timer is merely being restarted by the next keystroke; wrong when the screen is going away for good.

| Action | Before |
|---|---|
| Edit weight, wait **700ms**, tap back | **lost** — storage still holds the old value |
| Edit weight, wait **2500ms**, tap back | saved |

The header reads `Auto-save on` the whole time. There is never an unsaved state, so the indicator is a promise rather than a status.

## The fix

`handleSave` now runs on unmount and on `pagehide` / `visibilitychange`. It already returns early when the serialised workout matches the last write, so these are no-ops when nothing changed — **asserted in a test**, because otherwise backing out of a workout would rewrite storage and pop a toast every single time.

Flush calls pass `silent: true`. A toast that lands on the screen you have just navigated to is noise about something you didn't ask for.

## Correcting myself

I told you `pagehide` already flushed, and that the reviewer who said otherwise was wrong. **That was backwards, and I had it in writing.**

There is no `pagehide`, `visibilitychange` or `beforeunload` handler anywhere in the client — `grep` finds none. My original test dispatched the events after enough Playwright round-trips to push past the 2s debounce, and I credited the events with what the timer did on its own.

The control I should have run first:

```
WITH pagehide+visibilitychange, 505ms after edit : saved = false
WITHOUT any events,             505ms after edit : saved = false
CONTROL, 2604ms after edit                       : saved = true
```

So **locking your phone mid-workout lost the set too** — which on a phone in a gym is the most common way a workout screen stops being watched. The bug was worse than I described it.

## Verification

Five tests, one per exit path: in-app back, browser back, backgrounding, a completed-set tick, and a no-change control.

Confirmed load-bearing by deleting the flush effect — **the four data-loss tests fail, the no-op control keeps passing**, which is exactly the split you want.

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 142 passed (5 new), run twice, clean both
build       -> ok
```

## One process note

Midway through this I had four tests failing against a fix that was actually correct. Cause: I'd started `vite preview` by hand earlier, it serves a static `dist/`, and `reuseExistingServer: true` meant Playwright reused it and skipped its own build. **Every run for a stretch there was testing stale code.**

I'd flagged that hazard earlier in the week and then walked straight into it. Worth knowing it exists — if a local run ever disagrees with CI, that's the first thing to check.
