### PR TITLE
fix: round the dialog corners for real, and stop Settings overflowing too

### DIFF
--- a/client/src/components/ModalTour.tsx
+++ b/client/src/components/ModalTour.tsx
@@ -188,7 +188,7 @@ export function ModalTour({
        */
       className={
         sticky
-          ? 'sticky -bottom-6 z-10 -mx-6 -mb-6 rounded-t-2xl bg-white p-5 shadow-2xl outline-none sm:rounded-b-lg dark:bg-gray-800'
+          ? 'sticky -bottom-6 z-10 -mx-6 -mb-6 rounded-t-2xl bg-white p-5 shadow-2xl outline-none rounded-b-lg dark:bg-gray-800'
           : '-mx-6 -mb-6 rounded-b-lg border-t bg-gray-50 p-5 outline-none dark:bg-gray-900/40'
       }
       stepIndex={index}

--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -99,7 +99,12 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
     <>
       <Dialog open={open} onOpenChange={setOpen}>
         <DialogTrigger asChild>{children}</DialogTrigger>
-        <DialogContent className="space-y-4">
+        {/* Same shape as the two workout dialogs: capped height, scrolling on
+            an inner element rather than on the transformed DialogContent. This
+            one had grown past the screen too — measured 868px against an 839px
+            viewport, hanging off both ends with nothing to scroll. */}
+        <DialogContent className="overflow-hidden p-0">
+        <div className="max-h-[85vh] space-y-4 overflow-y-auto overscroll-contain p-6">
         <DialogHeader>
           <DialogTitle>Settings</DialogTitle>
           <DialogDescription>Manage app data and preferences.</DialogDescription>
@@ -173,6 +178,7 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
           IronPath v{__APP_VERSION__}<br />
           Created by Casey Flanigan<br />
           This is an open source project which can be found here: https://github.com/crflanigan/IronPath
+        </div>
         </div>
         </DialogContent>
       </Dialog>

--- a/client/src/components/ui/dialog.tsx
+++ b/client/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] rounded-lg",
         className
       )}
       {...props}

--- a/e2e/modal-tours.spec.ts
+++ b/e2e/modal-tours.spec.ts
@@ -322,3 +322,74 @@ test('the picker stays on screen and scrollable with a long list', async ({ page
   await last.scrollIntoViewIfNeeded();
   await expect(last, 'the bottom of the list cannot be reached').toBeVisible();
 });
+
+/**
+ * Every dialog must fit the screen and be scrollable when it cannot.
+ *
+ * Three separate dialogs had grown past the viewport with no overflow at all —
+ * the picker (1122px in an 839px screen with eight custom workouts), the
+ * builder, and Settings. Each hung off both the top and the bottom with
+ * nothing to scroll.
+ *
+ * Also asserts the corners are actually rounded. shadcn's DialogContent ships
+ * `sm:rounded-lg`, which does nothing below 640px — so on a phone these
+ * floated as square-cornered panels, and a "fix" that matched them with
+ * `sm:rounded-b-lg` was equally inert.
+ */
+test('dialogs fit the screen, scroll when tall, and have rounded corners', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('ironpath_tour_seen', '1');
+    localStorage.setItem('ironpath_template_tour_seen', '1');
+    localStorage.setItem('ironpath_builder_tour_seen', '1');
+    localStorage.setItem(
+      'ironpath_custom_templates',
+      JSON.stringify(
+        Array.from({ length: 8 }, (_, i) => ({
+          id: i + 1, name: `Workout ${i}`, exercises: [], abs: [],
+        })),
+      ),
+    );
+  });
+
+  const inspect = () =>
+    page.evaluate(() => {
+      const dialog = document.querySelector('[role="dialog"]') as HTMLElement;
+      const box = dialog.getBoundingClientRect();
+      let scroller: HTMLElement | null = null;
+      dialog.querySelectorAll('*').forEach(n => {
+        const el = n as HTMLElement;
+        const o = getComputedStyle(el).overflowY;
+        if (!scroller && (o === 'auto' || o === 'scroll')) scroller = el;
+      });
+      return {
+        fits: box.top >= -1 && box.bottom <= window.innerHeight + 1,
+        radius: parseFloat(getComputedStyle(dialog).borderBottomLeftRadius),
+        dialogOverflow: getComputedStyle(dialog).overflowY,
+        hasInnerScroller: !!scroller,
+      };
+    });
+
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Settings' }).click();
+  let d = await inspect();
+  expect(d.fits, 'Settings hangs off the screen').toBe(true);
+  expect(d.radius, 'Settings has square corners on a phone').toBeGreaterThan(0);
+  expect(d.hasInnerScroller, 'Settings cannot scroll').toBe(true);
+  expect(d.dialogOverflow).not.toBe('auto');
+
+  await page.keyboard.press('Escape');
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  d = await inspect();
+  expect(d.fits, 'the template picker hangs off the screen').toBe(true);
+  expect(d.radius, 'the picker has square corners on a phone').toBeGreaterThan(0);
+  expect(d.hasInnerScroller, 'the picker cannot scroll').toBe(true);
+  expect(d.dialogOverflow).not.toBe('auto');
+
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  await expect(page.getByLabel('Workout name')).toBeVisible();
+  d = await inspect();
+  expect(d.fits, 'the builder hangs off the screen').toBe(true);
+  expect(d.radius, 'the builder has square corners on a phone').toBeGreaterThan(0);
+  expect(d.dialogOverflow).not.toBe('auto');
+});


### PR DESCRIPTION
Cherry-picked onto `main` — you merged #174 moments before this last commit landed on that branch, so it never made it in. Nothing new here beyond what was already reviewed.

## The flat edge was still there, and my earlier fix was inert

shadcn's `DialogContent` ships **`sm:rounded-lg`** — that only applies at 640px and up. On a phone the dialog is square-cornered, and the `sm:rounded-b-lg` I put on the tour panel to "match" it was equally inert.

Measured at 412px:

```
before:  dialog 0px    panel 0px
after:   dialog 8px    panel 8px
```

What actually improved the builder last time was reaching over the padding so no content peeked out beneath the panel. The corners were never touched. You spotted that; I'd have carried on believing it was fixed.

These dialogs float — bottom at 777 against an 839 viewport — so square corners read as unfinished rather than as a deliberate full-bleed sheet. Rounded at every width now.

## Settings had the same overflow bug

Found only because changing the shared component made me measure it:

```
top: -29    bottom: 868    viewport: 839    no scroll
```

Hanging off both ends, unscrollable. It has grown — install guidance, replay tour, backup, storage usage, version. Same treatment as the picker and the builder.

That makes **three dialogs with the identical defect, one of which was reported.**

## The guard

Checks all three for: fitting the screen, having an inner scroller, keeping overflow off the transformed `DialogContent`, and a non-zero corner radius.

Confirmed load-bearing by restoring the `sm:` prefix — fails on the corner assertion. Re-verified on this base after the cherry-pick, not just on the original branch.

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 180 passed, run twice, clean both
build       -> ok
```

## After this

`v1.3.0` is merged but **not yet tagged** — I held off so the tag would include this. Merge it and say the word, and I'll tag at the merge commit and publish the notes.