### PR TITLE
fix: start the workout for the day you selected, not today

### DIFF
--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -6,7 +6,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { CalendarGrid } from '@/components/calendar-grid';
 import { WorkoutCard } from '@/components/workout-card';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
-import { generateWorkoutSchedule, getTodaysWorkoutType, workoutTemplates } from '@/lib/workout-data';
+import { generateWorkoutSchedule, workoutTemplates } from '@/lib/workout-data';
 import { parseISODate, formatLocalDate } from '@/lib/utils';
 import { calculateDayStreak, calculateTopDayStreak } from '@/lib/streak';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
@@ -205,21 +205,31 @@ export function CalendarPage() {
     setSelectedDate(normalized);
   };
 
-  const handleStartTodayWorkout = async () => {
-    const today = formatLocalDate(new Date());
-    const existingWorkout = await getWorkoutByDate(today);
+  /**
+   * Start (or open) the workout for the day the panel is showing.
+   *
+   * This used to always act on `new Date()` while sitting inside a panel headed
+   * with the selected date, directly under a line reading "Selected Day's
+   * Workout: Legs". So tapping a day and pressing the button created a workout
+   * for today, of today's type — not the one named a few pixels above.
+   */
+  const handleStartSelectedWorkout = async () => {
+    const date = selectedDate ?? formatLocalDate(new Date());
+    const existingWorkout = await getWorkoutByDate(date);
 
     if (existingWorkout) {
       navigateToWorkout(existingWorkout);
     } else {
-      // Create new workout for today
-      const workoutType = getTodaysWorkoutType();
+      // The type the panel is advertising for this day, which is the scheduled
+      // one — not today's.
+      const workoutType = selectedWorkoutType;
+      if (!workoutType) return;
       const builtIn = workoutTemplates[workoutType as keyof typeof workoutTemplates];
       let newWorkout: Workout | undefined;
       if (builtIn) {
         const template = builtIn;
         newWorkout = await createWorkout({
-          date: today,
+          date,
           type: workoutType,
           exercises: template.exercises.map(e => ({
             ...e,
@@ -239,7 +249,7 @@ export function CalendarPage() {
         const custom = customTemplates.find(t => t.name === workoutType);
         if (!custom) return;
         newWorkout = await createWorkout({
-          date: today,
+          date,
           type: workoutType,
           exercises: custom.exercises.map(e => ({
             ...e,
@@ -382,8 +392,10 @@ export function CalendarPage() {
             <p className="text-center font-medium">
               Selected Day's Workout: {selectedWorkoutType ?? 'None'}
             </p>
-            <Button onClick={handleStartTodayWorkout} className="w-full">
-              Start Today's Workout
+            <Button onClick={handleStartSelectedWorkout} className="w-full">
+              {selectedDate === formatLocalDate(new Date())
+                ? "Start Today's Workout"
+                : 'Start This Workout'}
             </Button>
 
             {selectedWorkout && (

--- a/e2e/selected-day.spec.ts
+++ b/e2e/selected-day.spec.ts
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * The start button lives inside a panel headed with the selected date, directly
+ * under a line reading "Selected Day's Workout: Legs". It nonetheless always
+ * acted on `new Date()` and today's scheduled type, so tapping a day and
+ * pressing it created a workout for today — of a different type than the one
+ * named a few pixels above.
+ */
+
+/** A day in the current month that is not today, avoiding month-edge cases. */
+function otherDayThisMonth() {
+  const now = new Date();
+  const day = now.getDate() === 15 ? 16 : 15;
+  const date = new Date(now.getFullYear(), now.getMonth(), day);
+  const iso = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+  return { day, iso };
+}
+
+test('starting from a selected day creates the workout for that day', async ({ page }) => {
+  const { day, iso } = otherDayThisMonth();
+
+  await page.goto('/');
+  await page.waitForTimeout(800);
+
+  // The default selection is today, so the familiar label is what shows first.
+  await expect(page.getByRole('button', { name: "Start Today's Workout" })).toBeVisible();
+
+  await page.getByRole('button', { name: String(day), exact: true }).first().click();
+  await page.waitForTimeout(500);
+
+  // Once the selection is not today, the button stops claiming to be about today.
+  const start = page.getByRole('button', { name: 'Start This Workout' });
+  await expect(start).toBeVisible();
+
+  const advertised = (await page.getByText(/Selected Day's Workout:/).textContent())
+    ?.replace(/Selected Day's Workout:\s*/, '')
+    .trim();
+  expect(advertised, 'panel should name a workout type').toBeTruthy();
+
+  await start.click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.waitForTimeout(1500);
+
+  const created = await page.evaluate(() => {
+    const stored = JSON.parse(localStorage.getItem('ironpath_workouts') || '[]');
+    return stored.map((w: { date: string; type: string }) => ({ date: w.date, type: w.type }));
+  });
+
+  expect(created, 'exactly one workout should have been created').toHaveLength(1);
+  // The whole bug: this used to be today's date and today's type.
+  expect(created[0].date).toBe(iso);
+  expect(created[0].type).toBe(advertised);
+});
+
+test('starting from today still works and still says so', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForTimeout(800);
+
+  await page.getByRole('button', { name: "Start Today's Workout" }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.waitForTimeout(1200);
+
+  const today = await page.evaluate(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+  });
+  const stored = await page.evaluate(() =>
+    JSON.parse(localStorage.getItem('ironpath_workouts') || '[]').map((w: { date: string }) => w.date),
+  );
+
+  expect(stored).toEqual([today]);
+});


### PR DESCRIPTION
Closes #152.

`handleStartTodayWorkout` always used `formatLocalDate(new Date())` and `getTodaysWorkoutType()` — while the button sits inside a panel headed with the **selected** date, directly beneath a line reading "Selected Day's Workout: Legs".

So tapping **15 August** and pressing the button created a workout dated **today**, of **today's** type — not the one named a few pixels above it.

## Change

The handler acts on `selectedDate` and the type the panel is already advertising for that day. Both creation paths — built-in and custom template — were already there and are unchanged apart from the date.

The label now follows what the button will actually do:

| selected day | label |
|---|---|
| today | `Start Today's Workout` |
| any other day | `Start This Workout` |

`selectedDate` initialises to today, so the default label and the familiar affordance are untouched. The heading directly above already names the day, so the alternate label doesn't repeat it.

## Guard

`e2e/selected-day.spec.ts` taps a day that isn't today, reads the type the panel advertises, presses the button, and asserts the stored workout carries **that date and that type**. A second test asserts starting from today still works and still says so.

Confirmed load-bearing — restoring `formatLocalDate(new Date())`:

```
Expected: "2026-08-15"
Received: "2026-08-01"
```

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **135 unit**, **210 end-to-end** tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)