### PR TITLE
feat: say which build you are looking at

### DIFF
--- a/client/src/components/SettingsDialog.tsx
+++ b/client/src/components/SettingsDialog.tsx
@@ -175,7 +175,9 @@ export function SettingsDialog({ children }: { children: React.ReactNode }) {
           Storage Usage: {Math.round(usage.percent * 100)}% ({(usage.used / 1024).toFixed(1)} KB of {(usage.limit / 1024).toFixed(1)} KB)
         </div>
         <div className="text-sm text-gray-500 dark:text-gray-400">
-          IronPath v{__APP_VERSION__}<br />
+          IronPath v{__APP_VERSION__}{' '}
+          <span className="text-gray-400 dark:text-gray-500">{__APP_BUILD__}</span>
+          <br />
           Created by Casey Flanigan<br />
           This is an open source project which can be found here: https://github.com/crflanigan/IronPath
         </div>

--- a/client/src/global.d.ts
+++ b/client/src/global.d.ts
@@ -4,3 +4,5 @@
  * render it). See `version.test.ts` for the guard that keeps the two in step.
  */
 declare const __APP_VERSION__: string;
+/** "PR #210 · 9ffdc4d" on a preview, "9ffdc4d" in production, "dev" locally. */
+declare const __APP_BUILD__: string;

--- a/client/src/lib/version.test.ts
+++ b/client/src/lib/version.test.ts
@@ -51,3 +51,34 @@ describe('the displayed app version', () => {
     expect(offenders).toEqual([]);
   });
 });
+
+/**
+ * The version alone could not say which build you were looking at. It moves
+ * only at release time, so every deploy preview between releases showed the
+ * same number as production — precisely when knowing the difference matters
+ * most, because you are testing a preview and asking "is this the new one?".
+ */
+describe('the build identity', () => {
+  const read = (rel: string) => readFileSync(path.join(REPO_ROOT, rel), 'utf-8');
+  const config = read('vite.config.ts');
+
+  it('is injected at build time, like the version', () => {
+    expect(config).toMatch(/__APP_BUILD__:\s*JSON\.stringify/);
+  });
+
+  it('comes from the deploy, not from anything committed', () => {
+    // Hardcoding it would go stale the moment it was written.
+    expect(config).toContain('process.env.COMMIT_REF');
+    expect(config).toContain('process.env.REVIEW_ID');
+  });
+
+  it('is declared, so a typo is a compile error rather than "undefined"', () => {
+    expect(read('client/src/global.d.ts')).toContain('__APP_BUILD__');
+  });
+
+  it('is shown beside the version in Settings', () => {
+    const settings = read('client/src/components/SettingsDialog.tsx');
+    expect(settings).toContain('__APP_VERSION__');
+    expect(settings).toContain('__APP_BUILD__');
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,9 +19,24 @@ const { version } = JSON.parse(
   readFileSync(path.resolve(DIRNAME, "package.json"), "utf-8"),
 ) as { version: string };
 
+/**
+ * Which build you are looking at.
+ *
+ * The version alone could not answer that. It only moves at release time, so
+ * every deploy preview between releases showed the same number as production
+ * and there was no way to tell them apart in the app — which matters most
+ * exactly when you are testing a preview and asking "is this the new one?".
+ *
+ * Netlify sets these at build time. Locally they are undefined, which is its
+ * own useful answer.
+ */
+const commit = process.env.COMMIT_REF?.slice(0, 7) ?? "dev";
+const review = process.env.REVIEW_ID ? `PR #${process.env.REVIEW_ID}` : "";
+
 export default defineConfig({
   define: {
     __APP_VERSION__: JSON.stringify(version),
+    __APP_BUILD__: JSON.stringify([review, commit].filter(Boolean).join(" · ")),
   },
   plugins: [
     react(),


### PR DESCRIPTION
You couldn't tell a preview from production, and that's been biting us all day — "is this live yet?" came up repeatedly.

The version only moves at release time, so **every deploy preview between releases showed the same number as production.** Settings said `v1.4.0` whether you were on ironpath.app or on a PR preview.

## Now

```
local        IronPath v1.4.0 dev
production   IronPath v1.4.0 9ffdc4d
preview      IronPath v1.4.0 PR #210 · 9ffdc4d
```

Injected at build time from Netlify's `COMMIT_REF` and `REVIEW_ID`, using the same `define` mechanism the version already uses — so nothing is committed that can go stale. Undefined locally, which is its own useful answer.

The SHA earns its place on production too: after merging something, you can now confirm at a glance that what's in your browser is what you merged, rather than a cached service-worker build.

## Verified by rendering, not by grepping

All three shapes were confirmed by building with those variables set and reading the line out of a real browser:

```
COMMIT_REF=9ffdc4d… REVIEW_ID=210 npm run build
→ "IronPath v1.4.0 PR #210 · 9ffdc4d"
```

That distinction matters here more than usual — checking the bundle contains a string proves the build, not the render.

## Guards

`version.test.ts` gains four checks alongside the existing ones: injected rather than hardcoded, sourced from the deploy environment, declared in `global.d.ts` so a typo is a compile error rather than `undefined`, and actually shown in Settings.

ESLint **0 errors**, `tsc --noEmit` clean, **157 unit** and **232 end-to-end** tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)