### PR TITLE
fix: separate the Core Block ticks, which are the ones actually mis-tapped

### DIFF
--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -136,7 +136,23 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
               <button
                 type="button"
                 onClick={() => setShowHelp(true)}
-                className="text-gray-500 hover:text-primary"
+                /*
+                 * The icon is 20x20 — a hard thing to hit accurately with a
+                 * thumb, one-handed, between sets, which is exactly how this
+                 * screen is used.
+                 *
+                 * `before` is a 44x44 hit area centred on the icon. It is
+                 * absolutely positioned, so it takes part in no layout and the
+                 * row height does not change. Growing the button itself would
+                 * add roughly 400px to this page, which is the opposite of
+                 * what it needs.
+                 *
+                 * Safe to expand here specifically: the nearest neighbouring
+                 * control measures 59px away, and this zone reaches 12px per
+                 * side, leaving ~47px of separation. It cannot steal an
+                 * adjacent tap.
+                 */
+                className="relative text-gray-500 hover:text-primary before:absolute before:left-1/2 before:top-1/2 before:h-11 before:w-11 before:-translate-x-1/2 before:-translate-y-1/2 before:content-['']"
               >
                 <HelpCircle className="h-5 w-5" />
                 <span className="sr-only">{`Show reference photo for ${localExercise.machine}`}</span>

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -442,7 +442,24 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
               {/* "Abs Block" until core became its own muscle group and the
                   section stopped being only abs. */}
               <h3 className="font-semibold text-gray-900 dark:text-white mb-4">Core Block</h3>
-              <div className="space-y-3">
+              {/*
+                * space-y-3 put 16px between one row's tick and the next one's.
+                *
+                * These six sit in a column and are the controls people actually
+                * mis-tap — reaching for one and unchecking the row above. The
+                * set-completion circles are 304px apart and have never had the
+                * problem.
+                *
+                * The fix is separation, not a bigger target: at 36px tall with a
+                * 16px gap, widening the tap area to the usual 44px would cut the
+                * gap to 8px, and taps that currently land in dead space and do
+                * nothing would start hitting the neighbour instead. The dead
+                * zone is what protects you here, so it gets bigger: 16px -> 24px.
+                *
+                * Costs ~40px on a 4472px page, because the Core Block is six
+                * rows rather than the fifty this page has in total.
+                */}
+              <div className="space-y-5">
                 {workout.abs.map((absExercise, index) => (
                   <div key={index} className="flex items-center justify-between">
                     <span className="text-sm font-medium text-gray-700 dark:text-gray-300">

--- a/e2e/tap-targets.spec.ts
+++ b/e2e/tap-targets.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, type Page } from '@playwright/test';
+
+async function startTodaysWorkout(page: Page) {
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.waitForTimeout(1200);
+}
+
+/**
+ * The reference-photo button is a 20x20 icon on the screen used one-handed,
+ * in a gym, between sets. Its hit area is expanded to 44x44 with an absolutely
+ * positioned pseudo-element rather than by growing the button, because growing
+ * every undersized control on this page would add ~400px to a page that is
+ * already 4472px on an 839px screen.
+ *
+ * Two things therefore have to hold, and the second is the one that would make
+ * this a bad trade:
+ *
+ *   1. the tap area really is bigger, and the row height really is unchanged
+ *   2. the bigger area does not swallow taps meant for the control beside it
+ */
+
+test.describe('the reference-photo button', () => {
+  test('is tappable well outside the 20px icon, without moving anything', async ({ page }) => {
+    await startTodaysWorkout(page);
+
+    const photo = page.getByRole('button', { name: /Show reference photo/ }).first();
+    await expect(photo).toBeVisible();
+
+    // The workout page is ~4500px tall, so this button starts below the fold.
+    // Without scrolling it into view, boundingBox() gives coordinates outside
+    // the viewport and the click lands on nothing — which looks exactly like
+    // the hit area not working.
+    await photo.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
+
+    const pageHeightBefore = await page.evaluate(() => document.body.scrollHeight);
+    const box = (await photo.boundingBox())!;
+
+    // The drawn control is still small — this fix must not change the layout.
+    expect(Math.round(box.width)).toBeLessThanOrEqual(24);
+    expect(Math.round(box.height)).toBeLessThanOrEqual(24);
+
+    // Tap 16px above the centre. That is outside the icon entirely, and inside
+    // the 44px zone (which reaches 22px from the centre).
+    await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2 - 16);
+
+    await expect(page.getByRole('dialog')).toBeVisible();
+
+    // Nothing reflowed as a result of the larger target.
+    await page.keyboard.press('Escape');
+    await expect(page.getByRole('dialog')).toBeHidden();
+    expect(await page.evaluate(() => document.body.scrollHeight)).toBe(pageHeightBefore);
+  });
+
+  test('does not steal the tap meant for the control next to it', async ({ page }) => {
+    await startTodaysWorkout(page);
+
+    const photo = page.getByRole('button', { name: /Show reference photo/ }).first();
+    await photo.scrollIntoViewIfNeeded();
+    await page.waitForTimeout(200);
+    const photoBox = (await photo.boundingBox())!;
+
+    // Find the nearest other control and click its centre. If the expanded
+    // zone overlapped it, this would open the photo dialog instead.
+    const neighbour = await page.evaluate(({ cx, cy }) => {
+      const controls = Array.from(document.querySelectorAll('button, input'))
+        .map(el => {
+          const b = el.getBoundingClientRect();
+          return { el, x: b.left + b.width / 2, y: b.top + b.height / 2, w: b.width, h: b.height,
+                   label: (el.getAttribute('aria-label') || el.textContent || '').trim() };
+        })
+        .filter(c => c.w > 0 && c.h > 0 && !/Show reference photo/.test(c.label));
+
+      let best = null as null | typeof controls[0];
+      let bestD = Infinity;
+      for (const c of controls) {
+        const d = Math.hypot(c.x - cx, c.y - cy);
+        if (d < bestD) { bestD = d; best = c; }
+      }
+      return best ? { x: best.x, y: best.y, label: best.label, distance: Math.round(bestD) } : null;
+    }, { cx: photoBox.x + photoBox.width / 2, cy: photoBox.y + photoBox.height / 2 });
+
+    expect(neighbour, 'no neighbouring control found').not.toBeNull();
+
+    await page.mouse.click(neighbour!.x, neighbour!.y);
+    await page.waitForTimeout(300);
+
+    // The photo dialog must not have opened. Whatever the neighbour does is
+    // its own business; what matters is that the photo button did not win.
+    const dialogs = page.getByRole('dialog').filter({ hasText: /reference|photo/i });
+    await expect(dialogs).toHaveCount(0);
+  });
+});

--- a/e2e/tap-targets.spec.ts
+++ b/e2e/tap-targets.spec.ts
@@ -93,3 +93,42 @@ test.describe('the reference-photo button', () => {
     await expect(dialogs).toHaveCount(0);
   });
 });
