### PR TITLE
fix: give the reference-photo button a 44px tap target, at no layout cost

### DIFF
--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -136,7 +136,23 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
               <button
                 type="button"
                 onClick={() => setShowHelp(true)}
-                className="text-gray-500 hover:text-primary"
+                /*
+                 * The icon is 20x20 — a hard thing to hit accurately with a
+                 * thumb, one-handed, between sets, which is exactly how this
+                 * screen is used.
+                 *
+                 * `before` is a 44x44 hit area centred on the icon. It is
+                 * absolutely positioned, so it takes part in no layout and the
+                 * row height does not change. Growing the button itself would
+                 * add roughly 400px to this page, which is the opposite of
+                 * what it needs.
+                 *
+                 * Safe to expand here specifically: the nearest neighbouring
+                 * control measures 59px away, and this zone reaches 12px per
+                 * side, leaving ~47px of separation. It cannot steal an
+                 * adjacent tap.
+                 */
+                className="relative text-gray-500 hover:text-primary before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-['']"
               >
                 <HelpCircle className="h-5 w-5" />
                 <span className="sr-only">{`Show reference photo for ${localExercise.machine}`}</span>

--- a/e2e/tap-targets.spec.ts
+++ b/e2e/tap-targets.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function startTodaysWorkout(page: Page) {
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.waitForTimeout(1200);
+}
+
+/**
+ * The reference-photo button is a 20x20 icon on the screen used one-handed,
+ * in a gym, between sets. Its hit area is expanded to 44x44 with an absolutely
+ * positioned pseudo-element rather than by growing the button, because growing
+ * every undersized control on this page would add ~400px to a page that is
+ * already 4472px on an 839px screen.
+ *
+ * Two things therefore have to hold, and the second is the one that would make
+ * this a bad trade:
+ *
+ *   1. the tap area really is bigger, and the row height really is unchanged
+ *   2. the bigger area does not swallow taps meant for the control beside it
+ */
+
+test.describe('the reference-photo button', () => {
+  test('is tappable well outside the 20px icon, without moving anything', async ({ page }) => {
+    await startTodaysWorkout(page);
+
+    const photo = page.getByRole('button', { name: /Show reference photo/ }).first();
+    await expect(photo).toBeVisible();
+
+    // The workout page is ~4500px tall, so this button starts below the fold.
+    // Without scrolling it into view, boundingBox() gives coordinates outside
+    // the viewport and the click lands on nothing — which looks exactly like
+    // the hit area not working.
+    await photo.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
+
+    const pageHeightBefore = await page.evaluate(() => document.body.scrollHeight);
+    const box = (await photo.boundingBox())!;
+
+    // The drawn control is still small — this fix must not change the layout.
+    expect(Math.round(box.width)).toBeLessThanOrEqual(24);
+    expect(Math.round(box.height)).toBeLessThanOrEqual(24);
+
+    // Tap 16px above the centre. That is outside the icon entirely, and inside
+    // the 44px zone (which reaches 22px from the centre).
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2 - 16);
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    // Nothing reflowed as a result of the larger target.
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog')).toBeHidden();
+    expect(await page.evaluate(() => document.body.scrollHeight)).toBe(pageHeightBefore);
+  });
+
+  test('does not steal the tap meant for the control next to it', async ({ page }) => {
+    await startTodaysWorkout(page);
+
+    const photo = page.getByRole('button', { name: /Show reference photo/ }).first();
+    await photo.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
+    const photoBox = (await photo.boundingBox())!;
+
+    // Find the nearest other control and click its centre. If the expanded
+    // zone overlapped it, this would open the photo dialog instead.
+    const neighbour = await page.evaluate(({ cx, cy }) => {
+      const controls = Array.from(document.querySelectorAll('button, input'))
+        .map(el => {
+          const b = el.getBoundingClientRect();
+          return { el, x: b.left + b.width / 2, y: b.top + b.height / 2, w: b.width, h: b.height,
+                   label: (el.getAttribute('aria-label') || el.textContent || '').trim() };
+        })
+        .filter(c => c.w > 0 && c.h > 0 && !/Show reference photo/.test(c.label));
+
+      let best = null as null | typeof controls[0];
+      let bestD = Infinity;
+      for (const c of controls) {
+        const d = Math.hypot(c.x - cx, c.y - cy);
+        if (d < bestD) { bestD = d; best = c; }
+      }
+      return best ? { x: best.x, y: best.y, label: best.label, distance: Math.round(bestD) } : null;
+    }, { cx: photoBox.x + photoBox.width / 2, cy: photoBox.y + photoBox.height / 2 });
+
+    expect(neighbour, 'no neighbouring control found').not.toBeNull();
+
+    await page.mouse.click(neighbour!.x, neighbour!.y);
+    await page.waitForTimeout(300);
+
+    // The photo dialog must not have opened. Whatever the neighbour does is
+    // its own business; what matters is that the photo button did not win.
+    const dialogs = page.getByRole('dialog').filter({ hasText: /reference|photo/i });
+    await expect(dialogs).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
The reference-photo button is a **20×20** icon, on the screen used one-handed in a gym between sets. Every other control on that page is 36–40px; this one is 20.

## Why not just make everything bigger

I measured before recommending anything. The workout page has **132 controls across 53 rows**, and is already **4,472px** on an 839px viewport.

Growing every row to 44px would add **+404px** — about half a screen more scrolling. That's the opposite of what this page needs, and would undo the calendar work in #192.

So the hit area grows without the drawn control changing size: a 44×44 `::before` pseudo-element, absolutely positioned and centred on the icon. It participates in no layout.

## Proof it works

Walking outward from the button's centre with `elementFromPoint`:

| offset from centre | element hit |
|---|---|
| 0px | **the button** |
| −14px | **the button** |
| −20px | **the button** |
| −24px | the card behind it — correctly *outside* the 44px zone |
| +20px | **the button** |

And the cost:

| | page height | icon size |
|---|---|---|
| before | 4,472px | 20×20 |
| after | **4,472px** | **20×20** |

Nothing moved. Nothing got bigger on screen. The target is now 44px.

## Why only this one control

Expanding a hit area is only safe where there's room, so I measured clearance to the nearest neighbouring control:

| control | nearest neighbour |
|---|---|
| reference-photo buttons | **59px** (median 61) |
| completion circles | **8px** |

59px is ample — the zone reaches 12px per side and still leaves ~47px of separation.

The **36px completion circles have only 8px**, so expanding those would make adjacent targets abut. They need a different approach and are deliberately left alone. The ~103 inputs at 40px are 4px short and 56–64px wide — already easy to hit, and where the entire 404px would come from.

## Guards

`e2e/tap-targets.spec.ts`:

1. **The target really is bigger** — clicks 16px above the centre, outside the icon entirely, and expects the dialog. Also asserts the drawn control stays under 24px and the page height doesn't change. **Confirmed load-bearing**: reverting the className fails it in both browser projects.
2. **It doesn't steal a neighbour's tap** — clicks the nearest other control and asserts the photo dialog does *not* open. A hit area that swallows adjacent taps would be worse than the small target it replaced. This one passes with and without the fix **by design** — it's a safety check, not a fix detector.

My first version of test 1 failed against *correct* code: it never scrolled the button into view, so `boundingBox()` returned coordinates outside the viewport and the click landed on nothing — indistinguishable from the hit area not working.

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **126 unit tests**, **200 end-to-end tests** pass
- Page height measured identical before and after

🤖 Generated with [Claude Code](https://claude.com/claude-code)