### PR TITLE
fix: stop reporting a failed save as a successful one

### DIFF
--- a/client/src/lib/storage-write-failure.test.ts
+++ b/client/src/lib/storage-write-failure.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
+import { LocalWorkoutStorage, StorageWriteError } from './storage';
+import type { InsertWorkout } from '@shared/schema';
+
+/**
+ * A failed write used to be reported to the user as a successful save.
+ *
+ * `safeSetItem` caught the exception, flipped to an in-memory store and
+ * returned normally, so `updateWorkout` resolved, the caller's `catch` never
+ * fired, and the success path ran: "Auto-saved — Your workout progress has been
+ * saved", with nothing whatsoever in localStorage.
+ *
+ * This is not a hypothetical browser. `setItem` throws in Safari private mode,
+ * with "block all cookies" set, and on an exhausted origin quota.
+ *
+ * Falling back to memory is still the right behaviour — the session keeps
+ * working. What was wrong was not saying so.
+ */
+
+const workout = (): InsertWorkout => ({
+  date: '2026-08-01',
+  type: 'Chest Day',
+  exercises: [
+    {
+      machine: 'Pec Fly',
+      equipment: 'machine',
+      region: 'Chest',
+      feel: 'Medium',
+      sets: [{ weight: 100, reps: 10, rest: '1:00', completed: true }],
+      completed: false,
+    },
+  ],
+  abs: [],
+});
+
+describe('a workout edit that cannot be written to this device', () => {
+  let storage: LocalWorkoutStorage;
+
+  beforeEach(() => {
+    localStorage.clear();
+    storage = new LocalWorkoutStorage();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects rather than resolving, so the caller cannot claim it saved', async () => {
+    const created = await storage.createWorkout(workout());
+    expect(created).toBeDefined();
+
+    // What Safari private mode does.
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      });
+
+    await expect(
+      storage.updateWorkout(created!.id, { completed: true }),
+    ).rejects.toBeInstanceOf(StorageWriteError);
+
+    setItem.mockRestore();
+  });
+
+  it('says the data is not durable, not something a user cannot act on', async () => {
+    const created = await storage.createWorkout(workout());
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+    });
+
+    await expect(
+      storage.updateWorkout(created!.id, { completed: true }),
+    ).rejects.toThrow(/could not be saved to this device/i);
+  });
+
+  it('keeps the session working, holding the edit in memory', async () => {
+    const created = await storage.createWorkout(workout());
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+    });
+
+    await storage.updateWorkout(created!.id, { completed: true }).catch(() => {});
+
+    // The point of the memory fallback: nothing crashes and the value is still
+    // readable for the rest of this session.
+    const workouts = storage.getWorkouts();
+    expect(workouts.find(w => w.id === created!.id)?.completed).toBe(true);
+  });
+
+  it('still resolves normally when the write succeeds', async () => {
+    const created = await storage.createWorkout(workout());
+
+    await expect(
+      storage.updateWorkout(created!.id, { completed: true }),
+    ).resolves.toBeDefined();
+
+    const persisted = JSON.parse(localStorage.getItem('ironpath_workouts') || '[]');
+    expect(persisted.find((w: { id: number }) => w.id === created!.id).completed).toBe(true);
+  });
+});

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -175,6 +175,20 @@ export interface IronPathBackup {
   customExercises: CustomExercise[];
 }
 
+/**
+ * Thrown when an edit could not be written to this device.
+ *
+ * A distinct type so a caller can tell "your data is not durable" apart from a
+ * programming error, and so the message shown to a user is not a raw browser
+ * exception.
+ */
+export class StorageWriteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StorageWriteError';
+  }
+}
+
 export class LocalWorkoutStorage {
   private storageLimit = 5 * 1024 * 1024; // 5MB approximate
   private warningThreshold = 0.8;
@@ -196,19 +210,33 @@ export class LocalWorkoutStorage {
     }
   }
 
