### PR TITLE
fix: make BEST trustworthy — show its date, and let it be reset

### DIFF
--- a/client/src/components/ResetPersonalBestDialog.tsx
+++ b/client/src/components/ResetPersonalBestDialog.tsx
@@ -1,0 +1,133 @@
+import { useState, useEffect } from 'react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { formatBestDate, type PersonalBest } from '@/lib/personal-best';
+
+interface ResetPersonalBestDialogProps {
+  machine: string | null;
+  current?: PersonalBest;
+  onClose: () => void;
+  onReset: (options: { manual?: { weight: number; reps: number } }) => void;
+}
+
+/**
+ * Start an exercise's personal best over.
+ *
+ * Deliberately not framed as fixing a mistake. People come here after an
+ * injury, after a year away, or because a figure from a long time ago is not a
+ * useful target any more — and one of those is far more common than a wrong
+ * number. The copy says "reset", never "incorrect".
+ *
+ * Two ways out, because both are reasonable:
+ *
+ *  - clear it, and let the next session you log set the new benchmark
+ *  - name a figure yourself, which stands until something logged beats it
+ *
+ * The second reintroduces a number the app did not observe, which is the thing
+ * this whole area was fixing — so it is labelled "set by you" wherever it
+ * appears, and it is never the default.
+ */
+export function ResetPersonalBestDialog({
+  machine,
+  current,
+  onClose,
+  onReset,
+}: ResetPersonalBestDialogProps) {
+  const [weight, setWeight] = useState('');
+  const [reps, setReps] = useState('');
+
+  // Fields are cleared each time it opens, so a figure typed for one exercise
+  // is never suggested for the next.
+  useEffect(() => {
+    if (machine) {
+      setWeight('');
+      setReps('');
+    }
+  }, [machine]);
+
+  const manualWeight = parseInt(weight, 10);
+  const manualReps = parseInt(reps, 10);
+  const hasManual = !isNaN(manualWeight) && manualWeight > 0;
+  const manualIncomplete = hasManual && (isNaN(manualReps) || manualReps <= 0);
+
+  return (
+    <AlertDialog open={machine !== null} onOpenChange={open => !open && onClose()}>
+      <AlertDialogContent className="max-w-sm">
+        <AlertDialogHeader>
+          <AlertDialogTitle>Reset personal best</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3 text-sm">
+              <p>
+                {machine} currently shows{' '}
+                <strong>
+                  {current?.weight} lbs × {current?.reps} reps
+                </strong>
+                {current?.date ? ` from ${formatBestDate(current.date)}` : ''}.
+              </p>
+              <p>
+                Resetting stops earlier sessions counting towards it. Your next
+                logged session sets the new one.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <div className="space-y-2">
+          <p className="text-sm text-gray-600 dark:text-gray-400">
+            Or start from a figure of your own — optional.
+          </p>
+          <div className="flex items-center space-x-2">
+            <Input
+              type="text"
+              inputMode="numeric"
+              aria-label="Personal best weight"
+              value={weight}
+              onChange={e => /^\d*$/.test(e.target.value) && setWeight(e.target.value)}
+              className="w-20 text-sm"
+              placeholder="lbs"
+            />
+            <span className="text-sm text-gray-500">×</span>
+            <Input
+              type="text"
+              inputMode="numeric"
+              aria-label="Personal best reps"
+              value={reps}
+              onChange={e => /^\d*$/.test(e.target.value) && setReps(e.target.value)}
+              className="w-20 text-sm"
+              placeholder="reps"
+            />
+          </div>
+          {manualIncomplete && (
+            <p className="text-xs text-red-600 dark:text-red-400">
+              Add reps as well, or leave both blank to just clear it.
+            </p>
+          )}
+        </div>
+
+        <AlertDialogFooter className="gap-2">
+          <Button variant="ghost" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            disabled={manualIncomplete}
+            onClick={() =>
+              onReset({
+                manual: hasManual ? { weight: manualWeight, reps: manualReps } : undefined,
+              })
+            }
+          >
+            {hasManual ? 'Set as my best' : 'Reset'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -8,7 +8,7 @@ import { ExerciseImageDialog } from './ExerciseImageDialog';
 import { useToast } from '@/hooks/use-toast';
 import { useCursorEndOnFocus } from '@/hooks/use-cursor-end-on-focus';
 import { hasExerciseImage } from '@/lib/exercise-images';
-import type { PersonalBest } from '@/lib/personal-best';
+import { formatBestDate, type PersonalBest } from '@/lib/personal-best';
 import { localWorkoutStorage } from '@/lib/storage';
 
 interface ExerciseFormProps {
@@ -23,9 +23,14 @@ interface ExerciseFormProps {
    * forever.
    */
   personalBest?: PersonalBest;
+  /**
+   * Opens the reset for this exercise. Omitted in contexts where resetting
+   * makes no sense, in which case the line renders as plain text.
+   */
+  onResetBest?: (machine: string, current: PersonalBest) => void;
 }
 
-export function ExerciseForm({ exercise, onUpdate, isActive = false, personalBest }: ExerciseFormProps) {
+export function ExerciseForm({ exercise, onUpdate, isActive = false, personalBest, onResetBest }: ExerciseFormProps) {
   const [localExercise, setLocalExercise] = useState<Exercise>(exercise);
   const [restDigits, setRestDigits] = useState<string[]>(
     exercise.sets.map((s) => s.rest?.replace(/\D/g, '') || '')
@@ -288,19 +293,44 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false, personalBes
           })}
         </div>
 
-        {/* Best Performance — omitted entirely when there is nothing to compare against */}
+        {/*
+          * Best Performance — omitted entirely when there is nothing to
+          * compare against.
+          *
+          * The date is not decoration. Without it this was an unattributed
+          * number you had to take on faith, and a real user spent a year with
+          * a Seated Dip "best" of 140lbs she had never lifted — a template
+          * default ticked through once in July 2025. A date from a year ago,
+          * on a workout she does not do, would have told her immediately.
+          *
+          * Tapping it opens the reset, because that is where you are when you
+          * decide the figure no longer represents you.
+          */}
         {hasRecordedBest && (
-          <div className="mt-2 flex items-center space-x-2">
+          <button
+            type="button"
+            onClick={() => onResetBest?.(localExercise.machine, personalBest!)}
+            disabled={!onResetBest}
+            className="mt-2 flex w-full items-center space-x-2 rounded text-left disabled:cursor-default"
+          >
             <span className="text-xs text-gray-500 dark:text-gray-400">BEST:</span>
             <span className="text-xs font-medium text-gray-600 dark:text-gray-400">
               {personalBest!.weight} lbs × {personalBest!.reps} reps
             </span>
+            {personalBest!.date && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">
+                {formatBestDate(personalBest!.date)}
+              </span>
+            )}
+            {personalBest!.manual && (
+              <span className="text-xs text-gray-400 dark:text-gray-500">set by you</span>
+            )}
             {getWeightChange().change && (
               <span className={`text-xs ${getWeightChange().color}`}>
                 {getWeightChange().change}
               </span>
             )}
-          </div>
+          </button>
         )}
       </CardContent>
     </Card>

--- a/client/src/lib/exercise-history.test.ts
+++ b/client/src/lib/exercise-history.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, beforeEach, vi, afterEach } from 'vitest';
+import { LocalWorkoutStorage } from './storage';
+import type { InsertWorkout } from '@shared/schema';
+
+/**
+ * Exercise history is what pre-fills your next session's weights, and it used
+ * to be overwritten by whichever workout was saved most recently — regardless
+ * of when that workout happened.
+ *
+ * Found in a real backup. A user's Seated Leg Press history read 130 dated
+ * 2026-07-07, while she had 140 logged and ticked on the 9th, 14th and 21st.
+ * The July 7th workout carried `updatedAt: 2026-07-26`: editing it three weeks
+ * later rewrote her prefill back to the older numbers, and every session after
+ * that started 10lbs light.
+ */
+
+const legPress = (weight: number) => ({
+  machine: 'Seated Leg Press',
+  equipment: 'machine' as const,
+  region: 'Legs',
+  feel: 'Medium' as const,
+  completed: true,
+  sets: [
+    { weight, reps: 10, rest: '1:00', completed: true },
+    { weight, reps: 10, rest: '1:00', completed: true },
+  ],
+});
+
+const workout = (date: string, weight: number): InsertWorkout => ({
+  date,
+  type: "Teresa's",
+  exercises: [legPress(weight)],
+  abs: [],
+});
+
+describe('exercise history', () => {
+  let storage: LocalWorkoutStorage;
+
+  beforeEach(() => {
+    localStorage.clear();
+    storage = new LocalWorkoutStorage();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  /** What the next workout would pre-fill with. */
+  const prefill = async () =>
+    (await storage.getLastExerciseSets('Seated Leg Press'))?.[0]?.weight;
+
+  /** Log a session the way the app does: create the day, then save sets into it. */
+  const log = async (date: string, weight: number) => {
+    const created = await storage.createWorkout(workout(date, weight));
+    await storage.updateWorkout(created!.id, { exercises: [legPress(weight)] });
+    return created!;
+  };
+
+  it('follows the most recent session, not the most recently saved one', async () => {
+    const july7 = await log('2026-07-07', 130);
+    await log('2026-07-21', 140);
+
+    expect(await prefill()).toBe(140);
+
+    // Now edit the older session, as happened in the reported data.
+    await storage.updateWorkout(july7.id, { exercises: [legPress(130)] });
+
+    expect(
+      await prefill(),
+      'editing a three-week-old workout must not drag the prefill backwards',
+    ).toBe(140);
+  });
+
+  it('still moves forward when the newer session is edited', async () => {
+    await log('2026-07-07', 130);
+    const july21 = await log('2026-07-21', 140);
+
+    await storage.updateWorkout(july21.id, { exercises: [legPress(145)] });
+
+    expect(await prefill()).toBe(145);
+  });
+
+  it('records a first session with nothing to compare against', async () => {
+    await log('2026-07-07', 130);
+    expect(await prefill()).toBe(130);
+  });
+
+  it('takes the same date as an update, so correcting today still works', async () => {
+    const today = await log('2026-07-07', 130);
+    await storage.updateWorkout(today.id, { exercises: [legPress(135)] });
+
+    expect(await prefill(), 'fixing a typo in today\'s session must stick').toBe(135);
+  });
+});

--- a/client/src/lib/personal-best.test.ts
+++ b/client/src/lib/personal-best.test.ts
@@ -53,7 +53,7 @@ describe('personalBests', () => {
       workout(3, 'Pec Fly', [set(100, 10)]), // later, but lighter
     ]);
 
-    expect(best.get('Pec Fly')).toEqual({ weight: 120, reps: 8 });
+    expect(best.get('Pec Fly')).toEqual({ weight: 120, reps: 8, date: '2026-08-01' });
   });
 
   it('breaks ties on weight by reps', () => {
@@ -62,7 +62,7 @@ describe('personalBests', () => {
       workout(2, 'Seated Row', [set(100, 12)]),
     ]);
 
-    expect(best.get('Seated Row')).toEqual({ weight: 100, reps: 12 });
+    expect(best.get('Seated Row')).toEqual({ weight: 100, reps: 12, date: '2026-08-01' });
   });
 
   it('ignores sets with no weight or no reps', () => {
@@ -70,7 +70,7 @@ describe('personalBests', () => {
       workout(1, 'Leg Press', [set(undefined, 10), set(200, undefined), set(80, 10)]),
     ]);
 
-    expect(best.get('Leg Press')).toEqual({ weight: 80, reps: 10 });
+    expect(best.get('Leg Press')).toEqual({ weight: 80, reps: 10, date: '2026-08-01' });
   });
 
   it('leaves out the workout in progress', () => {
@@ -81,8 +81,8 @@ describe('personalBests', () => {
 
     // Without this, whatever you have just typed instantly becomes your record
     // and the change indicator can never read anything but zero.
-    expect(personalBests(workouts, 2).get('Bar Curl')).toEqual({ weight: 50, reps: 10 });
-    expect(personalBests(workouts).get('Bar Curl')).toEqual({ weight: 999, reps: 10 });
+    expect(personalBests(workouts, 2).get('Bar Curl')).toEqual({ weight: 50, reps: 10, date: '2026-08-01' });
+    expect(personalBests(workouts).get('Bar Curl')).toEqual({ weight: 999, reps: 10, date: '2026-08-01' });
   });
 
   it('keeps exercises separate', () => {
@@ -91,8 +91,8 @@ describe('personalBests', () => {
       workout(2, 'Leg Press', [set(300, 10)]),
     ]);
 
-    expect(best.get('Pec Fly')).toEqual({ weight: 90, reps: 10 });
-    expect(best.get('Leg Press')).toEqual({ weight: 300, reps: 10 });
+    expect(best.get('Pec Fly')).toEqual({ weight: 90, reps: 10, date: '2026-08-01' });
+    expect(best.get('Leg Press')).toEqual({ weight: 300, reps: 10, date: '2026-08-01' });
     expect(best.get('Never Done')).toBeUndefined();
   });
 
@@ -116,6 +116,65 @@ describe('personalBests', () => {
       workout(1, 'Leg Press', [set(200, 10), prefilled(450, 15)]),
     ]);
 
-    expect(best.get('Leg Press')).toEqual({ weight: 200, reps: 10 });
+    expect(best.get('Leg Press')).toEqual({ weight: 200, reps: 10, date: '2026-08-01' });
+  });
+});
+
+describe('resetting a personal best', () => {
+  /**
+   * People reset for their own reasons — an injury, a year away, or a figure
+   * from long ago that is not a useful target any more. None of these is a
+   * correction, so nothing here treats a reset as fixing a mistake.
+   */
+  const dated = (id: number, date: string, weight: number): Workout =>
+    ({ ...workout(id, 'Seated Dip', [set(weight, 10)]), date }) as Workout;
+
+  it('stops sessions on or before the reset date counting', () => {
+    const best = personalBests(
+      [dated(1, '2025-07-29', 140), dated(2, '2026-06-01', 110)],
+      undefined,
+      [{ machine: 'Seated Dip', resetOn: '2026-01-01' }],
+    );
+
+    expect(best.get('Seated Dip')).toEqual({ weight: 110, reps: 10, date: '2026-06-01' });
+  });
+
+  it('leaves nothing at all when everything logged predates the reset', () => {
+    const best = personalBests([dated(1, '2025-07-29', 140)], undefined, [
+      { machine: 'Seated Dip', resetOn: '2026-01-01' },
+    ]);
+
+    // The line disappears until the next session, rather than falling back to
+    // a lower old figure that is just as stale.
+    expect(best.get('Seated Dip')).toBeUndefined();
+  });
+
+  it('shows a figure the user named, marked as theirs', () => {
+    const best = personalBests([dated(1, '2025-07-29', 140)], undefined, [
+      { machine: 'Seated Dip', resetOn: '2026-01-01', manual: { weight: 90, reps: 10 } },
+    ]);
+
+    expect(best.get('Seated Dip')).toEqual({ weight: 90, reps: 10, manual: true });
+  });
+
+  it('lets a logged session beat the figure the user named', () => {
+    const best = personalBests(
+      [dated(1, '2025-07-29', 140), dated(2, '2026-06-01', 100)],
+      undefined,
+      [{ machine: 'Seated Dip', resetOn: '2026-01-01', manual: { weight: 90, reps: 10 } }],
+    );
+
+    expect(best.get('Seated Dip')).toEqual({ weight: 100, reps: 10, date: '2026-06-01' });
+  });
+
+  it('touches only the exercise it names', () => {
+    const best = personalBests(
+      [dated(1, '2025-07-29', 140), workout(2, 'Pec Fly', [set(165, 15)])],
+      undefined,
+      [{ machine: 'Seated Dip', resetOn: '2026-01-01' }],
+    );
+
+    expect(best.get('Seated Dip')).toBeUndefined();
+    expect(best.get('Pec Fly')).toEqual({ weight: 165, reps: 15, date: '2026-08-01' });
   });
 });

