### PR TITLE
feat: measure workout duration instead of inventing it

### DIFF
--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -82,6 +82,7 @@ const storedWorkoutSchema = z.object({
   cardio: cardioSchema.optional().nullable(),
   completed: z.boolean().nullable().optional(),
   duration: z.number().int().nullable().optional(),
+  startedAt: z.coerce.date().nullable().optional(),
   createdAt: z.coerce.date().optional(),
   updatedAt: z.coerce.date().optional(),
 });

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -69,8 +69,14 @@ export function HistoryPage() {
   const stats = useMemo(() => {
     const completed = filteredWorkouts.filter(w => w.completed);
     const totalWorkouts = completed.length;
-    const totalDuration = completed.reduce((sum, w) => sum + (w.duration || 0), 0);
-    const avgDuration = totalWorkouts > 0 ? Math.round(totalDuration / totalWorkouts) : 0;
+    // Only workouts that were actually timed. Before durations were measured
+    // they were computed as `exercises * 5 + abs * 2 + cardio` — always 82
+    // minutes for the default workout — and averaging those together with real
+    // ones would produce a number that is neither. `startedAt` is what marks a
+    // duration as measured.
+    const timed = completed.filter(w => w.startedAt && typeof w.duration === 'number');
+    const totalDuration = timed.reduce((sum, w) => sum + (w.duration ?? 0), 0);
+    const avgDuration = timed.length > 0 ? Math.round(totalDuration / timed.length) : 0;
 
     const streakDays = localWorkoutStorage.getStreakDays();
     const currentStreak = calculateDayStreak(workouts, streakDays);

--- a/client/src/pages/workout.test.tsx
+++ b/client/src/pages/workout.test.tsx
@@ -56,6 +56,7 @@ const baseWorkout: Workout = {
   cardio: { type: 'Treadmill', duration: '', distance: '', completed: false },
   completed: false,
   duration: null,
+  startedAt: null,
   createdAt: new Date(),
   updatedAt: new Date(),
 };

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { ExerciseForm } from '@/components/exercise-form';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import type { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
-import { parseISODate, minutesFromDuration } from '@/lib/utils';
+import { parseISODate } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
 import { useCursorEndOnFocus } from '@/hooks/use-cursor-end-on-focus';
@@ -21,6 +21,12 @@ import {
   AlertDialogFooter,
   AlertDialogAction,
 } from '@/components/ui/alert-dialog';
+
+/**
+ * Above this, an elapsed time is measuring a forgotten tab rather than a
+ * session, so nothing is recorded.
+ */
+const MAX_PLAUSIBLE_MINUTES = 4 * 60;
 
 const successMessages = [
   { title: '🎉 Workout Complete!', description: 'You crushed it today.' },
@@ -87,6 +93,11 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     const serialized = JSON.stringify(currentWorkout);
     if (serialized === lastSavedRef.current) return;
 
+    // Reaching here means something actually changed, which is the honest
+    // moment a workout started — not when the record was created, since the
+    // calendar can create one hours before anybody trains.
+    const startedAt = currentWorkout.startedAt ?? new Date();
+
     try {
       await updateWorkout(currentWorkout.id, {
         exercises: currentWorkout.exercises,
@@ -94,6 +105,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         cardio: currentWorkout.cardio,
         completed: currentWorkout.completed,
         duration: currentWorkout.duration,
+        startedAt,
       });
 
       lastSavedRef.current = serialized;
@@ -279,13 +291,27 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     }
   };
 
-  const calculateWorkoutDuration = () => {
-    // Simple duration calculation based on estimated time
-    const exerciseTime = workout.exercises.length * 5; // 5 minutes per exercise
-    const absTime = workout.abs.length * 2; // 2 minutes per ab exercise
-    const entered = minutesFromDuration(workout.cardio?.duration);
-    const cardioTime = entered && entered > 15 ? Math.round(entered) : 15;
-    return exerciseTime + absTime + cardioTime;
+  /**
+   * How long the workout actually took.
+   *
+   * This used to be `exercises * 5 + abs * 2 + cardio`, which for the default
+   * workout is always exactly 82 minutes however long you were in the gym. It
+   * fed Avg Duration on History and both exports, so a fabricated number was
+   * sitting in backups looking like a measurement.
+   *
+   * Returns null rather than a guess when there is nothing to measure, or when
+   * the result is implausible. Above the cap it is not a workout, it is a tab
+   * left open — and no number is better than a wrong one.
+   */
+  const calculateWorkoutDuration = (): number | null => {
+    const startedAt = workout.startedAt ? new Date(workout.startedAt) : null;
+    if (!startedAt || Number.isNaN(startedAt.getTime())) return null;
+
+    const minutes = Math.round((Date.now() - startedAt.getTime()) / 60_000);
+    if (minutes < 0 || minutes > MAX_PLAUSIBLE_MINUTES) return null;
+
+    // A workout logged in seconds is still a workout; do not report zero.
+    return Math.max(minutes, 1);
   };
 
   const getProgressStats = () => {

--- a/e2e/autosave-flush.spec.ts
+++ b/e2e/autosave-flush.spec.ts
@@ -151,5 +151,9 @@ test('the flush cannot undo a completed workout', async ({ page }) => {
   });
 
   expect(stored.completed, 'the save-on-exit reverted the completion').toBe(true);
-  expect(stored.duration).not.toBeNull();
+  // This fixture has no `startedAt`, so there is nothing to measure and no
+  // duration is the right answer. It used to assert a number here, which was
+  // only ever the fabricated `exercises * 5 + abs * 2 + cardio`. Measured
+  // durations are covered in workout-duration.spec.ts.
+  expect(stored.duration).toBeNull();
 });

--- a/e2e/workout-duration.spec.ts
+++ b/e2e/workout-duration.spec.ts
@@ -1,0 +1,104 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Workout duration must be measured or absent — never invented.
+ *
+ * It used to be `exercises * 5 + abs * 2 + cardio`, which is exactly 82 for
+ * the default workout no matter how long you were in the gym, and it fed both
+ * Avg Duration and the exports. A fabricated number that looks measured is
+ * worse than no number, because it ends up in backups.
+ */
+
+function iso(daysAgo = 0): string {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+/** A workout ready to complete, with `startedAt` under our control. */
+function ready(startedAt: string | null, daysAgo = 0) {
+  return {
+    id: 1,
+    date: iso(daysAgo),
+    type: 'Chest Day',
+    exercises: [{
+      code: 'S24', machine: 'Adjustable Cable Crossover', region: 'Chest Pecs',
+      feel: 'Medium', sets: [{ weight: 60, reps: 15, rest: '1:00', completed: true }],
+      bestWeight: 90, bestReps: 15, completed: true,
+    }],
+    abs: [],
+    cardio: { type: 'Treadmill', duration: '15:00', distance: '1', completed: true },
+    completed: false,
+    duration: null,
+    startedAt,
+  };
+}
+
+async function completeAndRead(page: Page, record: unknown) {
+  await page.addInitScript(([w]) => {
+    localStorage.setItem('ironpath_workouts', JSON.stringify([w]));
+    localStorage.setItem('ironpath_current_id', '1');
+    localStorage.setItem('ironpath_tour_seen', '1');
+  }, [record]);
+
+  await page.goto('/workout/1');
+  const close = page.getByRole('button', { name: 'Close', exact: true });
+  if (await close.count()) await close.click();
+  await page.getByRole('button', { name: 'Complete Workout' }).click();
+  await expect(page).toHaveURL(/\/$/, { timeout: 15000 });
+  await page.waitForTimeout(500);
+
+  return page.evaluate(() => {
+    const list = JSON.parse(localStorage.getItem('ironpath_workouts') ?? '[]');
+    return { duration: list[0]?.duration, completed: list[0]?.completed };
+  });
+}
+
+test('a workout started 47 minutes ago records 47 minutes', async ({ page }) => {
+  const started = new Date(Date.now() - 47 * 60_000).toISOString();
+  const r = await completeAndRead(page, ready(started));
+
+  expect(r.completed).toBe(true);
+  // Not 82. Not a count of exercises. The elapsed time.
+  expect(r.duration).toBeGreaterThanOrEqual(46);
+  expect(r.duration).toBeLessThanOrEqual(48);
+});
+
+test('a tab left open overnight records nothing rather than 14 hours', async ({ page }) => {
+  const started = new Date(Date.now() - 14 * 60 * 60_000).toISOString();
+  const r = await completeAndRead(page, ready(started));
+
+  expect(r.completed, 'the workout should still complete').toBe(true);
+  expect(r.duration, 'an implausible elapsed time was recorded as fact').toBeNull();
+});
+
+test('a workout with no start time records no duration', async ({ page }) => {
+  // Every workout stored before durations were measured looks like this.
+  const r = await completeAndRead(page, ready(null));
+
+  expect(r.completed).toBe(true);
+  expect(r.duration, 'a duration was invented with nothing to measure').toBeNull();
+});
+
+test('the start time is stamped on the first change, not on creation', async ({ page }) => {
+  await page.addInitScript(() => localStorage.setItem('ironpath_tour_seen', '1'));
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.waitForTimeout(1200);
+
+  const beforeAnyChange = await page.evaluate(() => {
+    const list = JSON.parse(localStorage.getItem('ironpath_workouts') ?? '[]');
+    return list[list.length - 1]?.startedAt ?? null;
+  });
+  expect(beforeAnyChange, 'the clock started before the user did anything').toBeNull();
+
+  await page.locator('button[aria-label^="Mark set"]').first().click();
+  await page.waitForTimeout(2800);
+
+  const afterChange = await page.evaluate(() => {
+    const list = JSON.parse(localStorage.getItem('ironpath_workouts') ?? '[]');
+    return list[list.length - 1]?.startedAt ?? null;
+  });
+  expect(afterChange, 'no start time was recorded on the first change').not.toBeNull();
+});

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -30,7 +30,11 @@ export const workouts = pgTable("workouts", {
   abs: jsonb("abs").notNull().$type<z.infer<typeof absExerciseSchema>[]>(),
   cardio: jsonb("cardio").$type<z.infer<typeof cardioSchema>>(),
   completed: boolean("completed").default(false),
-  duration: integer("duration"), // Workout duration in minutes
+  duration: integer("duration"), // Workout duration in minutes, measured
+  // Set the first time anything in the workout changes, which is when someone
+  // actually started training — not when the record was created, since a
+  // workout can be scheduled on the calendar hours before it is done.
+  startedAt: timestamp("started_at"),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow()
 });


### PR DESCRIPTION
Closes #163.

## Correction to how I first described this

I said duration was "always 82." **That's wrong, and Casey caught it.** It varies by workout composition:

| Template | exercises | abs | reports |
|---|---|---|---|
| Chest & Triceps | 6 | 6 | 57 |
| Chest Day | 7 | 5 | 60 |
| Chest & Shoulders | 9 | 6 | 72 |
| Legs / Back & Biceps | 10 | 6 | 77 |
| Back, Biceps & Legs | 11 | 6 | 82 |

```ts
exercises.length * 5 + abs.length * 2 + cardio
```

Five distinct values across the presets, and if you enter **more than 15 minutes** of cardio it uses your real figure. So it's a composition-based estimate with a bit of genuine input — not a fabrication, and a reasonable heuristic on its own terms.

## The actual problem

**It cannot tell a 40-minute session from a 90-minute one.** Same workout type, same number, every time, regardless of what happened.

So "Avg Duration" isn't averaging durations — it's averaging how many exercises your workouts contain. That's a real quantity, just not the one the label claims, and it can't show the thing that would be interesting: whether you're getting faster at the same volume.

## What it does now

A nullable `startedAt`, stamped **the first time anything in the workout changes**. Not on creation — the calendar can create a workout hours before anyone trains. Elapsed time recorded on completion.

| Situation | Recorded |
|---|---|
| Started 47 minutes ago | **47** |
| Tab left open 14 hours | **nothing** |
| No start time (every pre-existing record) | **nothing** |

The max was the whole answer to the overnight problem. Above four hours it isn't a workout duration, and no number beats a wrong one.

## Two things worth knowing

**The schema had to learn the field.** `storedWorkoutSchema` is a `z.object`, which **strips unknown keys** — so without adding it there, a record could be written with `startedAt` and silently lose it on the next read. That would present as "the timer just doesn't work." There's a test that fails if the line goes missing; verified by deleting it.

**Old records keep their estimates.** I'm not rewriting history. They no longer feed **Avg Duration**, though — mixing estimates with measurements gives a number that's neither.

This is a better trade than I first implied, since those estimates are at least internally consistent and comparable to each other. The cost is that Avg Duration will be thin for a while and grow more meaningful as you train. Old rows still display their stored figure. **Say the word if you'd rather those be blanked** — I left them because removing something visible is the more destructive default.

## Verification

Four tests, each confirmed load-bearing:

| Regression reintroduced | Tests failed |
|---|---|
| Restore the estimate | 3 |
| Remove the 4h cap | 1 |
| Drop `startedAt` from the stored schema | 1 |

One existing assertion changed: the completion test in `autosave-flush.spec.ts` asserted a *non-null* duration on a fixture with no start time. It encoded the old behaviour; null is correct now.

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 158 passed (4 new), run twice, clean both
build       -> ok
```

## Testing it

Start a workout, tick everything, complete it, check History. **The number should match how long you actually took** — and crucially, doing the same workout type quickly versus slowly should now produce different numbers, which it never did before.
