### PR TITLE
Fold completed exercises to a single line

### DIFF
--- a/client/src/components/exercise-form.tsx
+++ b/client/src/components/exercise-form.tsx
@@ -36,6 +36,34 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false, personalBes
     exercise.sets.map((s) => s.rest?.replace(/\D/g, '') || '')
   );
   const [showHelp, setShowHelp] = useState(false);
+
+  /*
+   * A finished exercise folds to one line.
+   *
+   * The workout page measured 4628px — five and a half screens — with ten
+   * completed cards at ~304px each. Every set meant scrolling past everything
+   * already done to reach the thing being done now, which is friction on every
+   * single set rather than once per session.
+   *
+   * Seeded from completion *at mount*, deliberately, rather than tracking it.
+   * An exercise already finished when you arrive is folded. One you finish
+   * right now stays open: collapsing it the instant you tick the last set
+   * would pull 240px out from under the finger still resting on that circle,
+   * and those circles are already the easiest thing in the app to hit by
+   * mistake — folding on a mis-tap hides the control needed to undo it.
+   *
+   * Either way it is a per-session choice, so correcting a number is one tap
+   * and leaving the screen resets it to folded.
+   */
+  const [expanded, setExpanded] = useState(!exercise.completed);
+  const collapsed = localExercise.completed && !expanded;
+
+  /** The heaviest set, which is what you want to see at a glance. */
+  const topSet = localExercise.sets.reduce<{ weight?: number; reps?: number } | null>(
+    (best, set) =>
+      typeof set.weight === 'number' && (!best || set.weight > (best.weight ?? -1)) ? set : best,
+    null,
+  );
   const { toast } = useToast();
   const focusToEnd = useCursorEndOnFocus();
 
