### PR TITLE
fix: make the workout dialogs scroll, and stop trapping the tour off screen

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -328,7 +328,29 @@ export function CustomWorkoutBuilderModal({
   return (
     <>
       <Dialog open={open} onOpenChange={handleOpenChange}>
-        <DialogContent className="max-h-[90vh] overflow-y-auto max-w-2xl">
+        {/*
+          * The scroll lives on the inner div, not on DialogContent.
+          *
+          * DialogContent is `position: fixed` with a `translate(-50%, -50%)`,
+          * and an `overflow-y-auto` element in that configuration is where iOS
+          * Safari's touch scrolling has long been unreliable — Radix's
+          * scroll-locking has to decide whether a touchmove belongs to an
+          * allowed scroller, and the dialog being both the boundary and the
+          * scroller is the ambiguous case. Reported as "the builder does not
+          * scroll at all" on a phone, while a wheel and a synthetic touch drag
+          * both scroll it fine in Chromium — so this removes the structure
+          * rather than chasing a reproduction that does not happen here.
+          *
+          * `overflow-hidden` on the parent keeps the child clipped to the
+          * dialog's rounded corners; `overscroll-contain` stops a flick at the
+          * end of the list from scrolling the page behind it.
+          */}
+        <DialogContent className="max-w-2xl overflow-hidden p-0">
+          {/* `grid gap-4` reproduces the spacing DialogContent used to apply
+              to these children directly; several of them carry negative top
+              margins that assume it, and without it the header and the filter
+              row overlap. */}
+          <div className="grid max-h-[90vh] gap-4 overflow-y-auto overscroll-contain p-6">
           <ErrorBoundary>
         <DialogHeader className="space-y-1">
           <DialogTitle>{template ? 'Edit Custom Workout' : 'Create Custom Workout'}</DialogTitle>
@@ -531,6 +553,7 @@ export function CustomWorkoutBuilderModal({
             />
           )}
           </ErrorBoundary>
+          </div>
       </DialogContent>
     </Dialog>
     <ExerciseImageDialog

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -72,7 +72,21 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="space-y-4">
+      {/*
+        * Scrolls on an inner element, like the builder.
+        *
+        * This dialog had no height cap and no overflow at all: with eight
+        * custom workouts it measured 1122px in an 839px viewport, hanging
+        * 143px off both the top and the bottom with nothing to scroll —
+        * which is why the fix was to delete workouts until the list fit.
+        * Adding a tour panel at the bottom then put "Got it" off screen.
+        *
+        * The scroll is on the inner div rather than DialogContent because
+        * DialogContent is `position: fixed` with a transform, which is the
+        * configuration iOS Safari handles worst.
+        */}
+      <DialogContent className="overflow-hidden p-0">
+        <div className="max-h-[85vh] space-y-4 overflow-y-auto overscroll-contain p-6">
         <DialogHeader>
           <DialogTitle>Select Workout Template</DialogTitle>
           <DialogDescription>
@@ -180,7 +194,6 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
         </div>
         {showTour && (
           <ModalTour
-            sticky={false}
             steps={TEMPLATE_STEPS}
             onDone={() => {
               markTemplateTourSeen();
@@ -188,6 +201,7 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
             }}
           />
         )}
+        </div>
       </DialogContent>
       <AlertDialog
         open={pendingDeleteId !== null}

--- a/e2e/modal-tours.spec.ts
+++ b/e2e/modal-tours.spec.ts
@@ -207,3 +207,118 @@ test.describe('the builder tour', () => {
     await expect(page.getByLabel('Workout name')).toBeVisible();
   });
 });
+
+/**
+ * Structural guard for a bug that could not be reproduced here.
+ *
+ * The builder was reported as not scrolling at all on a phone, while a wheel
+ * gesture and a synthetic touch drag both scrolled it in Chromium. The common
+ * cause for that gap is an `overflow-y-auto` on the Radix DialogContent
+ * itself, which is `position: fixed` with a transform — the configuration iOS
+ * Safari handles worst, and the ambiguous case for Radix's scroll locking.
+ *
+ * Since the symptom cannot be asserted from here, the structure is asserted
+ * instead: whatever scrolls must not be the dialog.
+ */
+test('the builder scrolls an inner element, not the dialog itself', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('ironpath_tour_seen', '1');
+    localStorage.setItem('ironpath_template_tour_seen', '1');
+    localStorage.setItem('ironpath_builder_tour_seen', '1');
+  });
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  await expect(page.getByLabel('Workout name')).toBeVisible();
+
+  const shape = await page.evaluate(() => {
+    const target = document.querySelector('[data-builder-tour="exercise-row"]')!;
+    let node = target.parentElement;
+    while (node) {
+      const o = getComputedStyle(node).overflowY;
+      if ((o === 'auto' || o === 'scroll') && node.scrollHeight > node.clientHeight) break;
+      node = node.parentElement;
+    }
+    // `closest`, not `querySelector`: the template picker stays mounted behind
+    // the builder, so a document-wide lookup returns *its* dialog and the
+    // comparison below silently compares against the wrong element. This guard
+    // passed against the exact shape it exists to reject until that was fixed.
+    const dialog = target.closest('[role="dialog"]') as HTMLElement;
+    return {
+      found: !!node,
+      isTheDialog: node === dialog,
+      scrollable: node ? node.scrollHeight > node.clientHeight : false,
+      dialogOverflow: getComputedStyle(dialog).overflowY,
+    };
+  });
+
+  expect(shape.found, 'nothing in the builder scrolls at all').toBe(true);
+  expect(shape.scrollable).toBe(true);
+  expect(
+    shape.isTheDialog,
+    'the transformed dialog is the scroll container again — the iOS-hostile shape',
+  ).toBe(false);
+  expect(shape.dialogOverflow).not.toBe('auto');
+});
+
+/**
+ * A long template picker.
+ *
+ * Reported from a real phone with eight saved custom workouts: the dialog had
+ * no height cap and no overflow at all, so it measured 1122px in an 839px
+ * viewport and hung 143px off both the top and the bottom with nothing to
+ * scroll. The workaround had been deleting custom workouts until the list fit.
+ *
+ * Adding a tour panel then put "Got it" off screen entirely, so the tour could
+ * not be dismissed. Every test here had zero custom workouts, which is why
+ * none of them noticed.
+ */
+test('the picker stays on screen and scrollable with a long list', async ({ page }) => {
+  const names = [
+    'Shoulders and Biceps', 'Shoulders, Chest, and Forearms', 'Cardio',
+    "Casey's Back, Biceps & Legs", 'Triceps and Legs', 'Caseys Legs',
+    'Bicep, Shoulders, back', 'Everything',
+  ];
+  await page.addInitScript(([list]) => {
+    localStorage.setItem('ironpath_tour_seen', '1');
+    localStorage.setItem(
+      'ironpath_custom_templates',
+      JSON.stringify((list as string[]).map((name, i) => ({
+        id: i + 1, name, exercises: [], abs: [],
+      }))),
+    );
+  }, [names]);
+
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await expect(page.getByTestId('modal-tour')).toBeVisible();
+
+  const m = await page.evaluate(() => {
+    const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+    const scroller = dialog.querySelector('div');
+    const gotIt = Array.from(dialog.querySelectorAll('button'))
+      .find(b => b.textContent?.trim() === 'Got it');
+    const d = dialog.getBoundingClientRect();
+    return {
+      fitsAbove: d.top >= 0,
+      fitsBelow: d.bottom <= window.innerHeight + 1,
+      scrolls: !!scroller && scroller.scrollHeight > scroller.clientHeight,
+      dialogOverflow: getComputedStyle(dialog).overflowY,
+      gotItReachable: gotIt ? gotIt.getBoundingClientRect().bottom <= window.innerHeight : false,
+    };
+  });
+
+  expect(m.fitsAbove, 'the dialog hangs off the top of the screen').toBe(true);
+  expect(m.fitsBelow, 'the dialog hangs off the bottom of the screen').toBe(true);
+  expect(m.scrolls, 'a list too tall to fit does not scroll').toBe(true);
+  expect(m.gotItReachable, 'the tour cannot be dismissed — Got it is off screen').toBe(true);
+  // The scroll must not be on the transformed dialog; see the builder guard.
+  expect(m.dialogOverflow).not.toBe('auto');
+
+  // And it is genuinely usable: dismiss the tour, reach the bottom of the list.
+  await page.getByTestId('modal-tour').getByRole('button', { name: 'Got it' }).click();
+  // `exact` because the row's own options button is "Options for Everything".
+  const last = page.getByRole('button', { name: 'Everything', exact: true });
+  await last.scrollIntoViewIfNeeded();
+  await expect(last, 'the bottom of the list cannot be reached').toBeVisible();
+});