+
+/**
+ * The Core Block's six completion ticks sit in a column. They are the controls
+ * that actually get mis-tapped — reaching for one and unchecking the row above.
+ *
+ * The fix is separation rather than a bigger target, and the direction matters:
+ * at 36px tall, widening these to the usual 44px would cut the gap between them
+ * from 16px to 8px, so taps that currently land in dead space and do nothing
+ * would start hitting the neighbour. This asserts both halves of that — more
+ * space between them, and no growth in height that would eat the space back.
+ */
+test('the Core Block ticks keep real space between them', async ({ page }) => {
+  await startTodaysWorkout(page);
+
+  const geometry = await page.evaluate(() => {
+    const marks = Array.from(document.querySelectorAll('button'))
+      .filter(b => /^Mark /.test(b.getAttribute('aria-label') || ''))
+      .map(b => {
+        const r = b.getBoundingClientRect();
+        return { label: b.getAttribute('aria-label')!, top: r.top + scrollY, bottom: r.bottom + scrollY, h: r.height };
+      })
+      .filter(m => !/set \d|cardio/i.test(m.label))
+      .sort((a, b) => a.top - b.top);
+
+    const gaps: number[] = [];
+    for (let i = 1; i < marks.length; i++) gaps.push(Math.round(marks[i].top - marks[i - 1].bottom));
+    return { count: marks.length, gaps, height: Math.round(marks[0]?.h ?? 0) };
+  });
+
+  expect(geometry.count, 'expected a column of Core Block ticks').toBeGreaterThan(2);
+
+  // Was 16px, which is where the mis-taps came from.
+  for (const gap of geometry.gaps) {
+    expect(gap, `gap between adjacent ticks: ${geometry.gaps.join(', ')}`).toBeGreaterThanOrEqual(24);
+  }
+
+  // If these ever grow, the separation above is silently spent paying for it.
+  expect(geometry.height).toBeLessThanOrEqual(40);
+});


### PR DESCRIPTION
> Supersedes #198 — this branch contains that commit too, so merging this closes both. Details below.

Reported: reaching for a completion tick and unchecking the row above, or checking the one below. The direction was the useful detail — **the collision is vertical, between rows**, not with the field beside it.

## Measuring the right thing

Vertical gaps between every completion control on the workout page:

| control | vertical gap |
|---|---|
| **Core Block ticks (six in a column)** | **16px** |
| Set completion circles | 304px |

So it's the Core Block, and the set circles were never involved — you couldn't mis-tap those if you tried.

An earlier version of this change also pushed the set circles right with `ml-auto` to separate them from the rest field. Removed. That was me measuring horizontal distance because it was the nearest number, not because it was the problem.

## Why not just make them bigger

**Widening these to 44px would make the reported problem worse.**

At 36px tall in a 52px pitch, going to 44px cuts the gap between adjacent ticks from 16px to 8px. That gap is dead space — and dead space is what turns a sloppy tap into *nothing happening* rather than into the wrong row toggling. Shrinking it converts near-misses into wrong hits.

So the height is deliberately unchanged, and the separation grows instead: `space-y-3` → `space-y-5`.

## Cost

| | before | after | |
|---|---|---|---|
| gap between ticks | 16px | **24px** | +50% |
| tick height | 36px | **36px** | unchanged — dead zone not eaten |
| page height | 4,472px | 4,512px | **+40px (+0.9%)** |

Cheap because the Core Block is six rows, not the fifty this page has in total. The same spacing everywhere would have cost 404px.

## Guard

`e2e/tap-targets.spec.ts` asserts at least 24px between adjacent ticks, **and** that they haven't grown taller — otherwise the separation gets silently spent paying for a bigger control.

Confirmed load-bearing:

```
Error: gap between adjacent ticks: 16, 16, 16, 16, 16
```

## Also in this branch (from #198)

The 20×20 reference-photo button gets a 44px hit area via a pseudo-element, at zero layout cost. That one has 59px of clearance so there's no neighbour to steal from. Worth keeping, but it was not the reported problem and I should not have presented it as the fix.

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **126 unit tests**, **202 end-to-end tests** pass
- Page height and gaps measured against a fresh build

🤖 Generated with [Claude Code](https://claude.com/claude-code)