### PR TITLE
feat: show what you have lifted over time

### DIFF
--- a/client/src/components/LiftProgressDialog.tsx
+++ b/client/src/components/LiftProgressDialog.tsx
@@ -1,0 +1,80 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/dialog';
+import { Sparkline } from '@/components/Sparkline';
+import { describeProgress, type LiftProgress } from '@/lib/progression';
+
+interface LiftProgressDialogProps {
+  lift: LiftProgress | null;
+  onClose: () => void;
+}
+
+const monthYear = (iso: string) =>
+  new Date(Number(iso.slice(0, 4)), Number(iso.slice(5, 7)) - 1, Number(iso.slice(8, 10)))
+    .toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
+
+/**
+ * One lift, over time.
+ *
+ * The headline is the number you are at now and how it got there in words; the
+ * line underneath is the shape of that, larger than the one in the list but
+ * still without axes or gridlines. The dates below it are the only labels,
+ * because two dates are enough to read a line and a full axis on a 412px phone
+ * is not.
+ *
+ * Scrolling lives on an inner element rather than DialogContent — that is the
+ * arrangement iOS handles, and getting it wrong is what made three dialogs
+ * unscrollable here before.
+ */
+export function LiftProgressDialog({ lift, onClose }: LiftProgressDialogProps) {
+  return (
+    <Dialog open={lift !== null} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-sm overflow-hidden p-0">
+        {lift && (
+          <div className="max-h-[80vh] overflow-y-auto overscroll-contain p-6">
+            <DialogHeader className="text-left">
+              <DialogTitle>{lift.machine}</DialogTitle>
+              <DialogDescription>
+                {describeProgress(lift)}
+              </DialogDescription>
+            </DialogHeader>
+
+            <div className="mt-6 text-primary">
+              <Sparkline values={lift.points.map(p => p.weight)} width={280} height={80} />
+            </div>
+
+            {lift.sessions > 1 && (
+              <div className="mt-1 flex justify-between text-xs text-gray-500 dark:text-gray-400">
+                <span>{monthYear(lift.firstDate)}</span>
+                <span>{monthYear(lift.lastDate)}</span>
+              </div>
+            )}
+
+            <dl className="mt-6 space-y-2 text-sm">
+              <div className="flex justify-between">
+                <dt className="text-gray-500 dark:text-gray-400">Now</dt>
+                <dd className="font-medium text-gray-900 dark:text-white">{lift.current} lbs</dd>
+              </div>
+              {lift.sessions > 1 && (
+                <div className="flex justify-between">
+                  <dt className="text-gray-500 dark:text-gray-400">
+                    When you started
+                  </dt>
+                  <dd className="font-medium text-gray-900 dark:text-white">{lift.first} lbs</dd>
+                </div>
+              )}
+              <div className="flex justify-between">
+                <dt className="text-gray-500 dark:text-gray-400">Sessions logged</dt>
+                <dd className="font-medium text-gray-900 dark:text-white">{lift.sessions}</dd>
+              </div>
+            </dl>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/Sparkline.tsx
+++ b/client/src/components/Sparkline.tsx
@@ -1,0 +1,71 @@
+interface SparklineProps {
+  /** Oldest first. */
+  values: number[];
+  width?: number;
+  height?: number;
+  className?: string;
+}
+
+/**
+ * The shape of a number over time. No axes, no gridlines, no labels, no
+ * library.
+ *
+ * Deliberately not a chart. It sits beside a sentence that already says what
+ * happened — "125 lbs, up 45 since Jul 2025" — so its whole job is to show the
+ * shape of getting there. Anything more would be decoration competing with the
+ * text for the same job, and this app removed 54 dependencies rather than keep
+ * a charting one.
+ *
+ * Inherits `currentColor`, so it takes the colour of whatever it sits in and
+ * needs no dark-mode handling of its own.
+ */
+export function Sparkline({ values, width = 64, height = 20, className }: SparklineProps) {
+  if (values.length === 0) return null;
+
+  const max = Math.max(...values);
+  const min = Math.min(...values);
+  const span = max - min;
+
+  // Inset by the stroke so the line is never clipped at the extremes.
+  const pad = 1.5;
+  const usableW = width - pad * 2;
+  const usableH = height - pad * 2;
+
+  const x = (i: number) =>
+    values.length === 1 ? width / 2 : pad + (i / (values.length - 1)) * usableW;
+
+  // A flat run has no span to divide by; draw it down the middle rather than
+  // at the top, which is what a naive normalisation does.
+  const y = (v: number) => (span === 0 ? height / 2 : pad + (1 - (v - min) / span) * usableH);
+
+  if (values.length === 1) {
+    return (
+      <svg width={width} height={height} className={className} aria-hidden="true">
+        <circle cx={x(0)} cy={y(values[0])} r={2} fill="currentColor" />
+      </svg>
+    );
+  }
+
+  const d = values.map((v, i) => `${i === 0 ? 'M' : 'L'}${x(i).toFixed(1)},${y(v).toFixed(1)}`).join(' ');
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={className}
+      aria-hidden="true"
+    >
+      <path
+        d={d}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.5}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* Where you are now, so the eye lands on the end of the line. */}
+      <circle cx={x(values.length - 1)} cy={y(values[values.length - 1])} r={2} fill="currentColor" />
+    </svg>
+  );
+}

--- a/client/src/lib/progression.test.ts
+++ b/client/src/lib/progression.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { liftProgress, describeProgress } from './progression';
+import type { Workout } from '@shared/schema';
+
+/**
+ * Shaped around a real year of data: Seated Row climbing 80 → 125 across
+ * twelve months, which is the story the app could not tell.
+ */
+
+const set = (weight?: number, reps = 10, completed = true) => ({ weight, reps, completed });
+
+const workout = (
+  id: number,
+  date: string,
+  machine: string,
+  sets: ReturnType<typeof set>[],
+): Workout =>
+  ({
+    id,
+    date,
+    type: "Teresa's",
+    exercises: [
+      {
+        machine,
+        equipment: 'machine' as const,
+        region: 'Back',
+        feel: 'Medium' as const,
+        sets,
+        completed: false,
+      },
+    ],
+    abs: [],
+    cardio: null,
+    completed: true,
+    duration: null,
+    startedAt: null,
+    createdAt: null,
+    updatedAt: null,
+  }) as Workout;
+
+describe('liftProgress', () => {
+  it('is empty when nothing has been logged', () => {
+    expect(liftProgress([])).toEqual([]);
+  });
+
+  it('gives one point per session, not per set', () => {
+    const [row] = liftProgress([
+      workout(1, '2025-07-22', 'Seated Row', [set(80), set(80), set(80)]),
+      workout(2, '2026-07-21', 'Seated Row', [set(120), set(125), set(125)]),
+    ]);
+
+    expect(row.points).toEqual([
+      { date: '2025-07-22', weight: 80, reps: 10 },
+      { date: '2026-07-21', weight: 125, reps: 10 },
+    ]);
+    expect(row.sessions).toBe(2);
+  });
+
+  it('takes the heaviest completed set of the day', () => {
+    const [row] = liftProgress([
+      workout(1, '2025-07-22', 'Seated Row', [set(80), set(95), set(85)]),
+    ]);
+    expect(row.current).toBe(95);
+  });
+
+  it('ignores sets that were never ticked', () => {
+    // Templates arrive pre-filled; an untouched default is not a lift.
+    const [row] = liftProgress([
+      workout(1, '2025-07-22', 'Seated Row', [set(80), set(230, 15, false)]),
+    ]);
+    expect(row.current).toBe(80);
+  });
+
+  it('reports the change across the whole span', () => {
+    const [row] = liftProgress([
+      workout(1, '2025-07-22', 'Seated Row', [set(80)]),
+      workout(2, '2026-01-01', 'Seated Row', [set(105)]),
+      workout(3, '2026-07-21', 'Seated Row', [set(125)]),
+    ]);
+
+    expect(row.first).toBe(80);
+    expect(row.current).toBe(125);
+    expect(row.change).toBe(45);
+    expect(row.firstDate).toBe('2025-07-22');
+    expect(row.lastDate).toBe('2026-07-21');
+  });
+
+  it('forgets sessions hidden by a reset', () => {
+    // The reason this matters: a template default ticked through once, a year
+    // ago, would open the trend with a spike and make every real session after
+    // it read as decline.
+    const rows = liftProgress(
+      [
+        workout(1, '2025-07-29', 'Seated Dip', [set(140)]),
+        workout(2, '2026-06-01', 'Seated Dip', [set(90)]),
+        workout(3, '2026-07-01', 'Seated Dip', [set(110)]),
+      ],
+      [{ machine: 'Seated Dip', resetOn: '2026-01-01' }],
+    );
+
+    const dip = rows.find(r => r.machine === 'Seated Dip')!;
+    expect(dip.points.map(p => p.weight)).toEqual([90, 110]);
+    expect(dip.change, 'up 20, not down 30').toBe(20);
+  });
+
+  it('puts the lift you trained most recently first', () => {
+    const rows = liftProgress([
+      workout(1, '2025-01-01', 'Old Machine', [set(50)]),
+      workout(2, '2026-07-21', 'Current Machine', [set(100)]),
+    ]);
+
+    expect(rows.map(r => r.machine)).toEqual(['Current Machine', 'Old Machine']);
+  });
+
+  it('collapses two workouts sharing a date into one point', () => {
+    const [row] = liftProgress([
+      workout(1, '2026-07-21', 'Seated Row', [set(100)]),
+      workout(2, '2026-07-21', 'Seated Row', [set(120)]),
+    ]);
+
+    expect(row.sessions).toBe(1);
+    expect(row.current).toBe(120);
+  });
+});
+
+describe('describeProgress', () => {
+  const of = (weights: number[], dates: string[]) =>
+    liftProgress(weights.map((w, i) => workout(i, dates[i], 'Seated Row', [set(w)])))[0];
+
+  it('says what it is on a first session, without inventing a trend', () => {
+    expect(describeProgress(of([80], ['2026-07-21']))).toBe('80 lbs · first session');
+  });
+
+  it('leads with where you are now', () => {
+    const text = describeProgress(of([80, 125], ['2025-07-22', '2026-07-21']));
+    expect(text).toMatch(/^125 lbs/);
+    expect(text).toContain('up 45');
+    expect(text).toContain('Jul 2025');
+  });
+
+  it('is neutral when a number has gone down', () => {
+    // Injuries and deloads are normal. This app has already been caught once
+    // telling someone they were underperforming against a figure they never
+    // set, and that must not happen here.
+    const text = describeProgress(of([125, 100], ['2025-07-22', '2026-07-21']));
+    expect(text).toContain('down 25');
+    expect(text).not.toMatch(/lost|worse|fail|behind|regress/i);
+  });
+
+  it('does not pretend a flat year is progress', () => {
+    expect(describeProgress(of([100, 100], ['2025-07-22', '2026-07-21']))).toContain('same as');
+  });
+});

--- a/client/src/lib/progression.ts
+++ b/client/src/lib/progression.ts
@@ -1,0 +1,151 @@
+import type { Workout } from '@shared/schema';
+import type { PersonalBestReset } from './personal-best';
+
+/**
+ * What you have lifted on each machine, session by session.
+ *
+ * The question this answers is "am I getting stronger", and the honest answer
+ * for a normal person is a sentence — "Seated Row, 125 lbs, up 45 since July
+ * 2025" — not a chart. The shape is decoration on top of that sentence, which
+ * is why everything here produces the sentence's ingredients first and the
+ * series second.
+ *
+ * Two rules are borrowed deliberately from `personalBests`, so the two never
+ * disagree on screen:
+ *
+ *  - only sets marked complete count, because templates arrive pre-filled and
+ *    an untouched default is not something you lifted
+ *  - a reset hides sessions on or before its date
+ *
+ * The second matters more here than it looks. A stale record — a template
+ * default ticked through once, a year ago — would open the trend with a spike
+ * and make every real session afterwards read as decline. Someone resetting
+ * that record is telling us to forget it; forgetting it only for the record
+ * and not for the trend would be half a fix.
+ */
+
+export interface SessionPoint {
+  /** ISO date of the session. */
+  date: string;
+  /** Heaviest completed set that day. */
+  weight: number;
+  reps: number;
+}
+
+export interface LiftProgress {
+  machine: string;
+  /** Oldest first. One entry per session, never per set. */
+  points: SessionPoint[];
+  /** Heaviest set in the most recent session. */
+  current: number;
+  /** Heaviest set in the earliest session still counted. */
+  first: number;
+  /** `current - first`. Negative is fine and is not framed as failure. */
+  change: number;
+  firstDate: string;
+  lastDate: string;
+  sessions: number;
+}
+
+function heaviestCompletedSet(
+  workout: Workout,
+  machine: string,
+): { weight: number; reps: number } | undefined {
+  let best: { weight: number; reps: number } | undefined;
+
+  for (const exercise of workout.exercises) {
+    if (exercise.machine !== machine) continue;
+    for (const set of exercise.sets) {
+      if (!set.completed) continue;
+      if (typeof set.weight !== 'number' || typeof set.reps !== 'number') continue;
+      if (!best || set.weight > best.weight || (set.weight === best.weight && set.reps > best.reps)) {
+        best = { weight: set.weight, reps: set.reps };
+      }
+    }
+  }
+
+  return best;
+}
+
+/**
+ * One entry per exercise you have logged, most recently trained first.
+ *
+ * That ordering is on purpose: the lifts you are currently training are the
+ * ones you want to see, and something you last touched a year ago sinking to
+ * the bottom is the right outcome rather than a problem to solve.
+ */
+export function liftProgress(
+  workouts: Workout[],
+  resets: PersonalBestReset[] = [],
+): LiftProgress[] {
+  const resetByMachine = new Map(resets.map(r => [r.machine, r]));
+  const byMachine = new Map<string, Map<string, SessionPoint>>();
+
+  for (const workout of workouts) {
+    const machines = new Set<string>();
+    for (const exercise of workout.exercises) machines.add(exercise.machine);
+
+    for (const machine of Array.from(machines)) {
+      const reset = resetByMachine.get(machine);
+      if (reset && workout.date <= reset.resetOn) continue;
+
+      const best = heaviestCompletedSet(workout, machine);
+      if (!best) continue;
+
+      let sessions = byMachine.get(machine);
+      if (!sessions) {
+        sessions = new Map();
+        byMachine.set(machine, sessions);
+      }
+
+      // Two workouts can share a date — the heaviest of them is the day's set.
+      const existing = sessions.get(workout.date);
+      if (!existing || best.weight > existing.weight) {
+        sessions.set(workout.date, { date: workout.date, ...best });
+      }
+    }
+  }
+
+  const result: LiftProgress[] = [];
+  for (const [machine, sessions] of Array.from(byMachine.entries())) {
+    const points = Array.from(sessions.values()).sort((a, b) => a.date.localeCompare(b.date));
+    if (points.length === 0) continue;
+
+    const first = points[0];
+    const last = points[points.length - 1];
+    result.push({
+      machine,
+      points,
+      current: last.weight,
+      first: first.weight,
+      change: last.weight - first.weight,
+      firstDate: first.date,
+      lastDate: last.date,
+      sessions: points.length,
+    });
+  }
+
+  return result.sort((a, b) => b.lastDate.localeCompare(a.lastDate) || a.machine.localeCompare(b.machine));
+}
+
+/**
+ * The sentence, in the app's voice.
+ *
+ * Neutral about direction on purpose. A number going down is an injury, a
+ * deload, or a bad month — not a failure to be pointed at, and this app has
+ * already been caught once telling someone they were underperforming against
+ * a figure they never set.
+ */
+export function describeProgress(lift: LiftProgress): string {
+  if (lift.sessions < 2) return `${lift.current} lbs · first session`;
+
+  const since = new Date(
+    Number(lift.firstDate.slice(0, 4)),
+    Number(lift.firstDate.slice(5, 7)) - 1,
+    Number(lift.firstDate.slice(8, 10)),
+  ).toLocaleDateString(undefined, { month: 'short', year: 'numeric' });
+
+  if (lift.change === 0) return `${lift.current} lbs · same as ${since}`;
+  const direction = lift.change > 0 ? 'up' : 'down';
+  return `${lift.current} lbs · ${direction} ${Math.abs(lift.change)} since ${since}`;
+}

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -296,8 +296,8 @@ export function HistoryPage() {
         <CardContent>
           {lifts.length === 0 && (
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              Nothing here yet. Tick a set as done and the weights you lift will
-              show up, with how they have moved.
+              No lifts logged yet. Tick a set as done and the weights you
+              lift will show up here, with how they have moved.
             </p>
           )}
           <div className="space-y-1">

--- a/client/src/pages/history.tsx
+++ b/client/src/pages/history.tsx
@@ -9,11 +9,21 @@ import { parseISODate } from '@/lib/utils';
 import { calculateDayStreak } from '@/lib/streak';
 import { localWorkoutStorage } from '@/lib/storage';
 import { useToast } from '@/hooks/use-toast';
+import { liftProgress, describeProgress, type LiftProgress } from '@/lib/progression';
+import { Sparkline } from '@/components/Sparkline';
+import { LiftProgressDialog } from '@/components/LiftProgressDialog';
 
 export function HistoryPage() {
   const [selectedPeriod, setSelectedPeriod] = useState<'week' | 'month' | 'year'>('month');
   const { workouts, exportData, exportCSV, loading } = useWorkoutStorage();
   const { toast } = useToast();
+  const [openLift, setOpenLift] = useState<LiftProgress | null>(null);
+
+  /* Scans every stored workout, and this page re-renders on filter changes. */
+  const lifts = useMemo(
+    () => liftProgress(workouts, localWorkoutStorage.getPersonalBestResets()),
+    [workouts],
+  );
 
 
   const calculateWeightProgress = (completedWorkouts: Workout[]) => {
@@ -268,6 +278,54 @@ export function HistoryPage() {
         </CardContent>
       </Card>
 
+      {/*
+        * Your lifts.
+        *
+        * The insight is the sentence — "125 lbs, up 45 since Jul 2025" — and
+        * the shape beside it is decoration on top of that, not the other way
+        * round. Most recently trained first, so what you are working on now is
+        * what you see.
+        */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center">
+            <TrendingUp className="h-5 w-5 mr-2" />
+            Your lifts
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {lifts.length === 0 && (
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Nothing here yet. Tick a set as done and the weights you lift will
+              show up, with how they have moved.
+            </p>
+          )}
+          <div className="space-y-1">
+            {lifts.map(lift => (
+              <button
+                key={lift.machine}
+                type="button"
+                onClick={() => setOpenLift(lift)}
+                className="flex w-full items-center justify-between rounded p-2 text-left hover:bg-gray-50 dark:hover:bg-gray-800"
+              >
+                <span className="min-w-0 flex-1 pr-3">
+                  <span className="block truncate text-sm font-medium text-gray-900 dark:text-white">
+                    {lift.machine}
+                  </span>
+                  <span className="block text-xs text-gray-600 dark:text-gray-400">
+                    {describeProgress(lift)}
+                  </span>
+                </span>
+                <Sparkline
+                  values={lift.points.map(p => p.weight)}
+                  className="shrink-0 text-primary"
+                />
+              </button>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+
       {/* Recent Workouts */}
       <Card>
         <CardHeader>
@@ -331,6 +389,8 @@ export function HistoryPage() {
           </div>
         </CardContent>
       </Card>
+
+      <LiftProgressDialog lift={openLift} onClose={() => setOpenLift(null)} />
     </div>
   );
 }

--- a/e2e/progression.spec.ts
+++ b/e2e/progression.spec.ts
@@ -95,7 +95,7 @@ test('untouched template weights never appear as progress', async ({ page }) => 
   untouched.exercises[0].sets[0].completed = false;
 
   await openHistory(page, [untouched]);
-  await expect(page.getByText(/Nothing here yet/)).toBeVisible();
+  await expect(page.getByText(/No lifts logged yet/)).toBeVisible();
   await expect(page.getByText(/230 lbs/)).toHaveCount(0);
 });
 

--- a/e2e/progression.spec.ts
+++ b/e2e/progression.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Progress over time, built sentence-first.
+ *
+ * The insight is "125 lbs, up 45 since Jul 2025". The shape beside it is
+ * decoration on top of that, which is why these tests assert on the words
+ * before anything visual — if the drawing ever went away the feature would
+ * still work, and that is the property worth protecting.
+ */
+
+const session = (id: number, date: string, machine: string, weight: number) => ({
+  id,
+  date,
+  type: "Teresa's",
+  completed: true,
+  abs: [],
+  cardio: null,
+  duration: 65,
+  exercises: [
+    {
+      machine,
+      equipment: 'machine',
+      region: 'Back',
+      feel: 'Medium',
+      completed: true,
+      sets: [{ weight, reps: 10, rest: '1:00', completed: true }],
+    },
+  ],
+});
+
+/** A year of Seated Row, 80 → 125, which is the story this exists to tell. */
+const YEAR = [
+  ['2025-07-22', 80], ['2025-08-05', 90], ['2025-09-23', 100],
+  ['2025-10-14', 105], ['2025-12-11', 120], ['2026-07-21', 125],
+] as const;
+
+async function openHistory(page: Page, workouts: unknown[]) {
+  await page.addInitScript(w => {
+    localStorage.setItem('ironpath_tour_seen', '1');
+    localStorage.setItem('ironpath_workouts', JSON.stringify(w));
+  }, workouts);
+  await page.goto('/history');
+  await page.waitForTimeout(1400);
+}
+
+test('a year of training reads as one sentence', async ({ page }) => {
+  await openHistory(page, YEAR.map(([d, w], i) => session(i + 1, d, 'Seated Row', w)));
+
+  await expect(page.getByText('Your lifts')).toBeVisible();
+  await expect(page.getByText('Seated Row', { exact: true })).toBeVisible();
+  await expect(page.getByText(/125 lbs · up 45 since Jul 2025/)).toBeVisible();
+});
+
+test('tapping a lift opens its detail', async ({ page }) => {
+  await openHistory(page, YEAR.map(([d, w], i) => session(i + 1, d, 'Seated Row', w)));
+
+  await page.getByRole('button', { name: /Seated Row/ }).first().click();
+  const dialog = page.getByRole('dialog');
+  await expect(dialog).toBeVisible();
+
+  await expect(dialog.getByText(/125 lbs · up 45 since Jul 2025/)).toBeVisible();
+  // Exact, because "Jul 2025" also appears inside the sentence above.
+  await expect(dialog.getByText('Jul 2025', { exact: true })).toBeVisible();
+  await expect(dialog.getByText('Jul 2026', { exact: true })).toBeVisible();
+
+  await expect(dialog.getByText('Now')).toBeVisible();
+  await expect(dialog.getByText('When you started')).toBeVisible();
+  await expect(dialog.getByText('Sessions logged')).toBeVisible();
+  await expect(dialog.getByText('80 lbs')).toBeVisible();
+});
+
+test('a number going down is stated, not scolded', async ({ page }) => {
+  // Injuries and deloads are normal, and this app has already been caught once
+  // telling someone they were underperforming against a figure they never set.
+  await openHistory(page, [
+    session(1, '2025-07-22', 'Seated Row', 125),
+    session(2, '2026-07-21', 'Seated Row', 100),
+  ]);
+
+  await expect(page.getByText(/100 lbs · down 25 since Jul 2025/)).toBeVisible();
+
+  const card = await page.getByText('Your lifts').locator('xpath=ancestor::div[1]').innerText();
+  expect(card).not.toMatch(/lost|worse|fail|behind|regress/i);
+});
+
+test('one session does not pretend to be a trend', async ({ page }) => {
+  await openHistory(page, [session(1, '2026-07-21', 'Seated Row', 80)]);
+  await expect(page.getByText(/80 lbs · first session/)).toBeVisible();
+});
+
+test('untouched template weights never appear as progress', async ({ page }) => {
+  // The whole reason `completed` is required: presets arrive pre-filled.
+  const untouched = session(1, '2026-07-21', 'Seated Row', 230);
+  untouched.exercises[0].sets[0].completed = false;
+
+  await openHistory(page, [untouched]);
+  await expect(page.getByText(/Nothing here yet/)).toBeVisible();
+  await expect(page.getByText(/230 lbs/)).toHaveCount(0);
+});
+
+test('a reset hides the sessions it was meant to forget', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'ironpath_personal_best_resets',
+      JSON.stringify([{ machine: 'Seated Dip', resetOn: '2026-01-01' }]),
+    );
+  });
+  await openHistory(page, [
+    session(1, '2025-07-29', 'Seated Dip', 140), // the stale template default
+    session(2, '2026-06-01', 'Seated Dip', 90),
+    session(3, '2026-07-01', 'Seated Dip', 110),
+  ]);
+
+  // Up 20 from the real starting point, not down 30 from a figure never lifted.
+  await expect(page.getByText(/110 lbs · up 20 since Jun 2026/)).toBeVisible();
+  await expect(page.getByText(/down 30/)).toHaveCount(0);
+});


### PR DESCRIPTION
The app stored a year of training and couldn't tell you the story in it. Your wife's Seated Row runs **80 → 125 across twelve months**; nothing on any screen said so.

## Sentence first, shape second

The insight is a sentence — **"125 lbs · up 45 since Jul 2025"** — and the drawing beside it is decoration on top of that.

Built in that order on purpose: if the graphics were deleted tomorrow, the feature would still work. That's the opposite of how a chart-first version fails, and it's why the tests assert on the *words* before anything visual.

Three layers, each of which stands alone:

| | |
|---|---|
| **Your lifts** card in History | one line per exercise, most recently trained first |
| a sparkline beside each | 64×20, one path, no axes |
| tap for detail | bigger line, two date labels, the numbers |

## What it counts

Heaviest completed set per session, per machine. Two rules borrowed from `personalBests` so the two never disagree on screen:

- **only ticked sets count** — templates arrive pre-filled, and an untouched default isn't something you lifted
- **a reset hides sessions on or before its date**

The second matters more than it looks. That stale Seated Dip 140 would otherwise open the trend with a spike and make every real session after it read as decline. Resetting a record is someone telling us to forget it; forgetting it for the record but not the trend would be half a fix.

## Neutral about direction

A number going down is an injury, a deload, or a bad month. It reads `down 25 since Jul 2025` and nothing else — asserted by a test that greps the card:

```ts
expect(card).not.toMatch(/lost|worse|fail|behind|regress/i);
```

We've been caught once already telling someone they were underperforming against a figure they never set.

## No chart library

One hand-drawn SVG path. No axes, no gridlines, no legend, inherits `currentColor` so dark mode needs nothing.

```
JS   524,480 → 530,300   +5,820 bytes
CSS   55,574 →  55,963     +389 bytes
```

Roughly a fiftieth of what re-adding recharts would have cost, after spending the week removing 54 dependencies.

Detail scrolls on an inner element rather than `DialogContent` — the arrangement iOS handles, and the one that made three dialogs unscrollable here before.

## Verification

ESLint **0 errors**, `tsc --noEmit` clean, **165 unit** and **242 end-to-end** tests pass. Rendered against a realistic year of data before writing the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)