### PR TITLE
fix: two places the UI described itself wrongly

### DIFF
--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -25,7 +25,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog';
-import { Settings } from 'lucide-react';
+import { Plus, Settings } from 'lucide-react';
 import { useViewStack } from './view-stack-provider';
 import { ModalTour, TEMPLATE_STEPS } from './ModalTour';
 import { hasSeenTemplateTour, markTemplateTourSeen } from '@/lib/onboarding';
@@ -123,32 +123,35 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
             </div>
           ))}
 
-          <div className="flex items-center space-x-1">
-            <Button
-              variant="outline"
-              className="flex-1 justify-start"
-              data-builder-tour="create-custom"
-              onClick={() => {
-                onCreateCustom();
-                pushView('customWorkoutBuilder');
-              }}
-            >
-              Create Custom Workout
-            </Button>
-            <Button
-              aria-label="Create Custom Workout"
-              variant="ghost"
-              size="icon"
-              onClick={() => {
-                onCreateCustom();
-                pushView('customWorkoutBuilder');
-              }}
-            >
-              <Settings className="h-4 w-4" />
-            </Button>
-          </div>
-
+          {/*
+            * This is an action, not a template.
+            *
+            * It used to sit in the list styled exactly like Chest Day or Legs —
+            * same outlined card, and a gear button beside it. Two things were
+            * wrong with that: it is a verb among nouns, and a gear next to it
+            * implies "configure the create-new action", which is not a thing.
+            *
+            * The gear was also a duplicate: it called the same handler as the
+            * button it sat beside, so the row carried two controls doing one
+            * job, and a screen reader found two buttons with the same name.
+            *
+            * Now it is below the divider that ends the preset list, full width,
+            * with a plus rather than a gear.
+            */}
           <Separator className="my-2" />
+
+          <Button
+            variant="secondary"
+            className="w-full"
+            data-builder-tour="create-custom"
+            onClick={() => {
+              onCreateCustom();
+              pushView('customWorkoutBuilder');
+            }}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Create Custom Workout
+          </Button>
 
           {customTemplates.length > 0 && (
             <div className="pt-2 space-y-2">

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -407,9 +407,18 @@ export function CalendarPage() {
               />
             )}
 
+            {/*
+              * "No custom workout scheduled for this date" — which read as
+              * flatly denying the "Selected Day's Workout: Legs" three lines
+              * above it, and had two wrong words in five.
+              *
+              * `selectedWorkout` is the stored *record*, so this state has
+              * nothing to do with custom templates, and the day is scheduled —
+              * the rotation named it. What is absent is anything logged.
+              */}
             {!selectedWorkout && (
               <p className="text-center text-gray-600 dark:text-gray-400">
-                No custom workout scheduled for this date
+                Nothing logged for this day yet
               </p>
             )}
 

--- a/e2e/backup.spec.ts
+++ b/e2e/backup.spec.ts
@@ -45,7 +45,9 @@ test('a backup exports and restores through the UI', async ({ page }) => {
     localStorage.setItem('ironpath_tour_seen', '1');
   });
   await page.reload();
-  await expect(page.getByText('No custom workout scheduled for this date')).toBeVisible();
+  // Wording changed in #153: this state means nothing has been *logged* for
+  // the day, not that the day is unscheduled.
+  await expect(page.getByText('Nothing logged for this day yet')).toBeVisible();
 
   // Restore from the exported file.
   await page.getByRole('button', { name: 'Settings' }).click();


### PR DESCRIPTION
Closes #153 and #156.

## The calendar panel contradicted itself (#153)

You doubted this one, so I reproduced it against production before touching anything. Every day showed:

```
Selected Day's Workout: Legs
Start Today's Workout
No custom workout scheduled for this date
```

**8 of 8 days checked.** It's on screen constantly — which is why it never registered as a bug: you know "custom" means user-made templates, so you parse it correctly. Someone who doesn't reads "Legs", then "No workout scheduled" three lines later.

Two of those five words are wrong. `selectedWorkout` is the stored **record**, so this state has nothing to do with custom templates — and the day *is* scheduled, the rotation named it two lines above. What's absent is anything **logged**.

It now reads **"Nothing logged for this day yet"**, which can't be read as denying the line above it.

## "Create Custom Workout" looked like a template (#156)

It was rendered exactly like *Chest Day* or *Legs* — same outlined card, same gear icon beside it. A verb among nouns, and a gear next to it implies "configure the create-new action", which isn't a thing.

The gear was also a **duplicate**: it called the same handler as the button it sat beside. So the row held two controls doing one job, and a screen reader found two buttons with the same name:

```
controls named "Create Custom Workout": 1   (was 2)
```

It's now below the divider that ends the preset list — full width, secondary rather than outlined, with a plus rather than a gear. Reads as presets → divider → action.

`data-builder-tour="create-custom"` is preserved, so the builder tour still points at it.

## Test updated

`e2e/backup.spec.ts` used the old sentence as its proxy for "nothing exists for this date". It asserts the new one.

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **144 unit**, **210 end-to-end** tests pass
- Both changes confirmed visually in a built preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)