### PR TITLE
fix: derive BEST from what was actually lifted, and hide it until it exists

### DIFF
--- a/client/src/components/exercise-form.test.tsx
+++ b/client/src/components/exercise-form.test.tsx
@@ -44,10 +44,14 @@ describe('an exercise with no recorded best', () => {
 });
 
 describe('an exercise with a recorded best', () => {
+  // `personalBest` is now derived from logged workouts and passed in. It used
+  // to be `bestWeight` on the exercise itself, which came from the template and
+  // was the same fabricated number for everybody.
   it('still shows it', () => {
     render(
       <ExerciseForm
-        exercise={exercise({ bestWeight: 120, bestReps: 8 })}
+        exercise={exercise()}
+        personalBest={{ weight: 120, reps: 8 }}
         onUpdate={() => {}}
       />,
     );
@@ -59,10 +63,9 @@ describe('an exercise with a recorded best', () => {
     render(
       <ExerciseForm
         exercise={exercise({
-          bestWeight: 120,
-          bestReps: 8,
           sets: [{ weight: 130, reps: 8, rest: '1:00', completed: false }],
         })}
+        personalBest={{ weight: 120, reps: 8 }}
         onUpdate={() => {}}
       />,
     );
@@ -73,10 +76,9 @@ describe('an exercise with a recorded best', () => {
     render(
       <ExerciseForm
         exercise={exercise({
-          bestWeight: 120,
-          bestReps: 8,
           sets: [{ weight: 110, reps: 8, rest: '1:00', completed: false }],
         })}
+        personalBest={{ weight: 120, reps: 8 }}
         onUpdate={() => {}}
       />,
     );

--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -8,15 +8,24 @@ import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { useToast } from '@/hooks/use-toast';
 import { useCursorEndOnFocus } from '@/hooks/use-cursor-end-on-focus';
 import { hasExerciseImage } from '@/lib/exercise-images';
+import type { PersonalBest } from '@/lib/personal-best';
 import { localWorkoutStorage } from '@/lib/storage';
 
 interface ExerciseFormProps {
   exercise: Exercise;
   onUpdate: (exercise: Exercise) => void;
   isActive?: boolean;
+  /**
+   * The heaviest set logged for this exercise before today, or undefined if it
+   * has never been logged. Derived from stored workouts by `personalBests` and
+   * passed in, rather than read off the exercise — the `bestWeight` that used
+   * to live there was a template constant, identical for everyone and frozen
+   * forever.
+   */
+  personalBest?: PersonalBest;
 }
 
-export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseFormProps) {
+export function ExerciseForm({ exercise, onUpdate, isActive = false, personalBest }: ExerciseFormProps) {
   const [localExercise, setLocalExercise] = useState<Exercise>(exercise);
   const [restDigits, setRestDigits] = useState<string[]>(
     exercise.sets.map((s) => s.rest?.replace(/\D/g, '') || '')
@@ -99,18 +108,18 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
     return 'pending';
   };
 
-  // A previous best only exists once the exercise has actually been done
-  // before. Exercises added through the custom workout builder carry none, and
-  // treating that as zero made the first set anyone logged look like a
-  // personal record.
-  const hasRecordedBest = localExercise.bestWeight !== undefined;
+  // A previous best only exists once the exercise has actually been logged.
+  // Until then there is nothing true to show, so the line is not rendered at
+  // all — better than an invented number, and one less thing on the screen
+  // during a first workout.
+  const hasRecordedBest = personalBest !== undefined;
 
   const getWeightChange = () => {
     if (!hasRecordedBest) return { change: '', color: '' };
 
     const weights = localExercise.sets.map(s => s.weight ?? 0);
     const currentWeight = weights.length > 0 ? Math.max(...weights) : 0;
-    const difference = currentWeight - localExercise.bestWeight!;
+    const difference = currentWeight - personalBest!.weight;
 
     if (difference > 0) return { change: `↑ +${difference} lbs`, color: 'text-blue-600' };
     if (difference < 0) return { change: `↓ ${Math.abs(difference)} lbs`, color: 'text-red-600' };
@@ -284,8 +293,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false }: ExerciseF
           <div className="mt-2 flex items-center space-x-2">
             <span className="text-xs text-gray-500 dark:text-gray-400">BEST:</span>
             <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
-              {localExercise.bestWeight} lbs
-              {localExercise.bestReps !== undefined && ` × ${localExercise.bestReps} reps`}
+              {personalBest!.weight} lbs × {personalBest!.reps} reps
             </span>
             {getWeightChange().change && (
               <span className={`text-xs ${getWeightChange().color}`}>

--- a/client/src/lib/personal-best.test.ts
+++ b/client/src/lib/personal-best.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { personalBests } from './personal-best';
+import type { Workout } from '@shared/schema';
+
+/**
+ * `BEST:` used to render a constant from the workout template — specifically
+ * the heaviest set in that same template, relabelled as a record. It was
+ * identical for every user, and it never moved no matter what anyone lifted.
+ *
+ * These pin the replacement to the two things that make it worth showing: it
+ * comes from logged sets, and it is what you walked in with rather than what
+ * you have typed so far today.
+ */
+
+const set = (weight?: number, reps?: number) => ({ weight, reps, completed: true });
+
+/** A set as a template hands it to you: numbers filled in, never ticked. */
+const prefilled = (weight: number, reps: number) => ({ weight, reps, completed: false });
+
+const workout = (id: number, machine: string, sets: ReturnType<typeof set>[]): Workout =>
+  ({
+    id,
+    date: '2026-08-01',
+    type: 'Chest Day',
+    exercises: [
+      {
+        machine,
+        equipment: 'machine' as const,
+        region: 'Chest',
+        feel: 'Medium' as const,
+        sets,
+        completed: false,
+      },
+    ],
+    abs: [],
+    cardio: null,
+    completed: null,
+    duration: null,
+    startedAt: null,
+    createdAt: null,
+    updatedAt: null,
+  }) as Workout;
+
+describe('personalBests', () => {
+  it('is empty when nothing has been logged', () => {
+    expect(personalBests([]).size).toBe(0);
+  });
+
+  it('takes the heaviest set ever logged, not the most recent', () => {
+    const best = personalBests([
+      workout(1, 'Pec Fly', [set(90, 10)]),
+      workout(2, 'Pec Fly', [set(120, 8)]),
+      workout(3, 'Pec Fly', [set(100, 10)]), // later, but lighter
+    ]);
+
+    expect(best.get('Pec Fly')).toEqual({ weight: 120, reps: 8 });
+  });
+
+  it('breaks ties on weight by reps', () => {
+    const best = personalBests([
+      workout(1, 'Seated Row', [set(100, 10)]),
+      workout(2, 'Seated Row', [set(100, 12)]),
+    ]);
+
+    expect(best.get('Seated Row')).toEqual({ weight: 100, reps: 12 });
+  });
+
+  it('ignores sets with no weight or no reps', () => {
+    const best = personalBests([
+      workout(1, 'Leg Press', [set(undefined, 10), set(200, undefined), set(80, 10)]),
+    ]);
+
+    expect(best.get('Leg Press')).toEqual({ weight: 80, reps: 10 });
+  });
+
+  it('leaves out the workout in progress', () => {
+    const workouts = [
+      workout(1, 'Bar Curl', [set(50, 10)]),
+      workout(2, 'Bar Curl', [set(999, 10)]), // today, mid-session
+    ];
+
+    // Without this, whatever you have just typed instantly becomes your record
+    // and the change indicator can never read anything but zero.
+    expect(personalBests(workouts, 2).get('Bar Curl')).toEqual({ weight: 50, reps: 10 });
+    expect(personalBests(workouts).get('Bar Curl')).toEqual({ weight: 999, reps: 10 });
+  });
+
+  it('keeps exercises separate', () => {
+    const best = personalBests([
+      workout(1, 'Pec Fly', [set(90, 10)]),
+      workout(2, 'Leg Press', [set(300, 10)]),
+    ]);
+
+    expect(best.get('Pec Fly')).toEqual({ weight: 90, reps: 10 });
+    expect(best.get('Leg Press')).toEqual({ weight: 300, reps: 10 });
+    expect(best.get('Never Done')).toBeUndefined();
+  });
+
+  it('reports nothing for an exercise that has only ever been skipped', () => {
+    const best = personalBests([workout(1, 'Abductor', [set(undefined, undefined)])]);
+    expect(best.get('Abductor')).toBeUndefined();
+  });
+  it('does not count a template\'s prefilled weights as something you lifted', () => {
+    // Presets arrive with weights already in the boxes. Counting those would
+    // make the template's own defaults your record as soon as the workout
+    // became history — the same invention this replaced, one session later.
+    const best = personalBests([
+      workout(1, 'Leg Press', [prefilled(450, 15), prefilled(400, 15)]),
+    ]);
+
+    expect(best.get('Leg Press')).toBeUndefined();
+  });
+
+  it('counts the sets you ticked, ignoring the ones you left untouched', () => {
+    const best = personalBests([
+      workout(1, 'Leg Press', [set(200, 10), prefilled(450, 15)]),
+    ]);
+
+    expect(best.get('Leg Press')).toEqual({ weight: 200, reps: 10 });
+  });
+});

--- a/client/src/lib/personal-best.ts
+++ b/client/src/lib/personal-best.ts
@@ -1,0 +1,69 @@
+import type { Workout } from '@shared/schema';
+
+/**
+ * The heaviest set you have actually logged for an exercise.
+ *
+ * The `BEST:` line used to read `bestWeight` off the workout template, where it
+ * was a hardcoded constant — and not even a new one: it was the heaviest set in
+ * that same template, restated as though it were an achievement. So the app
+ * showed every user the same "record" on day one, and kept showing it forever,
+ * because a template constant never moves. The weight change indicator was
+ * measured against it too, which meant matching the preset's own top set read
+ * as a personal record.
+ *
+ * The prefilled weights in a template are a different thing and stay exactly as
+ * they are: they are a sensible starting point, and being able to load a preset
+ * and go is the point of presets. What changes is only the claim about what you
+ * have lifted.
+ */
+
+export interface PersonalBest {
+  weight: number;
+  reps: number;
+}
+
+/**
+ * Personal bests for every exercise across the given workouts, keyed by machine.
+ *
+ * A set counts only once it is marked complete.
+ *
+ * Requiring the tick is load-bearing, not fussiness. Templates arrive with
+ * weights already filled in — that is the point of a preset — so counting any
+ * set that merely *has* numbers would make the template's own defaults your
+ * personal record the moment the workout became history. That is the same
+ * invention this replaced, one session later.
+ *
+ * `excludeWorkoutId` leaves out the session in progress. Without it, typing a
+ * weight would immediately become your record and the change indicator would
+ * read zero forever — the number is meant to be what you walked in with.
+ *
+ * Ties on weight are broken by reps, so 100x12 beats 100x10.
+ */
+export function personalBests(
+  workouts: Workout[],
+  excludeWorkoutId?: number,
+): Map<string, PersonalBest> {
+  const best = new Map<string, PersonalBest>();
+
+  for (const workout of workouts) {
+    if (excludeWorkoutId !== undefined && workout.id === excludeWorkoutId) continue;
+
+    for (const exercise of workout.exercises) {
+      for (const set of exercise.sets) {
+        if (!set.completed) continue;
+        if (typeof set.weight !== 'number' || typeof set.reps !== 'number') continue;
+
+        const current = best.get(exercise.machine);
+        if (
+          !current ||
+          set.weight > current.weight ||
+          (set.weight === current.weight && set.reps > current.reps)
+        ) {
+          best.set(exercise.machine, { weight: set.weight, reps: set.reps });
+        }
+      }
+    }
+  }
+
+  return best;
+}

--- a/client/src/lib/workout-data.ts
+++ b/client/src/lib/workout-data.ts
@@ -24,9 +24,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 60, reps: 15, rest: "1:00" },
           { weight: 70, reps: 15, rest: "1:00" },
           { weight: 90, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 90,
-        bestReps: 15
+        ]
       },
       {
         code: "S5",
@@ -38,9 +36,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 100, reps: 15, rest: "1:00" },
           { weight: 115, reps: 10, rest: "1:30" },
           { weight: 115, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 115,
-        bestReps: 10
+        ]
       },
       {
         code: "S4",
@@ -52,9 +48,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 160, reps: 15, rest: "1:00" },
           { weight: 160, reps: 15, rest: "1:00" },
           { weight: 165, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 165,
-        bestReps: 15
+        ]
       },
       {
         code: "S12",
@@ -66,9 +60,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 60, reps: 15, rest: "1:00" },
           { weight: 70, reps: 10, rest: "1:00" },
           { weight: 70, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 70,
-        bestReps: 10
+        ]
       },
       {
         code: "S33",
@@ -80,9 +72,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 25, reps: 15, rest: "1:00" },
           { weight: 25, reps: 15, rest: "1:00" },
           { weight: 25, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 25,
-        bestReps: 15
+        ]
       },
       {
         code: "S24",
@@ -94,9 +84,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 100, reps: 15, rest: "1:00" },
           { weight: 120, reps: 10, rest: "1:30" },
           { weight: 120, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 120,
-        bestReps: 10
+        ]
       },
       {
         code: "S8",
@@ -108,9 +96,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 125, reps: 15, rest: "1:00" },
           { weight: 140, reps: 10, rest: "1:00" },
           { weight: 140, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 140,
-        bestReps: 10
+        ]
       }
     ],
     abs: [
@@ -134,9 +120,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 180, reps: 10, rest: "1:00" },
           { weight: 220, reps: 15, rest: "1:00" },
           { weight: 230, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 230,
-        bestReps: 15
+        ]
       },
       {
         code: "S22",
@@ -148,9 +132,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 400, reps: 10, rest: "1:30" },
           { weight: 450, reps: 10, rest: "1:00" },
           { weight: 450, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 450,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -162,9 +144,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 0, reps: 20, rest: "1:00" },
           { weight: 0, reps: 20, rest: "1:00" },
           { weight: 0, reps: 20, rest: "1:00" }
-        ],
-        bestWeight: 0,
-        bestReps: 20
+        ]
       },
       {
         code: "S14",
@@ -176,9 +156,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 165, reps: 15, rest: "1:30" },
           { weight: 175, reps: 10, rest: "1:00" },
           { weight: 175, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 175,
-        bestReps: 10
+        ]
       },
       {
         code: "S15",
@@ -190,9 +168,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 160, reps: 15, rest: "1:00" },
           { weight: 170, reps: 15, rest: "1:00" },
           { weight: 185, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 185,
-        bestReps: 15
+        ]
       },
       {
         code: "S16",
@@ -204,9 +180,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 150, reps: 10, rest: "1:00" },
           { weight: 150, reps: 10, rest: "1:00" },
           { weight: 150, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 150,
-        bestReps: 10
+        ]
       },
       {
         code: "S18",
@@ -218,9 +192,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 155, reps: 10, rest: "1:00" },
           { weight: 155, reps: 10, rest: "1:00" },
           { weight: 155, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 155,
-        bestReps: 10
+        ]
       },
       {
         code: "S17",
@@ -232,9 +204,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 135, reps: 10, rest: "1:00" },
           { weight: 140, reps: 10, rest: "1:00" },
           { weight: 140, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 140,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -246,9 +216,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 0, reps: 12, rest: "1:00" },
           { weight: 0, reps: 12, rest: "1:00" },
           { weight: 0, reps: 12, rest: "1:00" }