@@ -137,14 +165,57 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false, personalBes
   return (
     <>
     <Card className={`border-l-4 ${borderColor}`}>
+      {collapsed ? (
+        <CardContent className="p-3">
+          <button
+            type="button"
+            onClick={() => setExpanded(true)}
+            aria-expanded={false}
+            aria-label={`Show ${localExercise.machine}`}
+            className="flex w-full items-center justify-between text-left"
+          >
+            <span className="min-w-0 flex-1 pr-3">
+              <span className="block truncate text-sm font-medium text-gray-900 dark:text-white">
+                {localExercise.machine}
+              </span>
+              {topSet?.weight !== undefined && (
+                <span className="block text-xs text-gray-600 dark:text-gray-400">
+                  {topSet.weight} lbs{topSet.reps !== undefined && ` × ${topSet.reps} reps`}
+                </span>
+              )}
+            </span>
+            <Check className="h-5 w-5 shrink-0 text-green-500" />
+          </button>
+        </CardContent>
+      ) : (
       <CardContent className="p-4">
         <div className="flex items-center justify-between mb-3">
-          <div>
-            <h4 className="font-medium text-gray-900 dark:text-white">{localExercise.machine}</h4>
-            <p className="text-sm text-gray-600 dark:text-gray-400">
-              {localExercise.region} • {localExercise.feel} Feel
-            </p>
-          </div>
+          {/*
+            * Foldable again once finished, so checking a number does not leave
+            * the card open for the rest of the session. Not a button at all
+            * while the exercise is unfinished — there is nothing to fold.
+            */}
+          {localExercise.completed ? (
+            <button
+              type="button"
+              onClick={() => setExpanded(false)}
+              aria-expanded={true}
+              aria-label={`Hide ${localExercise.machine}`}
+              className="min-w-0 flex-1 pr-2 text-left"
+            >
+              <h4 className="font-medium text-gray-900 dark:text-white">{localExercise.machine}</h4>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {localExercise.region} • {localExercise.feel} Feel
+              </p>
+            </button>
+          ) : (
+            <div>
+              <h4 className="font-medium text-gray-900 dark:text-white">{localExercise.machine}</h4>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                {localExercise.region} • {localExercise.feel} Feel
+              </p>
+            </div>
+          )}
           <div className="flex items-center space-x-2">
             {hasReferencePhoto && (
               <button
@@ -333,6 +404,7 @@ export function ExerciseForm({ exercise, onUpdate, isActive = false, personalBes
           </button>
         )}
       </CardContent>
+      )}
     </Card>
     <ExerciseImageDialog
       exerciseName={localExercise.machine}

--- a/e2e/collapse-completed.spec.ts
+++ b/e2e/collapse-completed.spec.ts
@@ -1,0 +1,214 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * A finished exercise folds to one line.
+ *
+ * The workout page measured 4628px — five and a half screens — because a
+ * completed card is ~304px and looks exactly like an unfinished one. Reaching
+ * the exercise you are actually on meant scrolling past everything already
+ * done, on every set rather than once per session.
+ *
+ * The subtle rule these tests exist to hold is *when* a card folds. Folding on
+ * arrival is the point; folding under a finger that has just tapped a set
+ * circle is a bug — it pulls 240px out from under the tap, and those circles
+ * are the easiest thing in this app to hit by mistake, so the fold would hide
+ * the very control needed to undo the mis-tap.
+ */
+
+const set = (weight: number, completed: boolean) => ({
+  weight,
+  reps: 10,
+  rest: '1:00',
+  completed,
+});
+
+/** Three lifts: two behind you, one in front. */
+function session() {
+  return {
+    id: 1,
+    date: '2026-07-25',
+    type: 'Chest Day',
+    completed: false,
+    duration: null,
+    startedAt: null,
+    // As `createWorkout` stamps them. Without these the record can never
+    // autosave at all, which is a separate bug and not what this file tests.
+    createdAt: '2026-07-25T12:00:00.000Z',
+    updatedAt: '2026-07-25T12:00:00.000Z',
+    abs: [],
+    cardio: null,
+    exercises: [
+      {
+        code: 'S24',
+        machine: 'Wide Grip Pulldown',
+        region: 'Back',
+        feel: 'Medium',
+        completed: true,
+        // Heaviest in the middle, so "top set" cannot pass by reading the last.
+        sets: [set(100, true), set(110, true), set(105, true)],
+      },
+      {
+        code: 'S25',
+        machine: 'Seated Row',
+        region: 'Back',
+        feel: 'Medium',
+        completed: true,
+        sets: [set(120, true), set(120, true), set(120, true)],
+      },
+      {
+        code: 'S26',
+        machine: 'Preacher Curl',
+        region: 'Arms',
+        feel: 'Medium',
+        completed: false,
+        sets: [set(0, false)],
+      },
+    ],
+  };
+}
+
+/** The height of an exercise's card, folded or not. */
+async function cardHeight(page: Page, machine: string): Promise<number> {
+  const box = await page
+    .getByRole('button', { name: new RegExp(`^(Show|Hide) ${machine}$`) })
+    .locator('xpath=ancestor::div[contains(@class,"border-l-4")][1]')
+    .boundingBox();
+  if (!box) throw new Error(`no card for ${machine}`);
+  return box.height;
+}
+
+/**
+ * Finishing the last exercise triggers the end-of-workout celebration.
+ *
+ * Waited for rather than polled once: it renders a beat after the tap, and
+ * while it is open Radix marks the rest of the page `aria-hidden`, so a missed
+ * dismissal makes every later `getByRole` look like the element never existed.
+ */
+async function dismissCelebration(page: Page) {
+  const close = page.getByRole('button', { name: 'Close', exact: true });
+  await close.waitFor({ state: 'visible', timeout: 4000 }).catch(() => {});
+  if (await close.count()) await close.click();
+  await close.waitFor({ state: 'detached', timeout: 4000 }).catch(() => {});
+  await page.waitForTimeout(200);
+}
+
+async function open(page: Page, record: unknown = session()) {
+  // Seeded once, not on every navigation: init scripts re-run on each `goto`,
+  // and a second one would write the fixture back over whatever the app saved.
+  await page.addInitScript(w => {
+    if (!localStorage.getItem('ironpath_workouts')) {
+      localStorage.setItem('ironpath_workouts', JSON.stringify([w]));
+    }
+    localStorage.setItem('ironpath_current_id', '1');
+    localStorage.setItem('ironpath_tour_seen', '1');
+  }, record);
+  await page.goto('/workout/1');
+  const close = page.getByRole('button', { name: 'Close', exact: true });
+  if (await close.count()) await close.click();
+  await page.waitForTimeout(600);
+}
+
+test('a finished exercise arrives folded, showing its heaviest set', async ({ page }) => {
+  await open(page);
+
+  await expect(page.getByRole('button', { name: 'Show Wide Grip Pulldown' })).toBeVisible();
+  // The heaviest of the two, not the last one entered.
+  await expect(page.getByText('110 lbs × 10 reps')).toBeVisible();
+
+  // Folded means gone, not hidden: nothing to scroll past and nothing to tap.
+  await expect(page.getByLabel('Weight, set 1')).toHaveCount(1); // only Preacher Curl's
+  await expect(page.getByLabel('Mark set 1 complete')).toHaveCount(1);
+});
+
+test('the exercise you are on stays open', async ({ page }) => {
+  await open(page);
+
+  await expect(page.getByRole('button', { name: 'Show Preacher Curl' })).toHaveCount(0);
+  await expect(page.getByText('Arms • Medium Feel')).toBeVisible();
+
+  // The only one open, so the only one with editable sets.
+  const weights = page.getByLabel('Weight, set 1');
+  await expect(weights).toHaveCount(1);
+  await expect(weights).toBeVisible();
+});
+
+test('tapping a folded exercise opens it, and tapping it again folds it back', async ({ page }) => {
+  await open(page);
+
+  await page.getByRole('button', { name: 'Show Seated Row' }).click();
+  await expect(page.getByLabel('Weight, set 1')).toHaveCount(2);
+  await expect(page.getByText('Back • Medium Feel')).toBeVisible();
+
+  await page.getByRole('button', { name: 'Hide Seated Row' }).click();
+  await expect(page.getByRole('button', { name: 'Show Seated Row' })).toBeVisible();
+  await expect(page.getByLabel('Weight, set 1')).toHaveCount(1);
+});
+
+test('finishing an exercise does not fold it under your finger', async ({ page }) => {
+  // The guard on seeding from completion at *mount*. If this ever folds on the
+  // tick, an accidental tap on a set circle hides the control that undoes it,
+  // and everything below jumps up into where the eye already was.
+  await open(page);
+
+  await page.getByLabel('Weight, set 1').fill('80');
+  await page.getByLabel('Reps, set 1').fill('12');
+  await page.getByLabel('Mark set 1 complete').click();
+  await dismissCelebration(page);
+
+  await expect(page.getByRole('button', { name: 'Show Preacher Curl' })).toHaveCount(0);
+  await expect(page.getByLabel('Weight, set 1')).toBeVisible();
+  // It is finished — the fold control is offered, just not taken for you.
+  await expect(page.getByRole('button', { name: 'Hide Preacher Curl' })).toBeVisible();
+});
+
+test('leaving and coming back folds what you finished', async ({ page }) => {
+  await open(page);
+
+  await page.getByLabel('Weight, set 1').fill('80');
+  await page.getByLabel('Reps, set 1').fill('12');
+  await page.getByLabel('Mark set 1 complete').click();
+  await dismissCelebration(page);
+
+  // Wait on the write, not on a guess at the autosave debounce — and on the
+  // whole of it, since the numbers and the completion can land in either order.
+  await page.waitForFunction(
+    () => {
+      const w = JSON.parse(localStorage.getItem('ironpath_workouts') || '[]')[0] as
+        | {
+            exercises: {
+              machine: string;
+              completed: boolean;
+              sets: { weight?: number; reps?: number }[];
+            }[];
+          }
+        | undefined;
+      const e = w?.exercises.find(x => x.machine === 'Preacher Curl');
+      return !!e?.completed && e.sets[0]?.weight === 80 && e.sets[0]?.reps === 12;
+    },
+    null,
+    { timeout: 10000 },
+  );
+
+  await page.goto('/workout/1');
+  await dismissCelebration(page);
+
+  await expect(page.getByRole('button', { name: 'Show Preacher Curl' })).toBeVisible();
+  await expect(page.getByText('80 lbs × 12 reps')).toBeVisible();
+});
+
+test('a folded card costs a line instead of a screenful', async ({ page }) => {
+  // Measured on the card rather than the page, because the saving scales with
+  // how many lifts you have done and the fixture here only has two. Casey's
+  // eleven-exercise session went 4628px to 2208px on this change.
+  await open(page);
+
+  const folded = await cardHeight(page, 'Seated Row');
+  expect(folded).toBeLessThan(80);
+
+  await page.getByRole('button', { name: 'Show Seated Row' }).click();
+  await page.waitForTimeout(300);
+
+  const opened = await cardHeight(page, 'Seated Row');
+  expect(opened).toBeGreaterThan(200);
+  expect(folded).toBeLessThan(opened / 3);
+});


### PR DESCRIPTION
## The problem

Your Back, Biceps & Legs session measures **4628px — five and a half screens.** A finished exercise card looks exactly like an unfinished one, ~304px each, so reaching the exercise you are actually on means scrolling past everything you have already done. That is friction on every single set, not once per session.

## What changed

A finished exercise folds to one line: name, heaviest set, tick.

```
before   4628px   5.5 screens   cards: 304px each
after    2208px   2.6 screens   cards: [62 ×10, 300]
```

The ten completed lifts now fit on one screen with the current one starting below them.

## The part worth reviewing

**It folds on arrival, not under your hand.**

`expanded` is seeded from completion *at mount* rather than tracked, so an exercise already finished when you get there is folded, but one you finish right now stays open. Collapsing it the instant you tick the last set would pull 240px out from under the finger still resting on that circle — and those circles are the thing in this app you already mis-tap. Folding on a mis-tap would hide the control needed to undo it, and everything below would jump up into where your eye already was.

Either way it is a per-session choice: tapping a folded card opens it, tapping its header folds it again, and leaving the screen resets it. Correcting an old number costs one tap and does not have to be undone afterwards.

The heaviest set is shown rather than the last, because that is the number you want at a glance.

## Tests

Six new E2E tests, `e2e/collapse-completed.spec.ts`. Both guards were confirmed by reintroducing the bug:

| Reverted | Result |
|---|---|
| `useState(!exercise.completed)` → `useState(false)` | *"finishing an exercise does not fold it under your finger"* fails, alone |
| `collapsed` → `false` | all six fail |

Full suite green: **256 E2E, 169 unit**, lint 0 errors, tsc clean.

The disclosure buttons carry `aria-expanded`.

## Not in this PR

While writing the tests I hit a genuine defect in released code: a workout stored without `updatedAt` gets a fresh `new Date()` on every read ([storage.ts:490](client/src/lib/storage.ts#L490)), so the value a page loads is always older than the one the next save reads — every autosave then fails with "changed in another tab" with a single tab open, permanently. It only bites records written before `updatedAt` existed, and creating any new workout heals them all, but the failure is total and the message is misleading. Fixing it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)