### PR TITLE
fix: let Netlify's preview toolbar through the CSP, on previews only

### DIFF
--- a/client/src/lib/preview-headers.test.ts
+++ b/client/src/lib/preview-headers.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * The CSP the public site serves must stay strict.
+ *
+ * Netlify's deploy-preview toolbar is an iframe from https://app.netlify.com,
+ * which `default-src 'self'` blocks — leaving an empty bar at the bottom of
+ * every preview that cannot be dismissed. The fix relaxes `frame-src`, but
+ * only for the deploy-preview context, via a build command in netlify.toml.
+ *
+ * These guard the boundary, because the failure is quiet in both directions:
+ * a relaxation that leaked into production would weaken the site with nothing
+ * to see, and a script that silently stopped applying would leave previews
+ * broken exactly as they are now.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../..');
+const read = (rel: string) => readFileSync(path.join(REPO_ROOT, rel), 'utf-8');
+
+describe('the production CSP', () => {
+  const headers = read('client/public/_headers');
+
+  it('does not allow framing anything, including Netlify', () => {
+    expect(headers).not.toMatch(/frame-src/);
+    expect(headers).not.toMatch(/app\.netlify\.com/);
+  });
+
+  it('still forbids the app from talking to anywhere but itself', () => {
+    // The directive that makes "your training data never leaves your device"
+    // enforceable by the browser. Nothing about the preview fix may touch it.
+    expect(headers).toMatch(/connect-src 'self'/);
+  });
+});
+
+describe('the deploy-preview relaxation', () => {
+  const toml = read('netlify.toml');
+
+  /**
+   * The `command = "..."` under each section, ignoring comments.
+   *
+   * Matching raw text does not work: the comment above `[context.deploy-preview]`
+   * names the script, so a substring search finds it in the production half of
+   * the file and reports a leak that is not there.
+   */
+  const commandsByContext = () => {
+    const result: Record<string, string> = {};
+    let section = 'build';
+    for (const raw of toml.split('\n')) {
+      const line = raw.trim();
+      if (line.startsWith('#')) continue;
+      const heading = line.match(/^\[(.+)\]$/);
+      if (heading) {
+        section = heading[1];
+        continue;
+      }
+      const command = line.match(/^command\s*=\s*"(.*)"$/);
+      if (command) result[section] = command[1];
+    }
+    return result;
+  };
+
+  it('is scoped to the deploy-preview context, not the production build', () => {
+    const commands = commandsByContext();
+
+    expect(Object.keys(commands)).toContain('context.deploy-preview');
+    // The command the public site is built with must not run the relaxation.
+    expect(commands.build).toBeDefined();
+    expect(commands.build).not.toMatch(/allow-preview-toolbar/);
+  });
+
+  it('runs the script that performs it', () => {
+    const previewCommand = commandsByContext()['context.deploy-preview'] ?? '';
+
+    expect(previewCommand).toMatch(/allow-preview-toolbar\.mjs/);
+    // Still builds first — the script edits the build's output.
+    expect(previewCommand).toMatch(/npm run build\s*&&/);
+  });
+
+  it('has the script it points at', () => {
+    const script = read('scripts/allow-preview-toolbar.mjs');
+    expect(script).toMatch(/frame-src/);
+    expect(script).toMatch(/app\.netlify\.com/);
+    // It must refuse rather than no-op when the CSP is not where it expects.
+    expect(script).toMatch(/throw new Error/);
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -108,4 +108,12 @@ export default tseslint.config(
     files: ['client/public/sw.js'],
     languageOptions: { globals: { ...globals.serviceworker, ...globals.browser } },
   },
+
+  // Build scripts run under Node, not in a browser. The base config only hands
+  // Node globals to .ts/.tsx, so without this a plain `console.log` here is
+  // reported as `'console' is not defined`.
+  {
+    files: ['scripts/**/*.mjs'],
+    languageOptions: { globals: { ...globals.node } },
+  },
 );

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,14 @@
 [build]
   publish = "dist"
   command = "npm run build"
+
+# Deploy previews only. Production's command above is deliberately untouched,
+# so the CSP the public site serves is unchanged.
+#
+# Netlify injects its preview toolbar as an iframe from https://app.netlify.com,
+# which the site's `default-src 'self'` blocks — leaving a bar at the bottom of
+# every preview that cannot be dismissed. Headers in this file are global and
+# cannot be scoped to a context, but commands can, so the relaxation is applied
+# here instead. See scripts/allow-preview-toolbar.mjs.
+[context.deploy-preview]
+  command = "npm run build && node scripts/allow-preview-toolbar.mjs"

--- a/scripts/allow-preview-toolbar.mjs
+++ b/scripts/allow-preview-toolbar.mjs
@@ -1,0 +1,65 @@
+/**
+ * Let Netlify's deploy-preview toolbar through the CSP — on previews only.
+ *
+ * The toolbar is the bar at the bottom of a deploy preview. It is an iframe
+ * pointing at https://app.netlify.com, and the site's CSP declares no
+ * `frame-src`, so it falls back to `default-src 'self'` and the browser
+ * blocks it:
+ *
+ *   Framing 'https://app.netlify.com/' violates the following Content
+ *   Security Policy directive: "default-src 'self'".
+ *
+ * A blocked iframe still occupies the page, but has nothing inside it — so it
+ * covers the bottom of the preview and cannot be dismissed. That makes
+ * testing a preview on a phone materially worse, which is the whole point of
+ * having previews.
+ *
+ * Netlify's headers in `netlify.toml` are global and cannot be scoped to a
+ * deploy context, but build *commands* can. So `netlify.toml` runs this after
+ * the build for the deploy-preview context only, and production never sees it.
+ *
+ * The relaxed policy is derived from the real one rather than written out
+ * again. A second copy of the CSP would drift from the first, which is the
+ * failure this repo has already had with the version number and the licence.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+
+const HEADERS = 'dist/_headers';
+const DIRECTIVE = "frame-src 'self' https://app.netlify.com";
+
+const original = readFileSync(HEADERS, 'utf8');
+
+// Fail loudly rather than silently writing the file back unchanged. A no-op
+// here would ship a "fix" that changes nothing and looks like it worked.
+const cspLine = original
+  .split('\n')
+  .find(line => line.trim().startsWith('Content-Security-Policy:'));
+
+if (!cspLine) {
+  throw new Error(
+    `${HEADERS} has no Content-Security-Policy line — refusing to guess. ` +
+      `If the CSP moved, update this script.`,
+  );
+}
+
+if (cspLine.includes('frame-src')) {
+  throw new Error(
+    `${HEADERS} already declares frame-src. This script only knows how to add ` +
+      `one, so the two would conflict. Reconcile them by hand.`,
+  );
+}
+
+// Insert before the trailing directives so the line stays readable; any
+// position is equivalent to the browser.
+const relaxed = cspLine.replace(
+  'frame-ancestors',
+  `${DIRECTIVE}; frame-ancestors`,
+);
+
+if (relaxed === cspLine) {
+  throw new Error(`Could not insert ${DIRECTIVE} into the CSP — anchor not found.`);
+}
+
+writeFileSync(HEADERS, original.replace(cspLine, relaxed));
+
+console.log(`[preview] CSP relaxed for the Netlify toolbar: ${DIRECTIVE}`);


### PR DESCRIPTION
The bar at the bottom of every deploy preview stopped working when the CSP shipped in #178, and can't be dismissed.

## What's wrong

Netlify's preview toolbar is an **iframe** pointing at `https://app.netlify.com`. The CSP declares no `frame-src`, so it falls back to `default-src 'self'` and the browser blocks it:

```
Framing 'https://app.netlify.com/' violates the following Content Security
Policy directive: "default-src 'self'". The request has been blocked.
```

A blocked iframe still occupies space but has nothing inside it — so it covers the bottom of the preview with no close button to press. You end up clicking around it.

*(Separately: the QR code in Netlify's PR comment is **not** this. `app.netlify.com/qr-code/…` returns HTTP 502 — `error decoding lambda response` — which is Netlify's own function failing. Nothing in this repo affects it.)*

## Production is untouched

Headers in `netlify.toml` are global and [cannot be scoped to a deploy context](https://docs.netlify.com/manage/routing/headers/), but build **commands** can. So the relaxation is a context-specific command, not a header:

```toml
[build]
  publish = "dist"
  command = "npm run build"          # unchanged

[context.deploy-preview]
  command = "npm run build && node scripts/allow-preview-toolbar.mjs"
```

Verified — `npm run build` alone still emits a `dist/_headers` with **no `frame-src` at all**:

| | CSP |
|---|---|
| production | `… worker-src 'self' blob:; frame-ancestors 'none'; …` |
| deploy preview | `… worker-src 'self' blob:; frame-src 'self' https://app.netlify.com; frame-ancestors 'none'; …` |

**`connect-src 'self'` is not touched in either context.** That's the directive that makes "your training data never leaves your device" enforceable by the browser rather than a promise in the README, and it stays exactly as it is.

## The script derives rather than duplicates

It reads the CSP the build already emitted and inserts one directive. Writing the policy out a second time would let the two drift — the failure this repo already had with the version number and the licence.

It **throws** rather than no-ops when the CSP is missing or already declares `frame-src`, so a build fails loudly instead of silently deploying an unrelaxed policy that looks fixed:

```
Error: dist/_headers has no Content-Security-Policy line — refusing to guess.
Error: dist/_headers already declares frame-src. […] Reconcile them by hand.
```

Both exit non-zero.

## Guards

`client/src/lib/preview-headers.test.ts` asserts the production `_headers` never gains `frame-src` or `app.netlify.com`, that it keeps `connect-src 'self'`, and that only the deploy-preview command runs the script.

Confirmed load-bearing against both regressions:

```
× does not allow framing anything, including Netlify        (frame-src added to production _headers)
× is scoped to the deploy-preview context, not production   (script leaked into the production command)
```

My first version of the scoping test failed against *correct* config — it substring-matched the file, and the comment above `[context.deploy-preview]` names the script. It now parses `command =` lines per section.

## Also

ESLint gave Node globals only to `.ts`/`.tsx`, so `console.log` in a `.mjs` build script was an error. Added a block for `scripts/**/*.mjs`.

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **126 unit tests** (5 new), **196 end-to-end tests** pass
- Production build confirmed to contain no `frame-src`

**This PR's own deploy preview is the end-to-end test** — it builds under the `deploy-preview` context, so if the toolbar appears and closes, the fix works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)