### PR TITLE
feat: remember where you were on the calendar, and give it a way home

### DIFF
--- a/client/src/components/calendar-grid.tsx
+++ b/client/src/components/calendar-grid.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button';
 import type { Workout } from '@shared/schema';
 import { generateWorkoutSchedule } from '@/lib/workout-data';
 import { cn, formatLocalDate } from '@/lib/utils';
+import { isSameMonth } from '@/lib/calendar-position';
 
 const monthNames = [
   'January', 'February', 'March', 'April', 'May', 'June',
@@ -108,6 +109,8 @@ export function CalendarGrid({
     return workoutSchedule.find(w => w.date === date);
   };
 
+  const showingCurrentMonth = isSameMonth(currentDate, new Date());
+
   const navigateMonth = (direction: 'prev' | 'next') => {
     const newDate = new Date(currentDate);
     newDate.setMonth(month + (direction === 'next' ? 1 : -1));
@@ -126,9 +129,37 @@ export function CalendarGrid({
         >
           <ChevronLeft className="h-4 w-4" />
         </Button>
-        <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
-          {monthNames[month]} {year}
-        </h2>
+        <div className="flex flex-col items-center">
+          <h2 className="text-xl font-semibold text-gray-900 dark:text-white">
+            {monthNames[month]} {year}
+          </h2>
+          {/*
+            * The way home.
+            *
+            * There was none: once you had browsed to June, the only route back
+            * was tapping the arrow the same number of times. That is what made
+            * the old "Start Today's Workout" feel missed — it always acted on
+            * today regardless of what was selected, so it doubled as an escape
+            * hatch, but only by claiming one day while acting on another.
+            *
+            * Hidden while the current month is on screen, so it is not a
+            * permanent control that does nothing most of the time.
+            */}
+          {!showingCurrentMonth && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                const now = new Date();
+                onDateChange(now);
+                onSelectDate(formatLocalDate(now));
+              }}
+              className="h-auto p-0 text-xs font-medium text-primary hover:bg-transparent hover:text-primary/80"
+            >
+              Today
+            </Button>
+          )}
+        </div>
         <Button
           variant="ghost"
           size="sm"

--- a/client/src/lib/calendar-position.ts
+++ b/client/src/lib/calendar-position.ts
@@ -1,0 +1,56 @@
+/**
+ * Where you were on the calendar, so returning from a workout puts you back.
+ *
+ * Browse back two months to check what you lifted, open the session, come back
+ * — and the calendar had reset to today, because the page unmounts and its
+ * `useState(new Date())` runs again. Six months back meant six taps to return.
+ *
+ * `sessionStorage`, deliberately, not `localStorage`. Position is a property of
+ * the visit, not of you: it should survive moving between screens and be gone
+ * when you next open the app, because landing anywhere but today on a fresh
+ * open would be worse than the problem this fixes.
+ *
+ * Reading on mount rather than hooking navigation means every route back is
+ * covered without knowing about any of them — the in-app arrow, the browser
+ * back button, and a swipe on an installed PWA all just remount the page.
+ */
+
+const KEY = 'ironpath_calendar_position';
+
+export interface CalendarPosition {
+  /** The month on screen, as YYYY-MM-01. */
+  month: string;
+  /** The highlighted day, as YYYY-MM-DD. */
+  selectedDate: string;
+}
+
+const isMonth = (v: unknown): v is string => typeof v === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(v);
+
+export function readCalendarPosition(): CalendarPosition | null {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<CalendarPosition>;
+    if (!isMonth(parsed.month) || !isMonth(parsed.selectedDate)) return null;
+    return { month: parsed.month, selectedDate: parsed.selectedDate };
+  } catch {
+    // A private-mode browser can refuse sessionStorage outright. Losing your
+    // place is a far smaller problem than failing to render the calendar.
+    return null;
+  }
+}
+
+export function writeCalendarPosition(position: CalendarPosition): void {
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify(position));
+  } catch {
+    /* see above */
+  }
+}
+
+/** Whether `date` falls in the same month as `reference` — used to hide "Today". */
+export function isSameMonth(date: Date, reference: Date): boolean {
+  return (
+    date.getFullYear() === reference.getFullYear() && date.getMonth() === reference.getMonth()
+  );
+}

