### PR TITLE
fix: give first-run History something to say

### DIFF
--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -25,7 +25,7 @@ import {
   AlertDialogAction,
   AlertDialogCancel,
 } from '@/components/ui/alert-dialog';
-import { Settings } from 'lucide-react';
+import { Plus, Settings } from 'lucide-react';
 import { useViewStack } from './view-stack-provider';
 import { ModalTour, TEMPLATE_STEPS } from './ModalTour';
 import { hasSeenTemplateTour, markTemplateTourSeen } from '@/lib/onboarding';
@@ -123,32 +123,35 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
             </div>
           ))}
 
-          <div className="flex items-center space-x-1">
-            <Button
-              variant="outline"
-              className="flex-1 justify-start"
-              data-builder-tour="create-custom"
-              onClick={() => {
-                onCreateCustom();
-                pushView('customWorkoutBuilder');
-              }}
-            >
-              Create Custom Workout
-            </Button>
-            <Button
-              aria-label="Create Custom Workout"
-              variant="ghost"
-              size="icon"
-              onClick={() => {
-                onCreateCustom();
-                pushView('customWorkoutBuilder');
-              }}
-            >
-              <Settings className="h-4 w-4" />
-            </Button>
-          </div>
-
+          {/*
+            * This is an action, not a template.
+            *
+            * It used to sit in the list styled exactly like Chest Day or Legs —
+            * same outlined card, and a gear button beside it. Two things were
+            * wrong with that: it is a verb among nouns, and a gear next to it
+            * implies "configure the create-new action", which is not a thing.
+            *
+            * The gear was also a duplicate: it called the same handler as the
+            * button it sat beside, so the row carried two controls doing one
+            * job, and a screen reader found two buttons with the same name.
+            *
+            * Now it is below the divider that ends the preset list, full width,
+            * with a plus rather than a gear.
+            */}
           <Separator className="my-2" />
+
+          <Button
+            variant="secondary"
+            className="w-full"
+            data-builder-tour="create-custom"
+            onClick={() => {
+              onCreateCustom();
+              pushView('customWorkoutBuilder');
+            }}
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Create Custom Workout
+          </Button>
 
           {customTemplates.length > 0 && (
             <div className="pt-2 space-y-2">

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -142,18 +142,27 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
             * button beside it, so the row held two controls doing one job and a
             * screen reader found two buttons with the same name.
             */}
-          <Button
-            variant="outline"
-            className="w-full justify-start border-primary text-primary hover:bg-primary/10 hover:text-primary"
-            data-builder-tour="create-custom"
-            onClick={() => {
-              onCreateCustom();
-              pushView('customWorkoutBuilder');
-            }}
-          >
-            <Plus className="mr-2 h-4 w-4" />
-            Create Custom Workout
-          </Button>
+          <div className="flex items-center space-x-1">
+            <Button
+              variant="outline"
+              className="flex-1 justify-start border-primary text-primary hover:bg-primary/10 hover:text-primary"
+              data-builder-tour="create-custom"
+              onClick={() => {
+                onCreateCustom();
+                pushView('customWorkoutBuilder');
+              }}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Create Custom Workout
+            </Button>
+            {/*
+              * Holds the space a template's gear occupies, so this row ends
+              * where every row above it ends. Without it the button was
+              * `w-full` and ran 44px past them, which read as a mistake rather
+              * than as emphasis.
+              */}
+            <div className="h-10 w-10 shrink-0" aria-hidden="true" />
+          </div>
 
           <Separator className="my-2" />
 

--- a/client/src/components/WorkoutTemplateSelectorModal.tsx
+++ b/client/src/components/WorkoutTemplateSelectorModal.tsx
@@ -124,25 +124,27 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
           ))}
 
           {/*
-            * This is an action, not a template.
+            * This is an action, not a template, and it used to be impossible to
+            * tell: same outlined card as Chest Day or Legs, with a gear beside
+            * it. A verb among nouns, and a gear implying "configure the
+            * create-new action", which is not a thing.
             *
-            * It used to sit in the list styled exactly like Chest Day or Legs —
-            * same outlined card, and a gear button beside it. Two things were
-            * wrong with that: it is a verb among nouns, and a gear next to it
-            * implies "configure the create-new action", which is not a thing.
+            * It stays in the list rather than moving below a divider. Pulling
+            * it out cost a separator plus a full-width row, and that space is
+            * worth most exactly when it is scarcest — a picker holding a lot of
+            * custom workouts already scrolls.
             *
-            * The gear was also a duplicate: it called the same handler as the
-            * button it sat beside, so the row carried two controls doing one
-            * job, and a screen reader found two buttons with the same name.
+            * So the difference is carried by colour instead: the primary teal
+            * on the border, text and icon, against the neutral grey of every
+            * template around it. Same footprint, unmistakably not a template.
             *
-            * Now it is below the divider that ends the preset list, full width,
-            * with a plus rather than a gear.
+            * The gear is gone regardless. It called the same handler as the
+            * button beside it, so the row held two controls doing one job and a
+            * screen reader found two buttons with the same name.
             */}