-        ],
-        bestWeight: 0,
-        bestReps: 12
+        ]
       },
       {
         code: "S3",
@@ -260,9 +228,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 45, reps: 20, rest: "1:00" },
           { weight: 45, reps: 20, rest: "1:00" },
           { weight: 45, reps: 20, rest: "1:00" }
-        ],
-        bestWeight: 45,
-        bestReps: 20
+        ]
       }
     ],
     abs: [
@@ -287,9 +253,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 135, reps: 10, rest: "1:00" },
           { weight: 150, reps: 10, rest: "1:00" },
           { weight: 160, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 160,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -301,9 +265,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 120, reps: 15, rest: "1:30" },
           { weight: 140, reps: 15, rest: "1:30" },
           { weight: 150, reps: 15, rest: "1:30" }
-        ],
-        bestWeight: 150,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -315,9 +277,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 140, reps: 15, rest: "1:30" },
           { weight: 200, reps: 10, rest: "1:30" },
           { weight: 200, reps: 6, rest: "1:30" }
-        ],
-        bestWeight: 200,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -329,9 +289,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 200, reps: 20, rest: "1:00" },
           { weight: 200, reps: 20, rest: "1:00" },
           { weight: 200, reps: 20, rest: "1:00" }
-        ],
-        bestWeight: 200,
-        bestReps: 20
+        ]
       },
       {
         code: "N/A",
@@ -343,9 +301,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 15, reps: 10, rest: "1:00" },
           { weight: 15, reps: 10, rest: "1:00" },
           { weight: 15, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 15,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -357,9 +313,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 70, reps: 10, rest: "1:00" },
           { weight: 70, reps: 10, rest: "1:00" },
           { weight: 70, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 70,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -371,9 +325,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 40, reps: 10, rest: "1:00" },
           { weight: 40, reps: 10, rest: "1:00" },
           { weight: 50, reps: 6, rest: "1:00" }
