### PR TITLE
fix: stop the calendar drawing a sixth row of nothing

### DIFF
--- a/client/src/components/calendar-grid.test.tsx
+++ b/client/src/components/calendar-grid.test.tsx
@@ -32,7 +32,53 @@ beforeEach(() => {
   formatCalls.n = 0;
 });
 
-describe('the 42-cell day grid', () => {
+describe('the day grid', () => {
+  /**
+   * Count day cells, excluding the seven weekday headings that share the grid.
+   */
+  const dayCells = (container: HTMLElement) => {
+    const grid = container.querySelector('.grid-cols-7')!;
+    return grid.children.length - 7;
+  };
+
+  /**
+   * The grid used to pad every month to 42 cells, so it always drew six rows.
+   * Most months do not need six: 19 of the 24 months in 2026-27 had a final
+   * row of nothing but next-month filler, and February 2026 — starting on a
+   * Sunday with 28 days — drew two. Cells are `aspect-square`, so each wasted
+   * row pushed a full cell of height onto a page read on a phone.
+   */
+  it.each([
+    { month: 'February 2026', date: new Date(2026, 1, 1), cells: 28, rows: 4 },
+    { month: 'July 2026', date: new Date(2026, 6, 1), cells: 35, rows: 5 },
+    { month: 'May 2026', date: new Date(2026, 4, 1), cells: 42, rows: 6 },
+    { month: 'January 2027', date: new Date(2027, 0, 1), cells: 42, rows: 6 },
+  ])('draws $month as $cells cells, $rows rows', ({ date, cells, rows }) => {
+    const { container } = render(<CalendarGrid {...props} currentDate={date} />);
+
+    expect(dayCells(container)).toBe(cells);
+    expect(dayCells(container) / 7).toBe(rows);
+  });
+
+  it('always ends on a whole week, and never splits a month across a partial row', () => {
+    for (let m = 0; m < 12; m++) {
+      const { container, unmount } = render(
+        <CalendarGrid {...props} currentDate={new Date(2026, m, 1)} />,
+      );
+
+      const cells = dayCells(container);
+      expect(cells % 7, `month ${m + 1} does not end on a whole week`).toBe(0);
+
+      // Every day of the month must still be present — trimming the trailing
+      // row must never trim a real day.
+      const daysInMonth = new Date(2026, m + 1, 0).getDate();
+      const startingDayOfWeek = new Date(2026, m, 1).getDay();
+      expect(cells).toBeGreaterThanOrEqual(startingDayOfWeek + daysInMonth);
+
+      unmount();
+    }
+  });
+
   it('is not rebuilt on an unrelated re-render', () => {
     const { rerender } = render(<CalendarGrid {...props} />);
     const afterFirst = formatCalls.n;

--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -74,7 +74,15 @@ export function CalendarGrid({
       });
     }
 
-    const remainingDays = 42 - days.length;
+    // Pad out to a whole week, not to a fixed six rows.
+    //
+    // This used to be `42 - days.length`, so every month rendered six rows
+    // whether it needed them or not. 19 of the 24 months in 2026-27 have a
+    // sixth row containing nothing but next-month filler, and February 2026
+    // — which starts on a Sunday and has 28 days — rendered two such rows.
+    // Cells are `aspect-square`, so each one costs a full cell of height on
+    // the page above the fold.
+    const remainingDays = (7 - (days.length % 7)) % 7;
     for (let day = 1; day <= remainingDays; day++) {
       days.push({
         day,


### PR DESCRIPTION
The day grid padded every month out to 42 cells, so it always drew six rows whether the month needed them or not.

Most months do not need six. **19 of the 24 months in 2026-27** had a final row containing nothing but next-month filler — and February 2026, which starts on a Sunday and has exactly 28 days, drew *two*.

Cells are `aspect-square`, so every wasted row costs a full cell of height at the top of the page.

## Measured, July 2026, phone viewport

| | rows | calendar | page height | "Start Today's Workout" |
|---|---|---|---|---|
| before | 6 | 361px | 1039px | y=814 |
| after | 5 | 306px | 984px | y=759 |

55px back, and everything below the calendar rises with it.

The practical effect is bigger than the number suggests: **"Start Today's Workout" was clipped by the bottom edge of the viewport and is now fully on screen.** The app's primary action no longer needs a scroll to reach.

## Nothing about the look changes

Same cells, same spacing, same colours, same rounding. The only thing removed is a row of grey numbers belonging to the following month.

## The change

```diff
-    const remainingDays = 42 - days.length;
+    const remainingDays = (7 - (days.length % 7)) % 7;
```

Padding to a whole week rather than a fixed six rows, so a month that genuinely needs six still gets six.

## Guards

Tests cover the row count for February 2026 (4 rows), July 2026 (5), May 2026 and January 2027 (6), plus a sweep of all twelve months of 2026 asserting two things: the grid always ends on a whole week, and trimming the trailing row never trims a real day.

Confirmed load-bearing — restoring `42 - days.length` fails them:

```
× draws February 2026 as 28 cells, 4 rows   → expected 42 to be 28
× draws July 2026 as 35 cells, 5 rows       → expected 42 to be 35
```

## Verification

- ESLint 0 errors, `tsc --noEmit` clean
- 121 unit tests (5 new), 196 end-to-end tests pass
- Before/after measured in the running app, not inferred

🤖 Generated with [Claude Code](https://claude.com/claude-code)