### PR TITLE
fix: three numbers on History that were not true

### DIFF
--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -82,13 +82,23 @@ export function HistoryPage() {
       avgDuration,
       currentStreak,
       weightProgress,
-      completionRate: workouts.length > 0 ? Math.round((completed.length / workouts.length) * 100) : 0
+      // Both sides of this must respect the Week/Month/Year filter. It used
+      // to divide the windowed count by *every workout ever stored*, so the
+      // number fell the longer you had been training: 50 workouts, all of them
+      // completed, reported 20%.
+      completionRate:
+        filteredWorkouts.length > 0
+          ? Math.round((completed.length / filteredWorkouts.length) * 100)
+          : 0,
     };
   }, [filteredWorkouts, workouts]);
 
   const getWorkoutsByType = () => {
     const types: { [key: string]: number } = {};
-    filteredWorkouts.forEach(workout => {
+    // Completed only, to match the headline count above. Counting every
+    // workout here let History report "0 Workouts" and, on the same screen,
+    // "Back, Biceps & Legs — 1 workouts".
+    filteredWorkouts.filter(w => w.completed).forEach(workout => {
       types[workout.type] = (types[workout.type] || 0) + 1;
     });
     return Object.entries(types).sort((a, b) => b[1] - a[1]);
@@ -241,6 +251,11 @@ export function HistoryPage() {
           <div className="space-y-3">
             {filteredWorkouts
               .filter(w => w.completed)
+              // Newest first. Without the sort this sliced an ascending list
+              // and showed the five *oldest* — so the session you just
+              // finished was the one entry guaranteed not to appear in a card
+              // called Recent.
+              .sort((a, b) => b.date.localeCompare(a.date))
               .slice(0, 5)
               .map(workout => (
                 <div

--- a/e2e/history-numbers.spec.ts
+++ b/e2e/history-numbers.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * The three numbers on History that were not telling the truth.
+ *
+ * Each is seeded rather than performed, because the point is arithmetic over a
+ * known set of workouts, not the UI that produces them.
+ */
+
+function iso(daysAgo: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function workout(id: number, daysAgo: number, completed: boolean, type = 'Chest Day') {
+  return {
+    id,
+    date: iso(daysAgo),
+    type,
+    exercises: [{
+      code: 'S24', machine: 'Adjustable Cable Crossover', region: 'Chest Pecs',
+      feel: 'Medium', sets: [{ weight: 60, reps: 15, rest: '1:00', completed }],
+      bestWeight: 90, bestReps: 15, completed,
+    }],
+    abs: [],
+    cardio: { type: 'Treadmill', duration: '15:00', distance: '1', completed },
+    completed,
+    duration: completed ? 60 : null,
+  };
+}
+
+async function seed(page: Page, records: unknown[]) {
+  await page.addInitScript(([r]) => {
+    localStorage.setItem('ironpath_workouts', JSON.stringify(r));
+    localStorage.setItem('ironpath_current_id', '999');
+    localStorage.setItem('ironpath_tour_seen', '1');
+  }, [records]);
+  await page.goto('/history');
+  await expect(page.getByText('Completion')).toBeVisible();
+}
+
+test('Completion % measures the selected window, not all of history', async ({ page }) => {
+  // Ten completed workouts inside the month, forty completed ~500 days ago.
+  // Everything is completed, so any honest window must read 100%.
+  const recent = Array.from({ length: 10 }, (_, i) => workout(i + 1, i, true));
+  const ancient = Array.from({ length: 40 }, (_, i) => workout(100 + i, 500 + i, true));
+  await seed(page, [...ancient, ...recent]);
+
+  // Dividing by the all-time total gave 20% here.
+  const rate = await page.locator('text=/^\\d+%$/').first().innerText();
+  expect(rate, 'completion rate is diluted by workouts outside the window').toBe('100%');
+});
+
+test('Recent Workouts shows the newest five, newest first', async ({ page }) => {
+  // Ten consecutive days. The newest is day 0 — the one a returning user is
+  // actually checking for.
+  await seed(page, Array.from({ length: 10 }, (_, i) => workout(i + 1, i, true)));
+
+  const rows = page.locator('text=Recent Workouts').locator('..').locator('..');
+  const shown = await rows.locator('div.font-medium').allInnerTexts();
+  expect(shown.length).toBeGreaterThan(0);
+
+  const dates = await rows.locator('div.text-sm').allInnerTexts();
+  const parsed = dates.map(d => new Date(d).getTime()).filter(n => !Number.isNaN(n));
+  expect(parsed.length, 'no dated rows found').toBeGreaterThanOrEqual(5);
+
+  // Descending, and the most recent workout must be present.
+  const sortedDesc = [...parsed].sort((a, b) => b - a);
+  expect(parsed, 'Recent Workouts is not newest-first').toEqual(sortedDesc);
+  expect(Math.max(...parsed)).toBe(sortedDesc[0]);
+
+  // Compared at day granularity: the rendered dates parse as local midnight
+  // while an ISO string parses as UTC, and the offset between them is not the
+  // thing under test.
+  expect(
+    new Date(dates[0]).toDateString(),
+    "today's workout is missing from Recent Workouts",
+  ).toBe(new Date().toDateString());
+});
+
+test('the headline count and Workout Types agree with each other', async ({ page }) => {
+  // One completed, one abandoned. History used to report "0 Workouts" beside
+  // "Chest Day — 1 workouts" after a partial session.
+  await seed(page, [workout(1, 1, true), workout(2, 0, false)]);
+
+  const headline = await page.locator('text=Workouts').first()
+    .locator('..').locator('div').first().innerText();
+  const typeRow = await page.locator('text=Workout Types').locator('..').locator('..')
+    .locator('text=/workouts?$/').first().innerText();
+
+  expect(headline.trim(), 'headline should count only completed').toBe('1');
+  expect(typeRow, 'Workout Types counted an incomplete workout').toContain('1');
+});


### PR DESCRIPTION
Closes #164, closes #165, plus the self-contradiction that surfaced while deciding *not* to fix #162.

All three live in `history.tsx`, all three are one-liners, none of them change behaviour beyond making a displayed number correct.

## Completion %

The numerator respected the Week/Month/Year filter. The denominator was **every workout ever stored**.

| Seeded | Showed | Should be |
|---|---|---|
| 50 workouts, all completed | **20%** | 100% |
| 10 workouts, all completed | 100% | 100% |
| 150 workouts, all completed | **5%** | 100% |

A metric called "Completion" that falls the longer you train, punishing exactly the people it should reward.

## Recent Workouts

`.slice(0, 5)` on an ascending list, no sort — so it showed the five **oldest**. The session you just finished, which is the reason anyone opens History, was guaranteed not to be in a card called *Recent*.

## The headline vs Workout Types

The headline counts completed workouts. Workout Types counted all of them. After an abandoned session History said **"0 Workouts"** and, on the same screen, **"Chest Day — 1 workouts."**

This one came out of deciding **not** to fix #162. You're right that the all-or-nothing gate is deliberate — an easy "done" button makes the streak meaningless, and going back to the machine is the point. But the gate being correct doesn't excuse the screen contradicting itself, and that half is independent of it.

## Verification

Three tests, seeded rather than performed, since what's under test is arithmetic over a known set of workouts.

Each confirmed load-bearing by reverting its fix in turn — **every revert breaks exactly one test**, and restoring gives three passes.

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 150 passed (3 new), run twice, clean both
build       -> ok
```

Worth a note on process: my first pass at reporting those reverts used `tail -1` on the Playwright summary, which silently swallowed the `1 failed` line and showed only `2 passed`. The runs were correct; my reading of them wasn't. Re-ran capturing both lines.

## Testing this

Open History. **Recent Workouts should have today at the top** — that's the visible one. Completion % should read 100% if you've completed everything in the window.