-        ],
-        bestWeight: 50,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -385,9 +337,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 55, reps: 10, rest: "1:00" },
           { weight: 70, reps: 10, rest: "1:00" },
           { weight: 70, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 70,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -399,9 +349,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 15, reps: 15, rest: "1:00" },
           { weight: 15, reps: 15, rest: "1:00" },
           { weight: 15, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 15,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -413,9 +361,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 90, reps: 15, rest: "1:00" },
           { weight: 90, reps: 15, rest: "1:00" },
           { weight: 90, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 90,
-        bestReps: 15
+        ]
       }
     ],
     abs: [
@@ -440,9 +386,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 110, reps: 15, rest: "1:00" },
           { weight: 135, reps: 15, rest: "1:00" },
           { weight: 135, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 135,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -454,9 +398,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 120, reps: 10, rest: "1:00" },
           { weight: 140, reps: 10, rest: "1:00" },
           { weight: 140, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 140,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -468,9 +410,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 40, reps: 10, rest: "1:30" },
           { weight: 40, reps: 10, rest: "1:30" },
           { weight: 40, reps: 10, rest: "1:30" }
-        ],
-        bestWeight: 40,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -482,9 +422,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 70, reps: 10, rest: "1:00" },
           { weight: 90, reps: 10, rest: "1:00" },
           { weight: 90, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 90,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -496,9 +434,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 70, reps: 15, rest: "1:00" },
           { weight: 70, reps: 15, rest: "1:00" },
           { weight: 70, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 70,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -510,9 +446,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 200, reps: 20, rest: "1:00" },
           { weight: 200, reps: 20, rest: "1:00" },
           { weight: 200, reps: 20, rest: "1:00" }