--- a/client/src/lib/personal-best.ts
+++ b/client/src/lib/personal-best.ts
@@ -5,50 +5,73 @@ import type { Workout } from '@shared/schema';
  *
  * The `BEST:` line used to read `bestWeight` off the workout template, where it
  * was a hardcoded constant — and not even a new one: it was the heaviest set in
- * that same template, restated as though it were an achievement. So the app
- * showed every user the same "record" on day one, and kept showing it forever,
- * because a template constant never moves. The weight change indicator was
- * measured against it too, which meant matching the preset's own top set read
- * as a personal record.
+ * that same template, restated as though it were an achievement.
  *
- * The prefilled weights in a template are a different thing and stay exactly as
- * they are: they are a sensible starting point, and being able to load a preset
- * and go is the point of presets. What changes is only the claim about what you
- * have lifted.
+ * Deriving it from logged sets is better, but it is not sufficient on its own.
+ * A real backup showed why: someone opened a Chest Day preset once in July
+ * 2025, changed a single exercise to their own weight, and ticked the rest
+ * through at the template's demo numbers. Every one of those became a permanent
+ * personal best — Seated Dip at 140lbs, a weight they had never lifted — with
+ * nothing on screen to say where it came from or any way to remove it.
+ *
+ * Hence the two things this module now carries beyond the number itself: the
+ * date it was set, so the claim can be checked at a glance, and support for a
+ * reset, so it can be corrected.
  */
 
 export interface PersonalBest {
   weight: number;
   reps: number;
+  /** ISO date of the workout it came from, or undefined when set by hand. */
+  date?: string;
+  /** True when the user set this figure themselves rather than logging it. */
+  manual?: boolean;
+}
+
+/**
+ * A user's decision to start an exercise's record over.
+ *
+ * Reasons are their own — an injury, a year away, or simply wanting a target
+ * that reflects where they are now. Nothing here treats a reset as a
+ * correction of something wrong.
+ */
+export interface PersonalBestReset {
+  machine: string;
+  /** Sets logged on or before this date stop counting. */
+  resetOn: string;
+  /** Optionally, the figure to show instead until it is beaten. */
+  manual?: { weight: number; reps: number };
 }
 
 /**
  * Personal bests for every exercise across the given workouts, keyed by machine.
  *
- * A set counts only once it is marked complete.
+ * A set counts only once it is marked complete. Requiring the tick is
+ * load-bearing: templates arrive with weights already filled in, so counting
+ * any set that merely *has* numbers would make the template's own defaults a
+ * personal best the moment the workout became history.
  *
- * Requiring the tick is load-bearing, not fussiness. Templates arrive with
- * weights already filled in — that is the point of a preset — so counting any
- * set that merely *has* numbers would make the template's own defaults your
- * personal record the moment the workout became history. That is the same
- * invention this replaced, one session later.
- *
- * `excludeWorkoutId` leaves out the session in progress. Without it, typing a
- * weight would immediately become your record and the change indicator would
- * read zero forever — the number is meant to be what you walked in with.
+ * `excludeWorkoutId` leaves out the session in progress, so today's typing does
+ * not become the record it is being compared against.
  *
  * Ties on weight are broken by reps, so 100x12 beats 100x10.
  */
 export function personalBests(
   workouts: Workout[],
   excludeWorkoutId?: number,
+  resets: PersonalBestReset[] = [],
 ): Map<string, PersonalBest> {
   const best = new Map<string, PersonalBest>();
+  const resetByMachine = new Map(resets.map(r => [r.machine, r]));
 
   for (const workout of workouts) {
     if (excludeWorkoutId !== undefined && workout.id === excludeWorkoutId) continue;
 
     for (const exercise of workout.exercises) {
+      const reset = resetByMachine.get(exercise.machine);
+      // Sets from on or before the reset date no longer count towards it.
+      if (reset && workout.date <= reset.resetOn) continue;
+
       for (const set of exercise.sets) {
         if (!set.completed) continue;
         if (typeof set.weight !== 'number' || typeof set.reps !== 'number') continue;
@@ -59,11 +82,38 @@ export function personalBests(
           set.weight > current.weight ||
           (set.weight === current.weight && set.reps > current.reps)
         ) {
-          best.set(exercise.machine, { weight: set.weight, reps: set.reps });
+          best.set(exercise.machine, {
+            weight: set.weight,
+            reps: set.reps,
+            date: workout.date,
+          });
         }
       }
     }
   }
 
+  // A figure the user set by hand stands until something logged beats it.
+  for (const reset of resets) {
+    if (!reset.manual) continue;
+    const logged = best.get(reset.machine);
+    if (!logged || reset.manual.weight > logged.weight) {
+      best.set(reset.machine, { ...reset.manual, manual: true });
+    }
+  }
+
   return best;
+}
+
+/**
+ * "29 Jul 2025" — short enough to sit inline, and explicit about the year,
+ * which is the part that matters when a record has gone stale.
+ */
+export function formatBestDate(iso: string): string {
+  const [year, month, day] = iso.split('-').map(Number);
+  if (!year || !month || !day) return iso;
+  return new Date(year, month - 1, day).toLocaleDateString(undefined, {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
 }

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -626,6 +626,17 @@ export class LocalWorkoutStorage {
         continue;
       }
       const key = e.machine; // use machine name to avoid duplicate codes
+
+      // Only move history forward. This used to overwrite unconditionally, so
+      // editing an old session rewrote "last used" with that session's older
+      // numbers and every future workout pre-filled from them.
+      //
+      // Seen in real data: a user's Seated Leg Press history read 130 dated
+      // 2026-07-07 while she had 140s logged on the 9th, 14th and 21st —
+      // because the July 7th workout was edited on the 26th, after all three.
+      const existing = history[key];
+      if (existing && existing.date > date) continue;
+
       history[key] = {
         sets: e.sets.map(s => ({ weight: s.weight!, reps: s.reps!, rest: s.rest })),
         date,

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -3,6 +3,7 @@ import { exerciseSchema, absExerciseSchema, cardioSchema } from "@shared/schema"
 import { z } from "zod";
 import { toast } from '@/hooks/use-toast';
 import { presetCycleNames } from '@/lib/workout-cycle';
+import type { PersonalBestReset } from '@/lib/personal-best';
 
 export interface CustomWorkoutTemplate {
   id: number;
@@ -23,7 +24,8 @@ const STORAGE_KEYS = {
   PRESET_PROMPTS: 'ironpath_preset_prompts',
   STREAK_DAYS: 'ironpath_streak_days',
   QUARANTINE: 'ironpath_quarantined_workouts',
-  CUSTOM_EXERCISES: 'ironpath_custom_exercises'
+  CUSTOM_EXERCISES: 'ironpath_custom_exercises',
+  PERSONAL_BEST_RESETS: 'ironpath_personal_best_resets'
 } as const;
 
 /**
@@ -849,6 +851,43 @@ export class LocalWorkoutStorage {
       this.syncAutoScheduleName(previousName, updated.name);
     }
     return updated;
+  }
+
+  /**
+   * Exercises whose personal best the user has chosen to start over.
+   *
+   * The reason is theirs — an injury, time away, or simply wanting a target
+   * that reflects where they are now. Nothing here treats a reset as a
+   * correction: it is a normal thing to want, and it is reversible by resetting
+   * again or by logging something heavier.
+   */
+  getPersonalBestResets(): PersonalBestReset[] {
+    try {
+      const stored = this.safeGetItem(STORAGE_KEYS.PERSONAL_BEST_RESETS);
+      const parsed = stored ? JSON.parse(stored) : [];
+      if (!Array.isArray(parsed)) return [];
+      return parsed.filter(
+        (r): r is PersonalBestReset =>
+          typeof r?.machine === 'string' && typeof r?.resetOn === 'string',
+      );
+    } catch {
+      return [];
+    }
+  }
+
+  /** Replaces any previous reset for the same exercise. */
+  savePersonalBestReset(reset: PersonalBestReset): void {
+    const others = this.getPersonalBestResets().filter(r => r.machine !== reset.machine);
+    this.safeSetItem(
+      STORAGE_KEYS.PERSONAL_BEST_RESETS,
+      JSON.stringify([...others, reset]),
+    );
+  }
+
+  /** Undo a reset, so the full logged history counts again. */
+  clearPersonalBestReset(machine: string): void {
+    const remaining = this.getPersonalBestResets().filter(r => r.machine !== machine);
+    this.safeSetItem(STORAGE_KEYS.PERSONAL_BEST_RESETS, JSON.stringify(remaining));
   }
 
   getCustomExercises(): CustomExercise[] {

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -318,13 +318,37 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
     setWorkout(completedWorkout);
     
     try {
-      await updateWorkout(workout.id, {
+      /*
+       * Deliberately not guarded by `expectedUpdatedAt`.
+       *
+       * Completing is an explicit, user-initiated action at the end of a
+       * session. Refusing it over a concurrency check is a worse outcome than
+       * the thing that check prevents, and doing so broke eight existing tests
+       * by leaving people stranded on a workout they had just finished.
+       */
+      const saved = await updateWorkout(workout.id, {
         exercises: completedWorkout.exercises,
         abs: completedWorkout.abs,
         cardio: completedWorkout.cardio,
         completed: true,
-        duration: completedWorkout.duration
+        duration: completedWorkout.duration,
       });
+
+      /*
+       * Both refs must follow what was just written.
+       *
+       * Without this, completing raised "Changed in another tab" on the way
+       * back to the calendar, with one tab open: the stored `updatedAt` moved
+       * on here, this tab kept believing the older value, and the flush that
+       * runs on navigation sent that stale expectation to a concurrency check
+       * doing exactly its job.
+       *
+       * `lastSavedRef` matters too — without it the flush runs at all, despite
+       * this write having just persisted everything.
+       */
+      expectedUpdatedAtRef.current = saved?.updatedAt ?? new Date();
+      lastSavedRef.current = JSON.stringify(completedWorkout);
+
       toast({
         title: "Workout completed! 🎉",
         description: "Great job! Your workout has been saved.",

--- a/client/src/pages/workout.tsx
+++ b/client/src/pages/workout.tsx
@@ -6,7 +6,9 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { ExerciseForm } from '@/components/exercise-form';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
-import { personalBests } from '@/lib/personal-best';
+import { personalBests, type PersonalBest } from '@/lib/personal-best';
+import { ResetPersonalBestDialog } from '@/components/ResetPersonalBestDialog';
+import { localWorkoutStorage } from '@/lib/storage';
 import { ConcurrentEditError, StorageWriteError } from '@/lib/storage';
 import type { Workout, Exercise, AbsExercise, Cardio } from '@shared/schema';
 import { parseISODate } from '@/lib/utils';
@@ -67,9 +69,14 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
    * Memoised because it scans every stored workout, and this page re-renders
    * on each keystroke.
    */
+  const [resetsVersion, setResetsVersion] = useState(0);
+  const [resetting, setResetting] = useState<{ machine: string; current: PersonalBest } | null>(null);
+
   const bests = useMemo(
-    () => personalBests(workouts, initialWorkout.id),
-    [workouts, initialWorkout.id],
+    () => personalBests(workouts, initialWorkout.id, localWorkoutStorage.getPersonalBestResets()),
+    // `resetsVersion` re-reads the resets after one is saved; they live in
+    // storage rather than state because nothing else needs to watch them.
+    [workouts, initialWorkout.id, resetsVersion],
   );
   const focusToEnd = useCursorEndOnFocus();
 
@@ -544,7 +551,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
                             placeholder="time"
                           />
                           <span className="text-xs text-gray-500 dark:text-gray-400">time</span>
-                        </>
+    </>
                       )}
                       <Button
                         variant="ghost"
@@ -644,6 +651,7 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
               onUpdate={(updatedExercise) => handleExerciseUpdate(index, updatedExercise)}
               isActive={index === currentExerciseIndex}
               personalBest={bests.get(exercise.machine)}
+              onResetBest={(machine, current) => setResetting({ machine, current })}
             />
           </ErrorBoundary>
         ))}
@@ -685,6 +693,23 @@ export function WorkoutPage({ workout: initialWorkout, onNavigateBack }: Workout
         </AlertDialogFooter>
       </AlertDialogContent>
       </AlertDialog>
+
+      <ResetPersonalBestDialog
+        machine={resetting?.machine ?? null}
+        current={resetting?.current}
+        onClose={() => setResetting(null)}
+        onReset={({ manual }) => {
+          if (resetting) {
+            localWorkoutStorage.savePersonalBestReset({
+              machine: resetting.machine,
+              resetOn: new Date().toISOString().slice(0, 10),
+              manual,
+            });
+            setResetsVersion(v => v + 1);
+          }
+          setResetting(null);
+        }}
+      />
     </ErrorBoundary>
   );
 }

--- a/e2e/complete-then-leave.spec.ts
+++ b/e2e/complete-then-leave.spec.ts
@@ -1,0 +1,63 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Completing a workout and going back raised "Changed in another tab", with
+ * one tab open.
+ *
+ * `handleCompleteWorkout` saved without passing `expectedUpdatedAt` and never
+ * refreshed the ref that tracks it, so the stored `updatedAt` moved on while
+ * this tab still believed the older value. Leaving the screen then triggers
+ * the flush, which *does* send the expectation — now stale by exactly one
+ * write — and the concurrency check correctly reports a conflict that never
+ * happened.
+ *
+ * It also left `lastSavedRef` behind, so the flush ran at all despite there
+ * being nothing new to write.
+ *
+ * The existing cardio-only spec already walks this flow and passes, because it
+ * asserts on the URL and on storage. Nothing was watching for a toast.
+ */
+
+test('completing a workout and going back does not claim another tab changed it', async ({ page }) => {
+  const autosaveErrors: string[] = [];
+  page.on('console', m => {
+    if (m.type() === 'error' && /Autosave failed/i.test(m.text())) autosaveErrors.push(m.text());
+  });
+
+  await page.addInitScript(() => {
+    localStorage.setItem('ironpath_tour_seen', '1');
+    localStorage.setItem('ironpath_template_tour_seen', '1');
+    localStorage.setItem('ironpath_builder_tour_seen', '1');
+  });
+
+  // The shape this was reported against: a custom, cardio-only session.
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Create or Edit Custom Workout' }).click();
+  await page.getByRole('button', { name: 'Create Custom Workout' }).first().click();
+  await page.getByLabel('Workout name').fill('Just Cardio');
+  await page.getByRole('button', { name: 'Save Workout' }).click();
+  await page.getByRole('button', { name: 'Just Cardio', exact: true }).click();
+  await page.getByRole('button', { name: 'Start', exact: true }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+
+  await page.getByPlaceholder('mm:ss').first().fill('20:00');
+  await page.locator('button[aria-label^="Mark cardio"]').click();
+  await page.waitForTimeout(2600);
+
+  const close = page.getByRole('button', { name: 'Close', exact: true });
+  if (await close.count()) await close.click();
+
+  await page.getByRole('button', { name: 'Complete Workout' }).click();
+  await expect(page).toHaveURL(/\/$/, { timeout: 15000 });
+
+  // The navigation above is what fires the flush; give it room to misfire.
+  await page.waitForTimeout(1500);
+
+  await expect(
+    page.getByText(/Changed in another tab/i),
+    'only one tab is open; nothing changed anywhere else',
+  ).toHaveCount(0);
+  await expect(page.getByText(/changed somewhere else/i)).toHaveCount(0);
+
+  expect(autosaveErrors, 'the flush after completing should not fail').toEqual([]);
+});

--- a/e2e/history-empty.spec.ts
+++ b/e2e/history-empty.spec.ts
@@ -32,7 +32,9 @@ test('exporting CSV with nothing logged says so rather than downloading a header
   page.on('download', () => { downloadStarted = true; });
 
   await page.getByRole('button', { name: /Export to CSV/i }).click();
-  await expect(page.getByText(/Nothing to export yet/i)).toBeVisible();
+  // The toast renders its title and an aria-live status with the same words,
+  // so both match. Either proves it fired.
+  await expect(page.getByText(/Nothing to export yet/i).first()).toBeVisible();
 
   await page.waitForTimeout(700);
   expect(downloadStarted, 'an empty CSV should not have been downloaded').toBe(false);

--- a/e2e/reset-personal-best.spec.ts
+++ b/e2e/reset-personal-best.spec.ts
@@ -1,0 +1,126 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Reproduces a real report, then the way out of it.
+ *
+ * A user's Seated Dip showed a personal best of 140lbs — a Chest Day template
+ * default, ticked through once in July 2025 and never lifted. It sat there for
+ * a year telling her she was down 25lbs, with nothing on screen to say where
+ * the number came from and no way to remove it.
+ *
+ * So: the date has to be visible, and the figure has to be resettable.
+ */
+
+const OLD_SESSION = {
+  id: 4001,
+  date: '2025-07-29',
+  type: 'Chest Day',
+  completed: true,
+  abs: [],
+  cardio: null,
+  exercises: [
+    {
+      machine: 'Seated Dip',
+      equipment: 'machine',
+      region: 'Outer Triceps',
+      feel: 'Medium',
+      completed: true,
+      sets: [
+        { weight: 140, reps: 10, rest: '1:00', completed: true },
+        { weight: 140, reps: 10, rest: '1:00', completed: true },
+      ],
+    },
+  ],
+};
+
+/** Today's session, so the old one counts as history rather than in-progress. */
+const TODAY_SESSION = (date: string) => ({
+  id: 4002,
+  date,
+  type: 'Hers',
+  completed: false,
+  abs: [],
+  cardio: null,
+  exercises: [
+    {
+      machine: 'Seated Dip',
+      equipment: 'machine',
+      region: 'Outer Triceps',
+      feel: 'Medium',
+      completed: false,
+      sets: [{ weight: 115, reps: 10, rest: '1:00', completed: false }],
+    },
+  ],
+});
+
+async function openWorkoutWithStaleBest(page: Page) {
+  const today = new Date();
+  const iso = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
+
+  await page.addInitScript(
+    ([old, todaySession]) => {
+      localStorage.setItem('ironpath_tour_seen', '1');
+      localStorage.setItem('ironpath_workouts', JSON.stringify([old, todaySession]));
+    },
+    [OLD_SESSION, TODAY_SESSION(iso)] as const,
+  );
+
+  await page.goto('/workout/4002');
+  await page.waitForTimeout(1500);
+  await expect(page.getByText('Seated Dip').first()).toBeVisible();
+}
+
+test('a personal best says when it was set', async ({ page }) => {
+  await openWorkoutWithStaleBest(page);
+
+  await expect(page.getByText(/BEST:/)).toBeVisible();
+  await expect(page.getByText('140 lbs × 10 reps')).toBeVisible();
+
+  // The part that would have caught this a year ago.
+  await expect(page.getByText(/2025/)).toBeVisible();
+});
+
+test('a personal best can be reset, and the line goes quiet until you log again', async ({ page }) => {
+  await openWorkoutWithStaleBest(page);
+
+  await page.getByText(/BEST:/).click();
+  await expect(page.getByRole('alertdialog')).toBeVisible();
+  await expect(page.getByText(/Reset personal best/i)).toBeVisible();
+
+  // Framing check: this is not presented as fixing a mistake.
+  const dialog = await page.getByRole('alertdialog').innerText();
+  expect(dialog).not.toMatch(/incorrect|wrong|mistake|error/i);
+
+  await page.getByRole('button', { name: 'Reset', exact: true }).click();
+  await page.waitForTimeout(600);
+
+  await expect(page.getByText(/BEST:/)).toHaveCount(0);
+});
+
+test('a figure you name yourself is shown as yours', async ({ page }) => {
+  await openWorkoutWithStaleBest(page);
+
+  await page.getByText(/BEST:/).click();
+  await page.getByRole('textbox', { name: 'Personal best weight' }).fill('90');
+  await page.getByRole('textbox', { name: 'Personal best reps' }).fill('10');
+  await page.getByRole('button', { name: /Set as my best/i }).click();
+  await page.waitForTimeout(600);
+
+  await expect(page.getByText('90 lbs × 10 reps')).toBeVisible();
+  await expect(page.getByText('set by you')).toBeVisible();
+});
+
+test('a reset survives a reload, because it is stored not remembered', async ({ page }) => {
+  await openWorkoutWithStaleBest(page);
+
+  await page.getByText(/BEST:/).click();
+  await page.getByRole('button', { name: 'Reset', exact: true }).click();
+  await page.waitForTimeout(600);
+  await expect(page.getByText(/BEST:/)).toHaveCount(0);
+
+  await page.reload();
+  await page.waitForTimeout(1500);
+
+  await expect(page.getByText('Seated Dip').first()).toBeVisible();
+  await expect(page.getByText(/BEST:/), 'the 140 must not come back').toHaveCount(0);
+});


### PR DESCRIPTION
All three from your wife's report, traced through the backup she exported.

## What was actually wrong

Her Seated Dip showed a personal best of **140lbs she had never lifted**. Not a computation bug — the app was reading real ticked sets. The cause was one session.

On **2025-07-29** a Chest Day preset was opened, one exercise was changed to her own weight, and the rest were ticked through at the template's demo numbers. Her stored workout against the template:

| exercise | template ships | her session | |
|---|---|---|---|
| Adjustable Cable Crossover | 60×15, 70×15, 90×15 | same | identical |
| Pec Fly | 160×15, 160×15, 165×15 | same | identical |
| Lateral Raise | 60×15, 70×10, 70×10 | same | identical |
| High-Pulley Kick Back | 100×15, 120×10 **rest 1:30**, 120×10 | same | identical |
| **Seated Dip** | **125×15, 140×10, 140×10** | same | **identical** |
| Seated Chest Press | 100×15, 115×10, 115×10 | **30×10 ×3** | ← the one she edited |

**Six exercises' personal bests were template defaults**, from one session, a year ago. Requiring a completed tick wasn't enough — she did tick them.

## 1. Exercise history only moves forward

Separate confirmed bug, visible in the same file. Her Seated Leg Press history read **130 dated 2026-07-07** while she had 140s logged on the 9th, 14th and 21st — because the July 7th workout carried `updatedAt: 2026-07-26`. Editing it three weeks later rewrote her prefill backwards, and every session since started 10lbs light.

`updateExerciseHistory` now refuses a strictly older workout. Editing today still works.

## 2. The date

The line now reads:

> **BEST: 140 lbs × 10 reps  29 Jul 2025**

That turns an unattributed number into something checkable. A date from a year ago, on a workout she doesn't do, would have told her immediately — and it makes a stale record self-evident.

## 3. The reset

Tapping the line opens it.

**Deliberately not framed as fixing a mistake.** People reset after an injury, after a year away, or because a figure from long ago isn't a useful target any more — all more common than a wrong number. The copy says "reset", never "incorrect", and a test greps the dialog to keep it that way:

```ts
expect(dialog).not.toMatch(/incorrect|wrong|mistake|error/i);
```

Two ways out:

- **Clear it** — earlier sessions stop counting, and your next logged session sets the new one.
- **Name a figure yourself** — stands until something logged beats it. This reintroduces a number the app didn't observe, so it's labelled **"set by you"** wherever it appears and is never the default.

Stored per exercise as a date; `personalBests` skips sessions on or before it. Nothing is deleted — resetting again, or logging heavier, moves it on.

## Verification

- ESLint **0 errors**, `tsc --noEmit` clean
- **153 unit**, **222 end-to-end** tests, stable across repeated full runs
- E2E replays her exact scenario: stale 140 from 2025, reset it, confirm it stays gone through a reload

Also fixed a locator of mine in `history-empty.spec.ts` that matched both a toast title and its `aria-live` status — failed on mobile only, and was a real flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)