### PR TITLE
feat: allow cardio-only workouts, and call the core block Core

### DIFF
--- a/client/src/components/CustomWorkoutBuilderModal.tsx
+++ b/client/src/components/CustomWorkoutBuilderModal.tsx
@@ -241,7 +241,11 @@ export function CustomWorkoutBuilderModal({
   const isDuplicate = clashesWithTemplate || clashesWithPreset;
 
   const handleSave = () => {
-    if (name.trim() === '' || selected.size === 0 || isDuplicate) return;
+    // No exercise requirement: a workout can legitimately be cardio only —
+    // an hour of walking or running is a session. Every workout gets a cardio
+    // block attached regardless, so an empty selection still produces
+    // something to complete.
+    if (name.trim() === '' || isDuplicate) return;
     const exercises: Exercise[] = [];
     Array.from(selected).forEach(m => {
       const info = availableExercises.find(e => e.machine === m);
@@ -345,7 +349,7 @@ export function CustomWorkoutBuilderModal({
           * dialog's rounded corners; `overscroll-contain` stops a flick at the
           * end of the list from scrolling the page behind it.
           */}
-        <DialogContent className="max-w-2xl overflow-hidden p-0">
+        <DialogContent className="max-w-2xl overflow-hidden p-0" data-testid="custom-workout-builder">
           {/* `grid gap-4` reproduces the spacing DialogContent used to apply
               to these children directly; several of them carry negative top
               margins that assume it, and without it the header and the filter
@@ -354,7 +358,7 @@ export function CustomWorkoutBuilderModal({
           <ErrorBoundary>
         <DialogHeader className="space-y-1">
           <DialogTitle>{template ? 'Edit Custom Workout' : 'Create Custom Workout'}</DialogTitle>
-          <DialogDescription className="text-left">Select up to 15 exercises and name your workout.</DialogDescription>
+          <DialogDescription className="text-left">Name your workout and pick up to 15 exercises — or none, for a cardio-only session.</DialogDescription>
           <p className="text-sm text-muted-foreground text-left">Tap an exercise name to preview it.</p>
         </DialogHeader>
         
@@ -522,6 +526,11 @@ export function CustomWorkoutBuilderModal({
           {warning15 && (
             <p className="text-red-600 text-sm">🚨 Danger: Too many exercises in one session isn't effective. Consider splitting it up.</p>
           )}
+          {selected.size === 0 && selectedAbs.size === 0 && (
+            <p className="text-sm text-muted-foreground">
+              Nothing selected — this saves as a cardio-only workout.
+            </p>
+          )}
           <Input aria-label="Workout name" placeholder="Workout name" value={name} onChange={e => setName(e.target.value)} />
           <label className="flex items-center space-x-2 text-sm">
             <Checkbox
@@ -539,7 +548,7 @@ export function CustomWorkoutBuilderModal({
           {clashesWithTemplate && (
             <p className="text-red-600 text-sm">Workout name must be unique</p>
           )}
-          <Button onClick={handleSave} disabled={name.trim() === '' || selected.size === 0 || isDuplicate}>
+          <Button onClick={handleSave} disabled={name.trim() === '' || isDuplicate}>
             {template ? 'Update Workout' : 'Save Workout'}
           </Button>
         </div>

--- a/client/src/components/ModalTour.tsx
+++ b/client/src/components/ModalTour.tsx
@@ -63,7 +63,11 @@ export const BUILDER_STEPS: ModalTourStep[] = [
   {
     target: 'name-and-save',
     title: 'Name it, then save',
-    body: 'The name and Save sit below every exercise. Once saved you can put the workout on any day, or add it to your rotation.',
+    // The cardio-only case lives here rather than in step one because this
+    // step scrolls to Save — so it is read at the moment the button is in
+    // front of you, not before it means anything. Otherwise it is something
+    // you only notice after scrolling past every exercise to the bottom.
+    body: 'The name and Save sit below every exercise. Leave everything unticked and you get a cardio-only workout — useful for a run or a walk. Once saved you can put it on any day, or add it to your rotation.',
   },
 ];
 

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -434,10 +434,14 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         <div className="space-y-4">
           <h3 className="font-semibold text-gray-900 dark:text-white">Warmup</h3>
 
-          {/* Abs Section */}
+          {/* Core Section. Hidden when empty, which a cardio-only workout is:
+              an empty headed card reads as something failing to load. */}
+          {workout.abs.length > 0 && (
           <Card>
             <CardContent className="p-4">
-              <h3 className="font-semibold text-gray-900 dark:text-white mb-4">Abs Block</h3>
+              {/* "Abs Block" until core became its own muscle group and the
+                  section stopped being only abs. */}
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-4">Core Block</h3>
               <div className="space-y-3">
                 {workout.abs.map((absExercise, index) => (
                   <div key={index} className="flex items-center justify-between">
@@ -497,6 +501,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
               </div>
             </CardContent>
           </Card>
+          )}
 
           {/* Cardio Section */}
           <Card>
@@ -564,7 +569,9 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         </div>
       )}
 
-      {/* Main Workout */}
+      {/* Main Workout. A cardio-only workout has none, and a bare heading over
+          nothing looks like a rendering failure rather than an empty section. */}
+      {workout.exercises.length > 0 && (
       <div className="space-y-4">
         <h3 className="font-semibold text-gray-900 dark:text-white">Main Workout</h3>
 
@@ -578,6 +585,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
           </ErrorBoundary>
         ))}
       </div>
+      )}
 
       {/* Action Buttons */}
       <div className="space-y-3" ref={completeRef}>

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -60,7 +60,7 @@ test('the custom workout builder names every control', async ({ page }) => {
   await page.goto('/');
   await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
   await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
-  await expect(page.getByText('Select up to 15 exercises')).toBeVisible();
+  await expect(page.getByTestId('custom-workout-builder')).toBeVisible();
   expect(await unnamedControls(page)).toEqual([]);
 });
 

--- a/e2e/auto-schedule.spec.ts
+++ b/e2e/auto-schedule.spec.ts
@@ -12,7 +12,7 @@ import { test, expect, type Page } from '@playwright/test';
  * dialogs on that phrase matches the selector too once it reopens.
  */
 function builderDialog(page: Page) {
-  return page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' });
+  return page.getByTestId('custom-workout-builder');
 }
 
 /**

--- a/e2e/cardio-only.spec.ts
+++ b/e2e/cardio-only.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * A cardio-only workout.
+ *
+ * The builder required at least one exercise, so an hour of walking or running
+ * could not be recorded as a session. Every workout gets a cardio block
+ * attached whichever way it is created, so an empty selection still produces
+ * something to fill in and complete.
+ */
+
+async function openBuilder(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem('ironpath_tour_seen', '1');
+    localStorage.setItem('ironpath_template_tour_seen', '1');
+    localStorage.setItem('ironpath_builder_tour_seen', '1');
+  });
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  await expect(page.getByLabel('Workout name')).toBeVisible();
+}
+
+test('a workout with no exercises can be saved', async ({ page }) => {
+  await openBuilder(page);
+
+  const save = page.getByRole('button', { name: 'Save Workout' });
+  await expect(save, 'Save is disabled before a name is given').toBeDisabled();
+
+  await page.getByLabel('Workout name').fill('Morning Run');
+  // Nothing selected — this used to keep Save disabled forever.
+  await expect(save, 'Save is still blocked with no exercises selected').toBeEnabled();
+  await expect(page.getByText('cardio-only workout')).toBeVisible();
+
+  await save.click();
+  await expect(page.getByRole('button', { name: 'Morning Run', exact: true })).toBeVisible();
+});
+
+test('a cardio-only workout is usable and can be completed', async ({ page }) => {
+  await openBuilder(page);
+  await page.getByLabel('Workout name').fill('Long Walk');
+  await page.getByRole('button', { name: 'Save Workout' }).click();
+  // Selecting a custom template attaches it to the selected day; the day card
+  // is where you actually start it.
+  await page.getByRole('button', { name: 'Long Walk', exact: true }).click();
+  await page.getByRole('button', { name: 'Start', exact: true }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+
+  // Nothing to lift, so neither headed section should render an empty shell.
+  await expect(page.getByRole('heading', { name: 'Main Workout' })).toHaveCount(0);
+  await expect(page.getByRole('heading', { name: 'Core Block' })).toHaveCount(0);
+  await expect(page.getByRole('heading', { name: 'Cardio Block' })).toBeVisible();
+
+  // The cardio block is the whole workout, so progress is out of one item.
+  await expect(page.getByText('0/1 items')).toBeVisible();
+
+  await page.getByPlaceholder('mm:ss').first().fill('60:00');
+  await page.locator('button[aria-label^="Mark cardio"]').click();
+  await page.waitForTimeout(2600);
+
+  // Reaching 1/1 fires the celebration dialog, which sits over the page.
+  const close = page.getByRole('button', { name: 'Close', exact: true });
+  if (await close.count()) await close.click();
+
+  await page.getByRole('button', { name: 'Complete Workout' }).click();
+  await expect(page).toHaveURL(/\/$/, { timeout: 15000 });
+  await page.waitForTimeout(500);
+
+  const stored = await page.evaluate(() => {
+    const list = JSON.parse(localStorage.getItem('ironpath_workouts') ?? '[]');
+    const w = list[list.length - 1];
+    return { completed: w?.completed, exercises: w?.exercises?.length, abs: w?.abs?.length };
+  });
+  expect(stored.exercises, 'a cardio-only workout should have no exercises').toBe(0);
+  expect(stored.completed, 'a cardio-only workout could not be completed').toBe(true);
+});
+
+test('the core block is not called Abs', async ({ page }) => {
+  // Renamed when core became its own muscle group and the section stopped
+  // being only abs.
+  await page.addInitScript(() => localStorage.setItem('ironpath_tour_seen', '1'));
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page.getByRole('heading', { name: 'Core Block' })).toBeVisible();
+  await expect(page.getByText('Abs Block')).toHaveCount(0);
+});

--- a/e2e/cardio-only.spec.ts
+++ b/e2e/cardio-only.spec.ts
@@ -84,3 +84,24 @@ test('the core block is not called Abs', async ({ page }) => {
   await expect(page.getByRole('heading', { name: 'Core Block' })).toBeVisible();
   await expect(page.getByText('Abs Block')).toHaveCount(0);
 });
+
+test('the builder tour says a cardio-only workout is possible', async ({ page }) => {
+  // Otherwise it is only discoverable by scrolling past every exercise and
+  // noticing Save is enabled with nothing ticked. This step is the right home
+  // for it because the tour scrolls to Save as it shows it.
+  await page.addInitScript(() => {
+    localStorage.setItem('ironpath_tour_seen', '1');
+    localStorage.setItem('ironpath_template_tour_seen', '1');
+  });
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+
+  const tour = page.getByTestId('modal-tour');
+  await expect(tour).toBeVisible();
+  await tour.getByRole('button', { name: 'Next' }).click();
+  await tour.getByRole('button', { name: 'Next' }).click();
+
+  await expect(tour.getByRole('heading', { name: 'Name it, then save' })).toBeVisible();
+  await expect(tour, 'the tour never mentions cardio-only workouts').toContainText('cardio-only');
+});

--- a/e2e/custom-exercises.spec.ts
+++ b/e2e/custom-exercises.spec.ts
@@ -7,7 +7,7 @@ import { test, expect, type Page } from '@playwright/test';
  */
 
 function builder(page: Page) {
-  return page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' });
+  return page.getByTestId('custom-workout-builder');
 }
 
 async function openBuilder(page: Page) {

--- a/e2e/name-collision.spec.ts
+++ b/e2e/name-collision.spec.ts
@@ -10,7 +10,7 @@ import { test, expect, type Page } from '@playwright/test';
 async function openBuilder(page: Page) {
   await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
   await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
-  const builder = page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' });
+  const builder = page.getByTestId('custom-workout-builder');
   await expect(builder).toBeVisible();
   await builder.getByRole('checkbox').first().click();
   return builder;
@@ -61,7 +61,7 @@ test('renaming an existing template to its own name is still allowed', async ({ 
   await row.getByRole('button', { name: /Options for/ }).click();
   await page.getByRole('menuitem', { name: 'Edit workout' }).click();
 
-  const editor = page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' });
+  const editor = page.getByTestId('custom-workout-builder');
   await expect(editor).toBeVisible();
   // Unchanged name must not be reported as a duplicate of itself.
   await expect(editor.getByText('must be unique')).toHaveCount(0);

--- a/e2e/toggle-geometry.spec.ts
+++ b/e2e/toggle-geometry.spec.ts
@@ -32,7 +32,7 @@ async function settledBox(locator: Locator) {
 async function openBuilder(page: Page) {
   await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
   await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
-  await expect(page.getByText('Select up to 15 exercises')).toBeVisible();
+  await expect(page.getByTestId('custom-workout-builder')).toBeVisible();
 }
 
 for (const width of WIDTHS) {


### PR DESCRIPTION
Two things you raised.

## Cardio-only workouts

You're right that an hour of walking or running is a session, and the builder wouldn't save one — Save was gated on `selected.size === 0`.

The good news is nothing else needed changing: **every workout gets a cardio block attached whichever way it's created**, so an empty selection already produces something to fill in and complete. The guard on Save was the only thing in the way.

Removing it exposed two empty shells, though. A cardio-only workout rendered a headed **"Main Workout"** section with nothing under it, and an empty core card. A bare heading over nothing reads as a rendering failure, so both are hidden when empty.

The builder now says what an empty selection will do rather than leaving Save mysteriously enabled:

> *Nothing selected — this saves as a cardio-only workout.*

## Abs → Core

`Abs Block` is now `Core Block`. The section stopped being only abs when core became its own muscle group in the custom-exercises work; the label never caught up.

**The `abs` field name is untouched.** Renaming stored data to fix a caption would be a migration across everyone's history in exchange for nothing visible.

## The interesting part

Changing the builder's description copy **failed 46 tests**.

Five specs identified the builder dialog by a sentence of its own description text:

```ts
page.getByRole('dialog').filter({ hasText: 'Select up to 15 exercises' })
```

So editing one line of user-facing prose broke a third of the suite — and would again, every time the copy improves. The builder now carries a `data-testid` and those six locators use it. **No spec keys on that copy any more.**

Worth noting it failed loudly and identically twice rather than flaking, which is what made it quick to find.

## Verification

Three new tests, each confirmed load-bearing:

| Regression reintroduced | Tests failed |
|---|---|
| Require at least one exercise again | 2 |
| Rename back to "Abs Block" | 1 |
| Render the empty sections again | 1 |

```
eslint      -> 0 errors, 24 warnings
tsc         -> clean
vitest      -> 112 passed
playwright  -> 186 passed (3 new), run twice, clean both
build       -> ok
```

## Testing it

Create a workout, give it a name, **select nothing**, save. Put it on a day, start it, fill in your time and distance, tick cardio, complete. It should count as a completed workout and feed your streak.

And any existing workout should now say **Core Block** where it said Abs Block.