-        ],
-        bestWeight: 200,
-        bestReps: 20
+        ]
       },
       {
         code: "N/A",
@@ -524,9 +458,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 155, reps: 10, rest: "1:00" },
           { weight: 160, reps: 10, rest: "1:00" },
           { weight: 160, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 160,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -538,9 +470,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 380, reps: 15, rest: "1:30" },
           { weight: 400, reps: 10, rest: "1:30" },
           { weight: 400, reps: 10, rest: "1:30" }
-        ],
-        bestWeight: 400,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -552,9 +482,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 130, reps: 15, rest: "1:00" },
           { weight: 130, reps: 15, rest: "1:00" },
           { weight: 130, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 130,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -566,9 +494,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 0, reps: 12, rest: "1:00" },
           { weight: 0, reps: 12, rest: "1:00" },
           { weight: 0, reps: 12, rest: "1:00" }
-        ],
-        bestWeight: 0,
-        bestReps: 12
+        ]
       },
       {
         code: "N/A",
@@ -580,9 +506,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 45, reps: 15, rest: "1:00" },
           { weight: 45, reps: 15, rest: "1:00" },
           { weight: 45, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 45,
-        bestReps: 15
+        ]
       }
     ],
     abs: [
@@ -607,9 +531,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 75, reps: 15, rest: "1:00" },
           { weight: 100, reps: 15, rest: "1:00" },
           { weight: 100, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 100,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -621,9 +543,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 60, reps: 15, rest: "1:00" },
           { weight: 80, reps: 6, rest: "1:00" },
           { weight: 80, reps: 6, rest: "1:00" }