### PR DESCRIPTION
Your screenshot showed it. Reproduced exactly with eight seeded custom workouts:

```
dialogTop: -143   dialogBottom: 982   viewport: 839
overflowY: "visible"          <- no scrolling at all
gotItReachable: false         <- Got it sits at 961px
```

The **template picker** had no height cap and no overflow whatsoever. With your list it's 1122px tall in an 839px viewport, hanging 143px off *both* ends with no way to scroll. That's why you'd been deleting custom workouts — it was the only thing that worked.

And my picker tour made it worse: **"Got it" was off screen, so the tour couldn't be dismissed at all.** That one's on me and it shipped two days ago.

After:

```
dialogTop: 62   dialogBottom: 777   scrolls: true   gotItReachable: true
```

## Why no test caught it

**Every existing test had zero custom workouts.** The dialog only overflows once the list is long, and nothing ever made it long. The new test seeds your eight and asserts the dialog fits the screen, the list scrolls, and Got it is reachable.

## The builder had the same shape

`overflow-y-auto` on `DialogContent`, which is `position: fixed` with a transform — the configuration iOS Safari handles worst, and the ambiguous case for Radix's scroll locking. Both dialogs now scroll an inner element.

Stated plainly: **I could not reproduce the builder symptom here.** A wheel gesture and a synthetic touch drag both scroll it fine in Chromium. So this removes the structure rather than chasing a symptom, and asserts the structure since the symptom can't be asserted from Linux.

## Two things I got wrong along the way

**The picker's tour panel is sticky again.** I made it non-sticky reasoning the dialog was short with nothing to stick to. It isn't short — I drew that from a test fixture with no custom workouts rather than from your actual data.

**The structural guard was broken and passed against the exact shape it exists to reject.** It compared the scroll container to `document.querySelector('[role="dialog"]')` — and the picker stays mounted behind the builder, so it was comparing against the wrong dialog. Reverting the builder fix left it green. Now uses `closest`, and *both* scroll guards were only confirmed load-bearing after that.

Third time this session that document-wide selector has bitten me with these stacked dialogs.

## Verification

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 178 passed (2 new), run twice, clean both
build       -> ok
```

Both dialogs screenshotted with a long list. Layout regression caught by looking: moving the scroll broke the header spacing, because `DialogContent`'s `grid gap-4` had been supplying it and several children carry negative margins that assume it.

## Testing it

On your phone with your real workout list: open **Create or Edit Custom Workout**. The dialog should fit the screen, the list should scroll under your finger, and Got it should be tappable without hunting for it. Then into the builder and check the same.

That's the one I most want you to confirm — I can't test iOS, and the whole reason for the restructure is a symptom I never saw.