### PR TITLE
release: v1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-express",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "type": "module",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Ten merges since `v1.2.0`. One line changed — `package.json` — because the version machinery from that release does the rest: the app reads it at build time and an end-to-end test checks it against a real production build. The three-way drift that prompted it can't recur.

## What's in it

**Data integrity**
- Autosave now saves **on the way out** instead of cancelling the pending write. Leaving within ~2s of an edit lost it — via gesture-back, or force-quitting the app.
- Workout duration is **measured**, not estimated from exercise count. Above four hours nothing is recorded, because that's a forgotten tab.

**History told three untruths**
- Completion % divided a windowed count by the all-time total, so it fell the more you trained.
- "Recent Workouts" was `slice(0,5)` with no sort — the five **oldest**.
- The headline count and Workout Types disagreed after a partial session.

**Onboarding**
- A first-run tour, with the backup warning as its third step — most users have no backup and no way back.
- Install guidance in three places, including the one that says plainly it isn't in an app store.
- A one-step tour of the template picker and a three-step tour of the builder, each shown once.
- iOS install copy no longer tells Chrome users to use Safari.

**Discoverability**
- The site was indexed but unquotable — client-rendered, so `#root` was empty in the HTML and LLM crawlers saw nothing. Description, JSON-LD, honest sitemap, `llms.txt`.

**Fixed on the way**
- A full screen of text flashing before the app loaded — plus a **white** flash every dark-mode user had been getting on every cold start since the theme was added.
- The tour stranding the page scrolled with the header off screen.

## Verification

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 174 passed, run twice, clean both
build       -> ok
grep dist   -> "1.3.0" present
```

After you merge I'll tag `v1.3.0` at the merge commit and publish the notes — as agreed, not before.