--- a/client/src/pages/calendar.tsx
+++ b/client/src/pages/calendar.tsx
@@ -8,6 +8,7 @@ import { WorkoutCard } from '@/components/workout-card';
 import { useWorkoutStorage } from '@/hooks/use-workout-storage';
 import { generateWorkoutSchedule, workoutTemplates } from '@/lib/workout-data';
 import { parseISODate, formatLocalDate } from '@/lib/utils';
+import { readCalendarPosition, writeCalendarPosition } from '@/lib/calendar-position';
 import { calculateDayStreak, calculateTopDayStreak } from '@/lib/streak';
 import { WorkoutTemplateSelectorModal } from '@/components/WorkoutTemplateSelectorModal';
 import { CustomWorkoutBuilderModal } from '@/components/CustomWorkoutBuilderModal';
@@ -24,10 +25,32 @@ import { hasSeenTour, recordVisit } from '@/lib/onboarding';
 let visitRecorded = false;
 
 export function CalendarPage() {
-  const [currentDate, setCurrentDate] = useState(new Date());
-  const [selectedDate, setSelectedDate] = useState<string | null>(
-    () => formatLocalDate(new Date())
+  /*
+   * Restored from the visit, not reset to today.
+   *
+   * This page unmounts whenever a workout is opened, so `useState(new Date())`
+   * ran again on the way back and threw away however far you had browsed. Six
+   * months back to check something meant six taps to return.
+   *
+   * Reading here rather than hooking navigation covers every route back at
+   * once — the in-app arrow, the browser back button, and a swipe on an
+   * installed PWA all simply remount this.
+   */
+  const restored = readCalendarPosition();
+  const [currentDate, setCurrentDate] = useState(
+    () => (restored ? parseISODate(restored.month) : new Date()),
   );
+  const [selectedDate, setSelectedDate] = useState<string | null>(
+    () => restored?.selectedDate ?? formatLocalDate(new Date()),
+  );
+
+  useEffect(() => {
+    if (!selectedDate) return;
+    writeCalendarPosition({
+      month: formatLocalDate(new Date(currentDate.getFullYear(), currentDate.getMonth(), 1)),
+      selectedDate,
+    });
+  }, [currentDate, selectedDate]);
   const { currentView, pushView, popView } = useViewStack();
   const [, setLocation] = useLocation();
   const [selectedWorkout, setSelectedWorkout] = useState<Workout | null>(null);

--- a/e2e/calendar-position.spec.ts
+++ b/e2e/calendar-position.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * The calendar had no memory and no way home.
+ *
+ * Browse back two months to check what you lifted, open the session, come back
+ * — and it had reset to today, because the page unmounts and its
+ * `useState(new Date())` runs again. Six months back meant six taps to return.
+ *
+ * And there was no "Today" control at all, so once you had wandered, the only
+ * route back was the arrow, the same number of times. That is what made the
+ * pre-#152 "Start Today's Workout" feel missed: it always acted on today
+ * whatever was selected, so it doubled as an escape hatch — but only by
+ * claiming one day while acting on another.
+ */
+
+const monthOnScreen = (page: Page) =>
+  page.evaluate(() => (document.body.innerText.match(/[A-Z][a-z]+ \d{4}/) || ['?'])[0]);
+
+async function openCalendar(page: Page) {
+  await page.addInitScript(() => localStorage.setItem('ironpath_tour_seen', '1'));
+  await page.goto('/');
+  await page.waitForTimeout(900);
+}
+
+async function back(page: Page, times: number) {
+  for (let i = 0; i < times; i++) {
+    await page.getByRole('button', { name: 'Previous month' }).click();
+    await page.waitForTimeout(300);
+  }
+}
+
+test('coming back from a workout returns you to the month you were on', async ({ page }) => {
+  await openCalendar(page);
+  const start = await monthOnScreen(page);
+
+  await back(page, 2);
+  const browsed = await monthOnScreen(page);
+  expect(browsed, 'two taps should have moved the calendar').not.toBe(start);
+
+  await page.getByRole('button', { name: '15', exact: true }).first().click();
+  await page.waitForTimeout(400);
+  await page.getByRole('button', { name: /Start This Workout|Start Today's Workout/ }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.waitForTimeout(1200);
+
+  await page.getByRole('button', { name: 'Go back' }).click();
+  await page.waitForTimeout(1200);
+
+  expect(await monthOnScreen(page), 'the browsed month should still be on screen').toBe(browsed);
+});
+
+test('the browser back button restores it too', async ({ page }) => {
+  await openCalendar(page);
+  await back(page, 3);
+  const browsed = await monthOnScreen(page);
+
+  await page.getByRole('button', { name: '10', exact: true }).first().click();
+  await page.waitForTimeout(400);
+  await page.getByRole('button', { name: /Start This Workout|Start Today's Workout/ }).click();
+  await expect(page).toHaveURL(/\/workout\/\d+$/);
+  await page.waitForTimeout(1200);
+
+  // Not the in-app arrow — the real back button, which a PWA swipe also uses.
+  await page.goBack();
+  await page.waitForTimeout(1200);
+
+  expect(await monthOnScreen(page)).toBe(browsed);
+});
+
+test('a fresh visit still lands on today', async ({ page }) => {
+  await openCalendar(page);
+  await back(page, 4);
+  const browsed = await monthOnScreen(page);
+
+  // A new context is a new session, which is where the position lives.
+  const fresh = await page.context().browser()!.newContext();
+  const other = await fresh.newPage();
+  await other.addInitScript(() => localStorage.setItem('ironpath_tour_seen', '1'));
+  await other.goto(page.url());
+  await other.waitForTimeout(900);
+
+  const now = new Date();
+  const expected = now.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  expect(await monthOnScreen(other), 'opening the app afresh must start at today').toBe(expected);
+  expect(await monthOnScreen(other)).not.toBe(browsed);
+  await fresh.close();
+});
+
+test('Today appears only when you have wandered, and takes you back', async ({ page }) => {
+  await openCalendar(page);
+
+  const today = page.getByRole('button', { name: 'Today', exact: true });
+  await expect(today, 'nothing to escape from on the current month').toHaveCount(0);
+
+  await back(page, 2);
+  const browsed = await monthOnScreen(page);
+  await expect(today).toBeVisible();
+
+  await today.click();
+  await page.waitForTimeout(500);
+
+  const now = new Date();
+  expect(await monthOnScreen(page)).toBe(
+    now.toLocaleDateString('en-US', { month: 'long', year: 'numeric' }),
+  );
+  expect(await monthOnScreen(page)).not.toBe(browsed);
+
+  // And the one-tap-to-train path is back, without the button having lied.
+  await expect(page.getByRole('button', { name: "Start Today's Workout" })).toBeVisible();
+  await expect(today, 'it hides again once you are home').toHaveCount(0);
+});


### PR DESCRIPTION
Closes #208. Both halves of what you described, which turned out to be one root cause.

## Memory

Reproduced on production first:

```
start:            August 2026
after 2x back:    June 2026
opened workout:   /workout/1
after going back: August 2026   ← two taps of navigation, gone
```

Position now lives in **`sessionStorage`**, deliberately not `localStorage` — it's a property of the visit, not of you. It survives moving between screens and is gone next time you open the app, because landing anywhere but today on a fresh open would be worse than the problem being fixed.

**On the back button:** I didn't have to hook it. Reading position on mount rather than intercepting navigation covers every route back at once — the in-app arrow, the browser back button, and a swipe on an installed PWA all just remount the page. There's a test for the real `goBack()` specifically.

## A way home

Your point about "Start Today's Workout" was right about the need and, I think, wrong about the cause. That button doubled as an escape hatch — it always acted on today whatever was selected — but only by claiming one day while acting on another. #152 removed the lie and, with it, the accidental escape hatch.

So the escape hatch is now its own control: **Today**, under the month name, **hidden while the current month is showing** as you asked. Tapping it returns to today, selected — and the panel button then reads "Start Today's Workout" and does exactly that. One-tap-to-train restored, nothing misdescribing itself.

## Guards

`e2e/calendar-position.spec.ts`:

- returning from a workout keeps the browsed month
- the **browser** back button does too
- a fresh session still starts at today
- Today appears only when you've wandered, takes you home, and hides again

Confirmed load-bearing — removing the restore fails 4 of 8; showing Today unconditionally fails 2.

## Verification

ESLint **0 errors**, `tsc --noEmit` clean, **153 unit** and **232 end-to-end** tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)