-        ],
-        bestWeight: 80,
-        bestReps: 6
+        ]
       },
       {
         code: "N/A",
@@ -635,9 +555,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 15, reps: 15, rest: "1:00" },
           { weight: 15, reps: 15, rest: "1:00" },
           { weight: 15, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 15,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -649,9 +567,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 140, reps: 10, rest: "1:00" },
           { weight: 140, reps: 10, rest: "1:00" },
           { weight: 150, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 150,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -663,9 +579,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 50, reps: 10, rest: "1:30" },
           { weight: 50, reps: 10, rest: "1:30" },
           { weight: 50, reps: 10, rest: "1:30" }
-        ],
-        bestWeight: 50,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -677,9 +591,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 15, reps: 10, rest: "1:00" },
           { weight: 15, reps: 10, rest: "1:00" },
           { weight: 15, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 15,
-        bestReps: 10
+        ]
       }
     ],
     abs: [
@@ -704,9 +616,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 75, reps: 10, rest: "1:00" },
           { weight: 100, reps: 10, rest: "1:00" },
           { weight: 100, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 100,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -718,9 +628,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 0, reps: 10, rest: "1:00" },
           { weight: 0, reps: 10, rest: "1:00" },
           { weight: 0, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 0,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -732,9 +640,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 100, reps: 10, rest: "1:00" },
           { weight: 100, reps: 10, rest: "1:00" },
           { weight: 100, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 100,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -746,9 +652,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 20, reps: 10, rest: "1:30" },
           { weight: 30, reps: 10, rest: "1:30" },
           { weight: 30, reps: 10, rest: "1:30" }
-        ],
-        bestWeight: 30,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -760,9 +664,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 70, reps: 10, rest: "1:30" },
           { weight: 70, reps: 10, rest: "1:30" },
           { weight: 70, reps: 10, rest: "1:30" }
-        ],
-        bestWeight: 70,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -774,9 +676,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 55, reps: 10, rest: "1:30" },
           { weight: 65, reps: 10, rest: "1:30" },
           { weight: 65, reps: 10, rest: "1:30" }
