### PR TITLE
chore: 1.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rest-express",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rest-express",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-express",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "type": "module",
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
Version bump only. `package.json` is the single source — the app reads it at build time and Settings displays it — so this lands before the tag rather than after.

Covers the 55 commits since `v1.3.0`.

Release notes are drafted separately; paste them into the GitHub release when you cut the tag.

## Measured against a build of v1.3.0

| | v1.3.0 | now | |
|---|---|---|---|
| `index-HASH.js` | 530,195 | 524,480 | −5,715 |
| `index-HASH.css` | 83,761 | **55,574** | **−28,187 (−34%)** |
| dependencies | 94 | **40** | **−54** |
| unit tests | 116 | **153** | |
| end-to-end tests | 196 | **224** | |

The JS is only slightly down because 21 dependency updates added roughly what the dead-code removal took out. The CSS is the visible win — a third of it was rules Tailwind generated for 30 components that never rendered.

## Verification

`tsc --noEmit` clean, 153 unit tests, and `version.spec.ts` passes — it asserts Settings shows what `package.json` says and that no unsubstituted placeholder reaches the bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)