-  private safeSetItem(key: string, value: string): void {
+  /**
+   * Write a key, falling back to memory when the browser refuses.
+   *
+   * Returns whether the value actually reached localStorage. That return value
+   * is the whole point: this used to swallow the failure and return normally,
+   * so a caller's `catch` never fired and the success path ran. A workout could
+   * be reported as "Auto-saved" with nothing whatsoever persisted — Safari
+   * private mode, "block all cookies", and an exhausted quota all throw here.
+   *
+   * Falling back to memory is still right: the session keeps working. What was
+   * wrong was not saying so.
+   */
+  private safeSetItem(key: string, value: string): boolean {
     if (typeof localStorage === 'undefined' || this.storageFailed) {
       this.memoryStore[key] = value;
-      return;
+      return false;
     }
     try {
       localStorage.setItem(key, value);
       this.checkQuota();
+      return true;
     } catch (err) {
       console.error('localStorage setItem failed', err);
       this.storageFailed = true;
       this.memoryStore[key] = value;
       this.handleStorageError(err);
+      return false;
     }
   }
 
@@ -450,8 +478,9 @@ export class LocalWorkoutStorage {
     return workouts;
   }
 
-  private saveWorkouts(workouts: Workout[]): void {
-    this.safeSetItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
+  /** Returns whether the workouts actually reached localStorage. */
+  private saveWorkouts(workouts: Workout[]): boolean {
+    return this.safeSetItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
   }
 
   private getExerciseHistory(): Record<string, ExerciseHistoryEntry> {
@@ -643,7 +672,17 @@ export class LocalWorkoutStorage {
     } as Workout;
     
     workouts[index] = updatedWorkout;
-    this.saveWorkouts(workouts);
+
+    // Throwing here is what stops the caller reporting a save that did not
+    // happen. The edit is still in the in-memory store, so the session keeps
+    // working — the user is simply told the truth about durability.
+    if (!this.saveWorkouts(workouts)) {
+      throw new StorageWriteError(
+        'Workout could not be saved to this device. It is kept in memory for ' +
+          'this session only.',
+      );
+    }
+
     if (updates.exercises) {
       this.updateExerciseHistory(updatedWorkout.exercises, updatedWorkout.date);
     }

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { ExerciseForm } from '@/components/exercise-form';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { personalBests } from '@/lib/personal-best';
+import { StorageWriteError } from '@/lib/storage';
 import type { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
 import { parseISODate } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
@@ -139,8 +140,11 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     } catch (error) {
       console.error("Autosave failed", error);
       toast({
-        title: "Save failed",
-        description: "Failed to save workout progress",
+        title: "Not saved to this device",
+        description:
+          error instanceof StorageWriteError
+            ? error.message
+            : "Failed to save workout progress",
         variant: "destructive",
       });
     }


### PR DESCRIPTION
Closes #160.

`safeSetItem` caught the write failure, flipped to an in-memory store, and **returned normally**. So `updateWorkout` resolved, the caller's `catch` never fired, and the success path ran:

```
toast:        "Auto-saved — Your workout progress has been saved"
localStorage: nothing
```

`handleStorageError` did raise its own "working in memory only" toast, so the signal wasn't zero — but the success toast fired too and the header showed a save time. Contradictory feedback on top of real data loss.

**This isn't a hypothetical browser.** `setItem` throws in Safari private mode, with "block all cookies" set, and on an exhausted origin quota.

## Change

`safeSetItem` now returns whether the value actually reached localStorage. `saveWorkouts` passes that through, and `updateWorkout` throws a `StorageWriteError` when it didn't persist.

The `catch` in `workout.tsx` **already did the right thing** — destructive toast, and it skips `lastSavedRef`, the displayed save time, and the success toast. It simply never ran. Its title now reads "Not saved to this device" and it passes through the specific message.

**The memory fallback is deliberately kept.** The session keeps working and the edit stays readable — that part was never wrong. Not saying so was.

## Scope

`updateWorkout` only. `createWorkout` writes through the same path, but throwing there would stop someone starting a workout *at all* in Safari private mode — worse than today's degraded-but-working behaviour, where `handleStorageError` already warns them.

## Guard

`storage-write-failure.test.ts` makes `Storage.prototype.setItem` throw `QuotaExceededError`, then asserts:

- `updateWorkout` **rejects** with a `StorageWriteError`
- the message says the data isn't durable, in words a user can act on
- the session still works, with the edit held in memory
- a successful write still resolves **and** still persists

Confirmed load-bearing — restoring the swallow fails two of the four.

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **139 unit** (4 new), **206 end-to-end** tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)