### PR TITLE
fix: refuse to overwrite a workout another tab has changed

### DIFF
--- a/client/src/hooks/use-workout-storage.tsx
+++ b/client/src/hooks/use-workout-storage.tsx
@@ -137,8 +137,9 @@ export function useWorkoutStorage() {
   const updateWorkout = async (
     id: number,
     updates: Partial<InsertWorkout>,
+    options: { expectedUpdatedAt?: Date | null } = {},
   ) => {
-    const updated = await localWorkoutStorage.updateWorkout(id, updates);
+    const updated = await localWorkoutStorage.updateWorkout(id, updates, options);
     if (updated) {
       setWorkouts((prev) =>
         prev.map((w) => (w.id === id ? updated : w)),

--- a/client/src/lib/concurrent-edit.test.ts
+++ b/client/src/lib/concurrent-edit.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
+import { LocalWorkoutStorage, ConcurrentEditError } from './storage';
+import type { InsertWorkout, Workout } from '@shared/schema';
+
+/**
+ * Two tabs open on the same workout used to silently destroy each other's work.
+ *
+ * Reported sequence: in tab A set the first weight to 211 and let it autosave.
+ * In tab B set the second weight to 222 and let it autosave. A's 211 was gone —
+ * and tab A carried on displaying it, so neither screen showed the truth until
+ * a reload.
+ *
+ * Every save writes the whole workout, including the exercises array the tab
+ * loaded, so the later write wins wholesale. An installed PWA plus the site
+ * open in a browser tab is an ordinary state, not an exotic one.
+ */
+
+const exercise = (weights: number[]) => ({
+  machine: 'Pec Fly',
+  equipment: 'machine' as const,
+  region: 'Chest',
+  feel: 'Medium' as const,
+  sets: weights.map(weight => ({ weight, reps: 10, rest: '1:00', completed: true })),
+  completed: false,
+});
+
+const workout = (): InsertWorkout => ({
+  date: '2026-08-01',
+  type: 'Chest Day',
+  exercises: [exercise([100, 100])],
+  abs: [],
+});
+
+/** Both tabs read the same storage; each holds its own copy of the record. */
+function openInTwoTabs(storage: LocalWorkoutStorage, id: number) {
+  const load = () => storage.getWorkouts().find(w => w.id === id)!;
+  return { tabA: load(), tabB: load() };
+}
+
+const withWeights = (w: Workout, weights: number[]) => ({
+  exercises: [{ ...w.exercises[0], sets: exercise(weights).sets }],
+});
+
+describe('the same workout open in two tabs', () => {
+  let storage: LocalWorkoutStorage;
+  let id: number;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    storage = new LocalWorkoutStorage();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    id = (await storage.createWorkout(workout()))!.id;
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('refuses the second write rather than erasing the first', async () => {
+    const { tabA, tabB } = openInTwoTabs(storage, id);
+
+    // Tab A logs 211 and it lands.
+    await storage.updateWorkout(id, withWeights(tabA, [211, 100]), {
+      expectedUpdatedAt: tabA.updatedAt,
+    });
+    expect(storage.getWorkouts().find(w => w.id === id)!.exercises[0].sets[0].weight).toBe(211);
+
+    // Tab B, still holding the copy it loaded, tries to write its own version.
+    await expect(
+      storage.updateWorkout(id, withWeights(tabB, [100, 222]), {
+        expectedUpdatedAt: tabB.updatedAt,
+      }),
+    ).rejects.toBeInstanceOf(ConcurrentEditError);
+
+    // The whole point: A's set survived.
+    const stored = storage.getWorkouts().find(w => w.id === id)!;
+    expect(stored.exercises[0].sets[0].weight).toBe(211);
+  });
+
+  it('explains where the change came from', async () => {
+    const { tabA, tabB } = openInTwoTabs(storage, id);
+    await storage.updateWorkout(id, withWeights(tabA, [211, 100]), {
+      expectedUpdatedAt: tabA.updatedAt,
+    });
+
+    await expect(
+      storage.updateWorkout(id, withWeights(tabB, [100, 222]), {
+        expectedUpdatedAt: tabB.updatedAt,
+      }),
+    ).rejects.toThrow(/another tab or window/i);
+  });
+
+  it('lets a tab keep saving its own consecutive edits', async () => {
+    let seen = storage.getWorkouts().find(w => w.id === id)!;
+
+    // The check must not fire on a tab's own writes, or autosave would break
+    // for everybody after the first keystroke.
+    for (const weight of [120, 130, 140]) {
+      const saved = await storage.updateWorkout(id, withWeights(seen, [weight, 100]), {
+        expectedUpdatedAt: seen.updatedAt,
+      });
+      expect(saved).toBeDefined();
+      seen = saved!;
+    }
+
+    expect(storage.getWorkouts().find(w => w.id === id)!.exercises[0].sets[0].weight).toBe(140);
+  });
+
+  it('leaves callers that pass no expectation alone', async () => {
+    const { tabA, tabB } = openInTwoTabs(storage, id);
+    await storage.updateWorkout(id, withWeights(tabA, [211, 100]), {
+      expectedUpdatedAt: tabA.updatedAt,
+    });
+
+    // Backwards compatible: without an expectation the check is skipped.
+    await expect(
+      storage.updateWorkout(id, withWeights(tabB, [100, 222])),
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('the timestamp the check depends on', () => {
+  let storage: LocalWorkoutStorage;
+  let id: number;
+
+  beforeEach(async () => {
+    localStorage.clear();
+    storage = new LocalWorkoutStorage();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    id = (await storage.createWorkout(workout()))!.id;
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  /**
+   * `new Date()` has millisecond resolution, so two writes inside the same
+   * millisecond carried identical stamps and a real conflict slipped through.
+   * This surfaced as the suite above failing roughly half the time.
+   */
+  it('advances on every write, even when the clock does not', async () => {
+    // Freeze the clock rather than replacing the Date constructor — the
+    // storage layer parses dates through zod on the way back out, and a
+    // wholesale Date mock breaks that instead of testing this.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T10:00:00.000Z'));
+
+    const stamps: number[] = [];
+    let seen = storage.getWorkouts().find(w => w.id === id)!;
+    for (let i = 0; i < 3; i++) {
+      seen = (await storage.updateWorkout(id, withWeights(seen, [100 + i, 100]), {
+        expectedUpdatedAt: seen.updatedAt,
+      }))!;
+      stamps.push(seen.updatedAt!.getTime());
+    }
+
+    vi.useRealTimers();
+
+    expect(stamps[1]).toBeGreaterThan(stamps[0]);
+    expect(stamps[2]).toBeGreaterThan(stamps[1]);
+  });
+});

--- a/client/src/lib/storage-write-failure.test.ts
+++ b/client/src/lib/storage-write-failure.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
+import { LocalWorkoutStorage, StorageWriteError } from './storage';
+import type { InsertWorkout } from '@shared/schema';
+
+/**
+ * A failed write used to be reported to the user as a successful save.
+ *
+ * `safeSetItem` caught the exception, flipped to an in-memory store and
+ * returned normally, so `updateWorkout` resolved, the caller's `catch` never
+ * fired, and the success path ran: "Auto-saved — Your workout progress has been
+ * saved", with nothing whatsoever in localStorage.
+ *
+ * This is not a hypothetical browser. `setItem` throws in Safari private mode,
+ * with "block all cookies" set, and on an exhausted origin quota.
+ *
+ * Falling back to memory is still the right behaviour — the session keeps
+ * working. What was wrong was not saying so.
+ */
+
+const workout = (): InsertWorkout => ({
+  date: '2026-08-01',
+  type: 'Chest Day',
+  exercises: [
+    {
+      machine: 'Pec Fly',
+      equipment: 'machine',
+      region: 'Chest',
+      feel: 'Medium',
+      sets: [{ weight: 100, reps: 10, rest: '1:00', completed: true }],
+      completed: false,
+    },
+  ],
+  abs: [],
+});
+
+describe('a workout edit that cannot be written to this device', () => {
+  let storage: LocalWorkoutStorage;
+
+  beforeEach(() => {
+    localStorage.clear();
+    storage = new LocalWorkoutStorage();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects rather than resolving, so the caller cannot claim it saved', async () => {
+    const created = await storage.createWorkout(workout());
+    expect(created).toBeDefined();
+
+    // What Safari private mode does.
+    const setItem = vi
+      .spyOn(Storage.prototype, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+      });
+
+    await expect(
+      storage.updateWorkout(created!.id, { completed: true }),
+    ).rejects.toBeInstanceOf(StorageWriteError);
+
+    setItem.mockRestore();
+  });
+
+  it('says the data is not durable, not something a user cannot act on', async () => {
+    const created = await storage.createWorkout(workout());
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+    });
+
+    await expect(
+      storage.updateWorkout(created!.id, { completed: true }),
+    ).rejects.toThrow(/could not be saved to this device/i);
+  });
+
+  it('keeps the session working, holding the edit in memory', async () => {
+    const created = await storage.createWorkout(workout());
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new DOMException('QuotaExceededError', 'QuotaExceededError');
+    });
+
+    await storage.updateWorkout(created!.id, { completed: true }).catch(() => {});
+
+    // The point of the memory fallback: nothing crashes and the value is still
+    // readable for the rest of this session.
+    const workouts = storage.getWorkouts();
+    expect(workouts.find(w => w.id === created!.id)?.completed).toBe(true);
+  });
+
+  it('still resolves normally when the write succeeds', async () => {
+    const created = await storage.createWorkout(workout());
+
+    await expect(
+      storage.updateWorkout(created!.id, { completed: true }),
+    ).resolves.toBeDefined();
+
+    const persisted = JSON.parse(localStorage.getItem('ironpath_workouts') || '[]');
+    expect(persisted.find((w: { id: number }) => w.id === created!.id).completed).toBe(true);
+  });
+});

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -175,6 +175,20 @@ export interface IronPathBackup {
   customExercises: CustomExercise[];
 }
 
+/**
+ * Thrown when an edit could not be written to this device.
+ *
+ * A distinct type so a caller can tell "your data is not durable" apart from a
+ * programming error, and so the message shown to a user is not a raw browser
+ * exception.
+ */
+export class StorageWriteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StorageWriteError';
+  }
+}
+
 export class LocalWorkoutStorage {
   private storageLimit = 5 * 1024 * 1024; // 5MB approximate
   private warningThreshold = 0.8;
@@ -196,19 +210,33 @@ export class LocalWorkoutStorage {
     }
   }
 
-  private safeSetItem(key: string, value: string): void {
+  /**
+   * Write a key, falling back to memory when the browser refuses.
+   *
+   * Returns whether the value actually reached localStorage. That return value
+   * is the whole point: this used to swallow the failure and return normally,
+   * so a caller's `catch` never fired and the success path ran. A workout could
+   * be reported as "Auto-saved" with nothing whatsoever persisted — Safari
+   * private mode, "block all cookies", and an exhausted quota all throw here.
+   *
+   * Falling back to memory is still right: the session keeps working. What was
+   * wrong was not saying so.
+   */
+  private safeSetItem(key: string, value: string): boolean {
     if (typeof localStorage === 'undefined' || this.storageFailed) {
       this.memoryStore[key] = value;
-      return;
+      return false;
     }
     try {
       localStorage.setItem(key, value);
       this.checkQuota();
+      return true;
     } catch (err) {
       console.error('localStorage setItem failed', err);
       this.storageFailed = true;
       this.memoryStore[key] = value;
       this.handleStorageError(err);
+      return false;
     }
   }
 
@@ -450,8 +478,9 @@ export class LocalWorkoutStorage {
     return workouts;
   }
 
-  private saveWorkouts(workouts: Workout[]): void {
-    this.safeSetItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
+  /** Returns whether the workouts actually reached localStorage. */
+  private saveWorkouts(workouts: Workout[]): boolean {
+    return this.safeSetItem(STORAGE_KEYS.WORKOUTS, JSON.stringify(workouts));
   }
 
   private getExerciseHistory(): Record<string, ExerciseHistoryEntry> {
@@ -643,7 +672,17 @@ export class LocalWorkoutStorage {
     } as Workout;
     
     workouts[index] = updatedWorkout;
-    this.saveWorkouts(workouts);
+
+    // Throwing here is what stops the caller reporting a save that did not
+    // happen. The edit is still in the in-memory store, so the session keeps
+    // working — the user is simply told the truth about durability.
+    if (!this.saveWorkouts(workouts)) {
+      throw new StorageWriteError(
+        'Workout could not be saved to this device. It is kept in memory for ' +
+          'this session only.',
+      );
+    }
+
     if (updates.exercises) {
       this.updateExerciseHistory(updatedWorkout.exercises, updatedWorkout.date);
     }

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -189,6 +189,24 @@ export class StorageWriteError extends Error {
   }
 }
 
+/**
+ * Thrown when the stored workout has moved on since this tab last saw it.
+ *
+ * Every save serialises the whole workout — including the exercises array this
+ * tab loaded. Two tabs open on the same workout each wrote their own complete
+ * copy, so the later write erased the earlier one's sets, and both screens
+ * carried on showing numbers that were no longer on disk. The loss was
+ * invisible until a reload.
+ *
+ * An installed PWA plus the site open in a browser tab is an ordinary state.
+ */
+export class ConcurrentEditError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConcurrentEditError';
+  }
+}
+
 export class LocalWorkoutStorage {
   private storageLimit = 5 * 1024 * 1024; // 5MB approximate
   private warningThreshold = 0.8;
@@ -658,17 +676,54 @@ export class LocalWorkoutStorage {
     return newWorkout;
   }
 
-  async updateWorkout(id: number, updates: Partial<InsertWorkout>): Promise<Workout | undefined> {
+  /**
+   * `expectedUpdatedAt` is what the caller last saw on this record. If the
+   * stored copy is newer, another tab has written since, and overwriting would
+   * erase whatever it saved — so this refuses instead. Omit it and the check is
+   * skipped, which keeps every other caller behaving as before.
+   */
+  async updateWorkout(
+    id: number,
+    updates: Partial<InsertWorkout>,
+    options: { expectedUpdatedAt?: Date | null } = {},
+  ): Promise<Workout | undefined> {
     const workouts = this.getWorkouts();
     const index = workouts.findIndex(w => w.id === id);
     
     if (index === -1) return undefined;
+
+    const { expectedUpdatedAt } = options;
+    const storedUpdatedAt = workouts[index].updatedAt;
+    if (
+      expectedUpdatedAt != null &&
+      storedUpdatedAt != null &&
+      storedUpdatedAt.getTime() > expectedUpdatedAt.getTime()
+    ) {
+      throw new ConcurrentEditError(
+        'This workout was changed somewhere else — another tab or window. ' +
+          'Reload to pick up those changes before editing further.',
+      );
+    }
     
+    /*
+     * `updatedAt` must strictly increase, because the conflict check above
+     * compares against it. `new Date()` has millisecond resolution, so two
+     * writes inside the same millisecond — a create followed straight away by
+     * the first autosave, say — would carry identical stamps and a genuine
+     * conflict would slip through. Found by a test that failed about half the
+     * time, not by reading this.
+     */
+    const now = new Date();
+    const nextUpdatedAt =
+      storedUpdatedAt != null && now.getTime() <= storedUpdatedAt.getTime()
+        ? new Date(storedUpdatedAt.getTime() + 1)
+        : now;
+
     const updatedWorkout = {
       ...workouts[index],
       ...updates,
       duration: updates.duration ?? workouts[index].duration ?? null,
-      updatedAt: new Date(),
+      updatedAt: nextUpdatedAt,
     } as Workout;
     
     workouts[index] = updatedWorkout;

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -7,6 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { ExerciseForm } from '@/components/exercise-form';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { personalBests } from '@/lib/personal-best';
+import { StorageWriteError } from '@/lib/storage';
 import type { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
 import { parseISODate } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
@@ -139,8 +140,11 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     } catch (error) {
       console.error("Autosave failed", error);
       toast({
-        title: "Save failed",
-        description: "Failed to save workout progress",
+        title: "Not saved to this device",
+        description:
+          error instanceof StorageWriteError
+            ? error.message
+            : "Failed to save workout progress",
         variant: "destructive",
       });
     }

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -7,7 +7,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { ExerciseForm } from '@/components/exercise-form';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { personalBests } from '@/lib/personal-best';
-import { StorageWriteError } from '@/lib/storage';
+import { ConcurrentEditError, StorageWriteError } from '@/lib/storage';
 import type { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
 import { parseISODate } from '@/lib/utils';
 import { Save, CheckCircle, ArrowLeft } from 'lucide-react';
@@ -82,6 +82,16 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
   const lastSavedRef = useRef<string>(JSON.stringify(initialWorkout));
   const toastIdRef = useRef<string | null>(null);
 
+  /**
+   * The `updatedAt` this tab last saw on the stored record.
+   *
+   * Two tabs on the same workout each save their own complete copy of the
+   * exercises array, so the later write erased the earlier one's sets — with
+   * both screens still showing numbers that were no longer on disk. Sending
+   * what we last saw lets the storage layer refuse rather than clobber.
+   */
+  const expectedUpdatedAtRef = useRef<Date | null>(initialWorkout.updatedAt ?? null);
+
   const workoutRef = useRef<Workout>(initialWorkout);
   const autoSaveEnabledRef = useRef<boolean>(true);
 
@@ -114,15 +124,20 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     const startedAt = currentWorkout.startedAt ?? new Date();
 
     try {
-      await updateWorkout(currentWorkout.id, {
-        exercises: currentWorkout.exercises,
-        abs: currentWorkout.abs,
-        cardio: currentWorkout.cardio,
-        completed: currentWorkout.completed,
-        duration: currentWorkout.duration,
-        startedAt,
-      });
+      const saved = await updateWorkout(
+        currentWorkout.id,
+        {
+          exercises: currentWorkout.exercises,
+          abs: currentWorkout.abs,
+          cardio: currentWorkout.cardio,
+          completed: currentWorkout.completed,
+          duration: currentWorkout.duration,
+          startedAt,
+        },
+        { expectedUpdatedAt: expectedUpdatedAtRef.current },
+      );
 
+      expectedUpdatedAtRef.current = saved?.updatedAt ?? new Date();
       lastSavedRef.current = serialized;
       setLastSavedAt(new Date());
 
@@ -139,13 +154,25 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
       }
     } catch (error) {
       console.error("Autosave failed", error);
+
+      // Autosave retries every couple of seconds, so without stopping it the
+      // same warning would fire on a loop — and every attempt would be another
+      // chance to overwrite what the other tab saved.
+      if (error instanceof ConcurrentEditError) {
+        autoSaveEnabledRef.current = false;
+      }
+
       toast({
-        title: "Not saved to this device",
+        title:
+          error instanceof ConcurrentEditError
+            ? "Changed in another tab"
+            : "Not saved to this device",
         description:
-          error instanceof StorageWriteError
+          error instanceof ConcurrentEditError || error instanceof StorageWriteError
             ? error.message
             : "Failed to save workout progress",
         variant: "destructive",
+        duration: error instanceof ConcurrentEditError ? 10000 : undefined,
       });
     }
   }, [updateWorkout, toast, dismiss]);


### PR DESCRIPTION
Closes #161.

> Contains #202 as well — this branch was built on it because both touch the same save path. Merging this closes both.

Reported sequence: open the same workout in two tabs. In tab A set the first weight to `211`, let it autosave. In tab B set the second to `222`, let it autosave. **A's 211 is gone** — and tab A carries on displaying it, so neither screen shows the truth until a reload.

Every save serialises the whole workout, including the exercises array that tab loaded, so the later write wins wholesale.

## Change

`updateWorkout` takes an optional `expectedUpdatedAt` — what the caller last saw on that record. If the stored copy is newer, another tab has written since, so it throws `ConcurrentEditError` rather than clobbering. Omitting the option skips the check, so every other caller is unaffected.

The workout page tracks what it last saw, refreshes it after each successful save, and **stops autosaving once a conflict is detected** — otherwise the warning would fire every two seconds, and each retry would be another chance to overwrite the other tab.

## A hole the flaky test found

The check compares timestamps, and `new Date()` has millisecond resolution. Two writes inside the same millisecond — a create followed immediately by the first autosave — carried identical stamps, so a genuine conflict slipped straight through.

It showed up as the new suite failing about **half the time**:

```
run 1: 143 passed
run 2: 1 failed | 142 passed
run 3: 143 passed
run 4: 1 failed | 142 passed
```

`updatedAt` is now forced to strictly increase: if the clock hasn't moved past the stored value, the next stamp is stored + 1ms. Five consecutive full runs pass.

I'd have shipped that hole if the test hadn't been flaky enough to notice.

## Guards

`concurrent-edit.test.ts` replays the reported sequence and asserts:

- the second write is **refused** and A's 211 survives
- the message says *where* the change came from
- a tab's **own** consecutive saves are not blocked — otherwise autosave breaks for everybody after the first keystroke
- callers passing no expectation are unaffected
- `updatedAt` advances even with the clock frozen

Confirmed load-bearing: removing the check fails two, reverting the monotonic timestamp fails two.

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **144 unit** tests, **206 end-to-end** tests
- Suite stable across 5 consecutive runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)