-        ],
-        bestWeight: 65,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -788,9 +688,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 135, reps: 10, rest: "1:00" },
           { weight: 135, reps: 10, rest: "1:00" },
           { weight: 135, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 135,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -802,9 +700,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 200, reps: 10, rest: "1:00" },
           { weight: 200, reps: 10, rest: "1:00" },
           { weight: 200, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 200,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -816,9 +712,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 60, reps: 10, rest: "1:00" },
           { weight: 70, reps: 10, rest: "1:00" },
           { weight: 70, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 70,
-        bestReps: 10
+        ]
       }
     ],
     abs: [
@@ -842,9 +736,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 60, reps: 15, rest: "1:00" },
           { weight: 80, reps: 8, rest: "1:00" },
           { weight: 90, reps: 6, rest: "1:00" }
-        ],
-        bestWeight: 90,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -856,9 +748,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 25, reps: 15, rest: "1:00" },
           { weight: 30, reps: 15, rest: "1:00" },
           { weight: 30, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 30,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -870,9 +760,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 60, reps: 15, rest: "1:00" },
           { weight: 70, reps: 15, rest: "1:00" },
           { weight: 70, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 70,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -884,9 +772,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 180, reps: 10, rest: "1:00" },
           { weight: 200, reps: 10, rest: "1:00" },
           { weight: 200, reps: 10, rest: "1:00" }
-        ],
-        bestWeight: 200,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -898,9 +784,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 170, reps: 10, rest: "1:30" },
           { weight: 170, reps: 10, rest: "1:30" },
           { weight: 200, reps: 8, rest: "1:30" }
-        ],
-        bestWeight: 200,
-        bestReps: 10
+        ]
       },
       {
         code: "N/A",
@@ -912,9 +796,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 155, reps: 15, rest: "1:30" },
           { weight: 165, reps: 12, rest: "1:30" },
           { weight: 165, reps: 8, rest: "1:30" }
-        ],
-        bestWeight: 165,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -926,9 +808,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 130, reps: 15, rest: "1:00" },
           { weight: 130, reps: 15, rest: "1:00" },
           { weight: 130, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 130,
-        bestReps: 15
+        ]
       },
       {
         code: "N/A",
@@ -940,9 +820,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 0, reps: 12, rest: "1:00" },
           { weight: 0, reps: 12, rest: "1:00" },
           { weight: 0, reps: 12, rest: "1:00" }