-          <Separator className="my-2" />
-
           <Button
-            variant="secondary"
-            className="w-full"
+            variant="outline"
+            className="w-full justify-start border-primary text-primary hover:bg-primary/10 hover:text-primary"
             data-builder-tour="create-custom"
             onClick={() => {
               onCreateCustom();
@@ -152,6 +154,8 @@ export function WorkoutTemplateSelectorModal({ open, customTemplates, onClose, o
             <Plus className="mr-2 h-4 w-4" />
             Create Custom Workout
           </Button>
+
+          <Separator className="my-2" />
 
           {customTemplates.length > 0 && (
             <div className="pt-2 space-y-2">

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -407,9 +407,18 @@ export function CalendarPage() {
               />
             )}
 
+            {/*
+              * "No custom workout scheduled for this date" — which read as
+              * flatly denying the "Selected Day's Workout: Legs" three lines
+              * above it, and had two wrong words in five.
+              *
+              * `selectedWorkout` is the stored *record*, so this state has
+              * nothing to do with custom templates, and the day is scheduled —
+              * the rotation named it. What is absent is anything logged.
+              */}
             {!selectedWorkout && (
               <p className="text-center text-gray-600 dark:text-gray-400">
-                No custom workout scheduled for this date
+                Nothing logged for this day yet
               </p>
             )}
 

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -8,10 +8,12 @@ import { BarChart, Calendar, Download, FileText, TrendingUp } from 'lucide-react
 import { parseISODate } from '@/lib/utils';
 import { calculateDayStreak } from '@/lib/streak';
 import { localWorkoutStorage } from '@/lib/storage';
+import { useToast } from '@/hooks/use-toast';
 
 export function HistoryPage() {
   const [selectedPeriod, setSelectedPeriod] = useState<'week' | 'month' | 'year'>('month');
   const { workouts, exportData, exportCSV, loading } = useWorkoutStorage();
+  const { toast } = useToast();
 
 
   const calculateWeightProgress = (completedWorkouts: Workout[]) => {
@@ -123,6 +125,15 @@ export function HistoryPage() {
       if (format === 'json') {
         await exportData();
       } else {
+        // A CSV of nothing is a 31-byte file containing a header row, which
+        // downloaded silently and looked like the export had failed.
+        if (workouts.filter(w => w.completed).length === 0) {
+          toast({
+            title: 'Nothing to export yet',
+            description: 'Finish a workout and its sets will be in the CSV.',
+          });
+          return;
+        }
         await exportCSV();
       }
     } catch (error) {
@@ -232,6 +243,18 @@ export function HistoryPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
+          {/*
+            * On a fresh install both this card and Recent Workouts rendered as
+            * a heading over roughly 110px of nothing. That reads as something
+            * failing to load rather than as "you have not trained yet", and it
+            * is the first screen a new user is likely to reach.
+            */}
+          {getWorkoutsByType().length === 0 && (
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Nothing here yet. Finish a workout and the types you train will
+              show up, with a count for each.
+            </p>
+          )}
           <div className="space-y-2">
             {getWorkoutsByType().map(([type, count]) => (
               <div key={type} className="flex items-center justify-between">
@@ -254,6 +277,11 @@ export function HistoryPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
+          {filteredWorkouts.filter(w => w.completed).length === 0 && (
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              No completed workouts yet. Finish one and it will appear here.
+            </p>
+          )}
           <div className="space-y-3">
             {filteredWorkouts
               .filter(w => w.completed)

--- a/e2e/backup.spec.ts
+++ b/e2e/backup.spec.ts
@@ -45,7 +45,9 @@ test('a backup exports and restores through the UI', async ({ page }) => {
     localStorage.setItem('ironpath_tour_seen', '1');
   });
   await page.reload();
-  await expect(page.getByText('No custom workout scheduled for this date')).toBeVisible();
+  // Wording changed in #153: this state means nothing has been *logged* for
+  // the day, not that the day is unscheduled.
+  await expect(page.getByText('Nothing logged for this day yet')).toBeVisible();
 
   // Restore from the exported file.
   await page.getByRole('button', { name: 'Settings' }).click();

--- a/e2e/history-empty.spec.ts
+++ b/e2e/history-empty.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * On a fresh install, History rendered "Workout Types" and "Recent Workouts"
+ * as headed cards containing nothing at all — roughly 110px of void each, in
+ * both themes, with no copy explaining why. That reads as something failing to
+ * load rather than as "you have not trained yet", on one of the first screens
+ * a new user is likely to reach.
+ *
+ * Export to CSV on the same screen downloaded a 31-byte file — a header row
+ * and nothing else — with no indication anything was amiss.
+ */
+
+test('a first-run History explains itself instead of showing empty cards', async ({ page }) => {
+  await page.goto('/history');
+  await page.waitForTimeout(1200);
+
+  // Both cards are still there — the headings are the page's structure.
+  await expect(page.getByText('Workout Types')).toBeVisible();
+  await expect(page.getByText('Recent Workouts')).toBeVisible();
+
+  // ...but neither is a void any more.
+  await expect(page.getByText(/Nothing here yet/i)).toBeVisible();
+  await expect(page.getByText(/No completed workouts yet/i)).toBeVisible();
+});
+
+test('exporting CSV with nothing logged says so rather than downloading a header row', async ({ page }) => {
+  await page.goto('/history');
+  await page.waitForTimeout(1200);
+
+  let downloadStarted = false;
+  page.on('download', () => { downloadStarted = true; });
+
+  await page.getByRole('button', { name: /Export to CSV/i }).click();
+  await expect(page.getByText(/Nothing to export yet/i)).toBeVisible();
+
+  await page.waitForTimeout(700);
+  expect(downloadStarted, 'an empty CSV should not have been downloaded').toBe(false);
+});


### PR DESCRIPTION
Closes #167. Stacked on #204 — that branch has the wording fixes; merging this closes #153, #156 and #167 together.

On a fresh install, History rendered **Workout Types** and **Recent Workouts** as headed cards containing nothing at all — roughly 110px of void each, in both themes, with no copy explaining why.

Confirmed against production before touching anything:

```
hasWorkoutTypes: true
hasRecent:       true
hasEmptyCopy:    false
```

That reads as something failing to load rather than as "you haven't trained yet" — on one of the first screens a new user reaches.

**Export to CSV** on the same screen downloaded a **31-byte file** — a header row and nothing else — with no indication anything was amiss.

## Change

Both cards now say what they're waiting for, and the CSV export declines with a toast instead of handing over an empty file.

The cards themselves stay. They're the page's structure, and hiding them would make History look like it has fewer features than it does.

## Guard

`e2e/history-empty.spec.ts` asserts both headings are still present, that both explain themselves, and that pressing Export to CSV with nothing logged shows "Nothing to export yet" **and starts no download**.

Confirmed load-bearing — removing the empty states fails two of the four.

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **144 unit**, **214 end-to-end** tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)