-        ],
-        bestWeight: 0,
-        bestReps: 12
+        ]
       },
       {
         code: "N/A",
@@ -954,9 +832,7 @@ export const workoutTemplates: Partial<Record<WorkoutType, {
           { weight: 45, reps: 15, rest: "1:00" },
           { weight: 45, reps: 15, rest: "1:00" },
           { weight: 45, reps: 15, rest: "1:00" }
-        ],
-        bestWeight: 45,
-        bestReps: 15
+        ]
       }
     ],
     abs: [

--- a/client/src/pages/workout-cardio.test.tsx
+++ b/client/src/pages/workout-cardio.test.tsx
@@ -19,7 +19,8 @@ const mockToast = vi.fn((_options: { title?: string; description?: string }) => 
 }));
 
 vi.mock('@/hooks/use-workout-storage', () => ({
-  useWorkoutStorage: () => ({ updateWorkout: mockUpdateWorkout }),
+  // `workouts` feeds the personal-best derivation; the page reads it now.
+  useWorkoutStorage: () => ({ updateWorkout: mockUpdateWorkout, workouts: [] }),
 }));
 vi.mock('canvas-confetti', () => ({ default: vi.fn() }));
 vi.mock('@/hooks/use-toast', () => ({

--- a/client/src/pages/workout.test.tsx
+++ b/client/src/pages/workout.test.tsx
@@ -7,7 +7,8 @@ import type { Workout } from '@shared/schema';
 const mockUpdateWorkout = vi.fn();
 
 vi.mock('@/hooks/use-workout-storage', () => ({
-  useWorkoutStorage: () => ({ updateWorkout: mockUpdateWorkout }),
+  // `workouts` feeds the personal-best derivation; the page reads it now.
+  useWorkoutStorage: () => ({ updateWorkout: mockUpdateWorkout, workouts: [] }),
 }));
 
 vi.mock('canvas-confetti', () => ({
@@ -27,7 +28,7 @@ vi.mock('@/components/exercise-form', () => ({
       <p>{exercise.machine}</p>
       <button
         data-testid={`update-${exercise.machine}-${isActive ? 'active' : 'inactive'}`}
-        onClick={() => onUpdate({ ...exercise, bestReps: (exercise.bestReps ?? 0) + 1 })}
+        onClick={() => onUpdate({ ...exercise, code: String(Number(exercise.code ?? 0) + 1) })}
       >
         update
       </button>
@@ -47,8 +48,6 @@ const baseWorkout: Workout = {
       region: 'chest',
       feel: 'Medium',
       sets: [{ weight: 100, reps: 8, rest: '1:00', completed: false }],
-      bestWeight: undefined,
-      bestReps: undefined,
       completed: false,
     },
   ],
@@ -104,12 +103,12 @@ describe('WorkoutPage exercise updates', () => {
         {
           ...baseWorkout.exercises[0],
           machine: 'Dup Machine',
-          bestReps: 1,
+          code: '1',
         },
         {
           ...baseWorkout.exercises[0],
           machine: 'Dup Machine',
-          bestReps: 2,
+          code: '2',
         },
       ],
     };
@@ -120,7 +119,8 @@ describe('WorkoutPage exercise updates', () => {
     fireEvent.click(screen.getByText('Save Workout'));
 
     const payload = mockUpdateWorkout.mock.calls.at(-1)?.[1];
-    expect(payload.exercises[0].bestReps).toBe(1);
-    expect(payload.exercises[1].bestReps).toBe(3);
+    // `code` is just a marker here: index 1 was updated, index 0 untouched.
+    expect(payload.exercises[0].code).toBe('1');
+    expect(payload.exercises[1].code).toBe('3');
   });
 });

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, useCallback } from 'react';
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -6,6 +6,7 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ExerciseForm } from '@/components/exercise-form';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
+import { personalBests } from '@/lib/personal-best';
 import type { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
 import { parseISODate } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
@@ -54,8 +55,21 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   const [celebrated, setCelebrated] = useState(false);
   const [showDialog, setShowDialog] = useState(false);
   const [successMessage, setSuccessMessage] = useState<typeof successMessages[number]>(successMessages[0]);
-  const { updateWorkout } = useWorkoutStorage();
+  const { updateWorkout, workouts } = useWorkoutStorage();
   const { toast, dismiss } = useToast();
+
+  /**
+   * What you walked in with, per exercise — the heaviest set logged in any
+   * earlier session. The current workout is excluded, so today's typing does
+   * not instantly become the record it is compared against.
+   *
+   * Memoised because it scans every stored workout, and this page re-renders
+   * on each keystroke.
+   */
+  const bests = useMemo(
+    () => personalBests(workouts, initialWorkout.id),
+    [workouts, initialWorkout.id],
+  );
   const focusToEnd = useCursorEndOnFocus();
 
   useEffect(() => {
@@ -598,6 +612,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
               exercise={exercise}
               onUpdate={(updatedExercise) => handleExerciseUpdate(index, updatedExercise)}
               isActive={index === currentExerciseIndex}
+              personalBest={bests.get(exercise.machine)}
             />
           </ErrorBoundary>
         ))}

--- a/e2e/personal-best.spec.ts
+++ b/e2e/personal-best.spec.ts
@@ -1,0 +1,77 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setNumericValue } from './helpers';
+
+/**
+ * `BEST:` used to render a constant from the workout template — and not even a
+ * distinct one: it was the heaviest set in that same template, relabelled as a
+ * personal record. Every user saw the same number on their first ever workout,
+ * and it never moved afterwards, so the weight-change arrow measured progress
+ * against a figure from a JSON file.
+ *
+ * The prefilled weights in a template are a different thing and are unchanged:
+ * loading a preset and going is the point of presets. What is asserted here is
+ * only the claim about what you have lifted.
+ */
+
+async function startTodaysWorkout(page: Page) {
+  await page.goto('/');
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.waitForTimeout(1200);
+}
+
+test('a first workout claims no personal record, but still arrives pre-filled', async ({ page }) => {
+  await startTodaysWorkout(page);
+
+  // Nothing has been logged, so there is nothing true to say.
+  await expect(page.getByText(/BEST:/)).toHaveCount(0);
+
+  // The convenience is untouched: the template's weights are still there to
+  // start from, which is the whole reason to load a preset.
+  const firstWeight = page.getByRole('textbox', { name: /^Weight, set 1$/ }).first();
+  await expect(firstWeight).not.toHaveValue('');
+});
+
+test('BEST reflects what was actually logged, in a later session', async ({ page }) => {
+  // Log a session by hand, then plant a second workout for a different day so
+  // the first becomes history rather than the session in progress.
+  await startTodaysWorkout(page);
+
+  const weight = page.getByRole('textbox', { name: /^Weight, set 1$/ }).first();
+  await setNumericValue(weight, '145');
+  const reps = page.getByRole('textbox', { name: /^Reps, set 1$/ }).first();
+  await setNumericValue(reps, '7');
+
+  // Tick it. Only completed sets count — otherwise the template's own
+  // prefilled weights would become the record as soon as this workout
+  // became history.
+  await page.getByRole('button', { name: /^Mark set 1 complete$/ }).first().click();
+  await page.waitForTimeout(2600); // let autosave settle
+
+  const machine = await page.evaluate(() => {
+    const stored = JSON.parse(localStorage.getItem('ironpath_workouts') || '[]');
+    return stored[0]?.exercises?.[0]?.machine ?? null;
+  });
+  expect(machine, 'expected a stored workout to read back').not.toBeNull();
+
+  // Re-open as a *new* session: duplicate the record under a fresh id and date,
+  // so the logged one counts as history.
+  await page.evaluate(() => {
+    const stored = JSON.parse(localStorage.getItem('ironpath_workouts') || '[]');
+    const copy = JSON.parse(JSON.stringify(stored[0]));
+    copy.id = 9001;
+    copy.date = '2099-01-01';
+    copy.exercises = copy.exercises.map((e: { sets: unknown[] }) => ({
+      ...e,
+      sets: (e.sets as Record<string, unknown>[]).map(s => ({ ...s, weight: undefined, reps: undefined })),
+    }));
+    localStorage.setItem('ironpath_workouts', JSON.stringify([...stored, copy]));
+  });
+
+  await page.goto('/workout/9001');
+  await page.waitForTimeout(1500);
+
+  // The record is now real, and it is the number that was logged.
+  await expect(page.getByText(/BEST:/).first()).toBeVisible();
+  await expect(page.getByText('145 lbs × 7 reps').first()).toBeVisible();
+});

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -36,8 +36,6 @@ export const exerciseSchema = z.object({
   region: z.string(),
   feel: z.enum(["Light", "Medium", "Hard", "Heavy", "N/A"]),
   sets: z.array(exerciseSetSchema),
-  bestWeight: z.number().optional(),
-  bestReps: z.number().optional(),
   completed: z.boolean().default(false)
 });
 


### PR DESCRIPTION
Closes #154.

`BEST: 90 lbs × 15 reps` was read from `bestWeight` on the workout template — a hardcoded constant, and not even a distinct one. It was the heaviest set in that same template, restated as an achievement:

```js
sets: [
  { weight: 60, reps: 15, rest: "1:00" },
  { weight: 70, reps: 15, rest: "1:00" },
  { weight: 90, reps: 15, rest: "1:00" },   ← the prefill
],
bestWeight: 90,   ← the same 90, relabelled as your record
bestReps: 15
```

Every user saw the same "record" on their first ever workout, and it never moved. The weight-change arrow measured against it too — so matching the preset's own top set displayed as a personal record, and six months of real progress was still being compared to a number in a JSON file.

## The prefill is untouched

`sets` still carries the starting weights. **Loading a preset and going still works exactly as it does today** — that's the point of a preset, and it's a different field from the claim about what you've lifted. Only the claim changes.

The end-to-end test asserts both halves in one place: a first workout shows **no BEST line** *and* the weight boxes **still arrive filled in**.

## Two rules that turned out to be load-bearing

**Only completed sets count.** This one I got wrong first, and the E2E caught it. Templates arrive with weights already in the boxes — so counting any set that merely *has* numbers would make the template's defaults your record as soon as the workout became history. The same fiction, one session later. It surfaced as `BEST:` appearing with a number nobody had lifted.

**The workout in progress is excluded.** Otherwise today's typing instantly becomes the record it's being compared against, and the arrow reads zero forever. The number should be what you walked in with.

Ties on weight break by reps, so 100×12 beats 100×10.

## Removed

- 62 `bestWeight`/`bestReps` pairs from the templates
- both fields from `exerciseSchema` — nothing else read them

Two existing tests used `bestReps` as a fixture marker to tell duplicate machine names apart; they use `code` now. Two mocks of `useWorkoutStorage` gained `workouts: []`, which the page now reads.

## Guards

`personal-best.test.ts` — heaviest-not-latest, tie-breaks, sets missing weight or reps, exercise isolation, prefilled-but-unticked sets, exclusion of the current workout.

Confirmed load-bearing:

| control | fails |
|---|---|
| drop the "must be ticked" rule | *does not count a template's prefilled weights as something you lifted* |
| stop excluding the current workout | *leaves out the workout in progress* |

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **135 unit tests**, **206 end-to-end tests** pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)