### PR TITLE
Let a workout logged before updatedAt existed save again

### DIFF
--- a/client/src/lib/concurrent-edit.test.ts
+++ b/client/src/lib/concurrent-edit.test.ts
@@ -157,3 +157,97 @@ describe('the timestamp the check depends on', () => {
     expect(stamps[2]).toBeGreaterThan(stamps[1]);
   });
 });
+
+/**
+ * `updatedAt` was added by the concurrency work above, so every workout logged
+ * before that release has none stored. `getWorkouts` filled the gap with
+ * `new Date()` — a fresh value on *every read*, so the stamp a screen loaded
+ * was always older than the one the next save read back, and the conflict
+ * check fired against a second tab that did not exist.
+ *
+ * The failure was total and permanent: the record could never be saved again,
+ * and the app blamed a tab the user did not have open. Reachable by anyone who
+ * upgraded and opened an old session to fix a number before starting a new one.
+ */
+describe('a workout logged before updatedAt existed', () => {
+  let storage: LocalWorkoutStorage;
+
+  /** Straight into localStorage, since the app can no longer write this shape. */
+  const seedLegacy = () => {
+    localStorage.setItem(
+      'ironpath_workouts',
+      JSON.stringify([
+        {
+          id: 1,
+          date: '2025-07-29',
+          type: 'Chest Day',
+          exercises: [exercise([100, 100])],
+          abs: [],
+          cardio: null,
+          completed: false,
+          duration: null,
+          startedAt: null,
+          createdAt: '2025-07-29T12:00:00.000Z',
+          // no updatedAt
+        },
+      ]),
+    );
+  };
+
+  beforeEach(() => {
+    localStorage.clear();
+    storage = new LocalWorkoutStorage();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    seedLegacy();
+  });
+
+  afterEach(() => vi.restoreAllMocks());
+
+  it('reads as having no stamp rather than a freshly invented one', () => {
+    const first = storage.getWorkouts()[0].updatedAt;
+    const second = storage.getWorkouts()[0].updatedAt;
+
+    expect(first).toBeNull();
+    expect(second).toBeNull();
+  });
+
+  it('can still be edited', async () => {
+    /*
+     * The clock has to move between the read and the write, because that is
+     * the whole bug: the invented stamp came from `new Date()` at read time,
+     * so a screen that loads and then autosaves a moment later compares two
+     * different values. Without this the two reads land in the same
+     * millisecond and the defect cannot reproduce.
+     */
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T10:00:00.000Z'));
+
+    const seen = storage.getWorkouts().find(w => w.id === 1)!;
+    vi.advanceTimersByTime(5);
+
+    const saved = await storage.updateWorkout(1, withWeights(seen, [211, 100]), {
+      expectedUpdatedAt: seen.updatedAt,
+    });
+
+    vi.useRealTimers();
+
+    expect(saved!.exercises[0].sets[0].weight).toBe(211);
+    expect(storage.getWorkouts()[0].exercises[0].sets[0].weight).toBe(211);
+  });
+
+  it('is protected again from its first write onwards', async () => {
+    const seen = storage.getWorkouts().find(w => w.id === 1)!;
+    await storage.updateWorkout(1, withWeights(seen, [211, 100]), {
+      expectedUpdatedAt: seen.updatedAt,
+    });
+
+    // A second tab still holding the pre-write copy must not overwrite it.
+    await expect(
+      storage.updateWorkout(1, withWeights(seen, [222, 100]), {
+        expectedUpdatedAt: seen.updatedAt,
+      }),
+    ).rejects.toThrow(ConcurrentEditError);
+
+    expect(storage.getWorkouts()[0].exercises[0].sets[0].weight).toBe(211);
+  });
+});

--- a/client/src/lib/storage.ts
+++ b/client/src/lib/storage.ts
@@ -487,7 +487,19 @@ export class LocalWorkoutStorage {
         duration: workout.duration ?? null,
         cardio: workout.cardio ?? undefined,
         createdAt: workout.createdAt ?? new Date(),
-        updatedAt: workout.updatedAt ?? new Date(),
+        /*
+         * Null, not `new Date()`. A record written before `updatedAt` existed
+         * has none stored, and inventing one here invents a *different* one on
+         * every read — so the stamp a screen loads is always older than the one
+         * the next save reads back, and the conflict check fires every time. A
+         * legacy workout could never be saved again: every autosave failed with
+         * "changed in another tab" with a single tab open, permanently.
+         *
+         * Null means "no basis to detect a conflict", which is the truth, and
+         * `updateWorkout` skips the check and stamps a real value — so the
+         * record heals on its first write and is protected from then on.
+         */
+        updatedAt: workout.updatedAt ?? null,
       } as Workout);
     }
 
@@ -694,6 +706,13 @@ export class LocalWorkoutStorage {
    * stored copy is newer, another tab has written since, and overwriting would
    * erase whatever it saved — so this refuses instead. Omit it and the check is
    * skipped, which keeps every other caller behaving as before.
+   *
+   * Passing it as `null` is not the same as omitting it. Null means the caller
+   * read a record that had no stamp — true of anything logged before
+   * `updatedAt` existed. If one is stored now, it was added after that read, so
+   * the record has moved on and this refuses exactly as it would for any other
+   * stale expectation. Without that distinction a legacy workout kept the
+   * original silent-overwrite bug this check exists to prevent.
    */
   async updateWorkout(
     id: number,
@@ -702,15 +721,15 @@ export class LocalWorkoutStorage {
   ): Promise<Workout | undefined> {
     const workouts = this.getWorkouts();
     const index = workouts.findIndex(w => w.id === id);
-    
+
     if (index === -1) return undefined;
 
     const { expectedUpdatedAt } = options;
     const storedUpdatedAt = workouts[index].updatedAt;
     if (
-      expectedUpdatedAt != null &&
+      'expectedUpdatedAt' in options &&
       storedUpdatedAt != null &&
-      storedUpdatedAt.getTime() > expectedUpdatedAt.getTime()
+      (expectedUpdatedAt == null || storedUpdatedAt.getTime() > expectedUpdatedAt.getTime())
     ) {
       throw new ConcurrentEditError(
         'This workout was changed somewhere else — another tab or window. ' +

--- a/e2e/legacy-data.spec.ts
+++ b/e2e/legacy-data.spec.ts
@@ -80,3 +80,44 @@ test('an unreadable record is set aside rather than deleted', async ({ page }) =
   expect(quarantined).toHaveLength(1);
   expect(quarantined[0].record.id).toBe(2);
 });
+
+/**
+ * `updatedAt` arrived with the two-tab concurrency check, so nothing logged
+ * before that release has one — `LEGACY_WORKOUT` above included.
+ *
+ * `getWorkouts` used to fill the gap with `new Date()`, which invented a
+ * *different* stamp on every read. The value the screen loaded was therefore
+ * always older than the one the next save read back, so the check fired on
+ * every autosave: the record could never be saved again, and the app blamed a
+ * tab the user did not have open.
+ */
+test('a workout logged before updatedAt existed can still be edited', async ({ page }) => {
+  const autosaveErrors: string[] = [];
+  page.on('console', m => {
+    if (m.type() === 'error' && /Autosave failed/i.test(m.text())) autosaveErrors.push(m.text());
+  });
+
+  await seedStorage(page, [LEGACY_WORKOUT]);
+  await page.addInitScript(() => localStorage.setItem('ironpath_tour_seen', '1'));
+  await page.goto('/workout/1');
+
+  const close = page.getByRole('button', { name: 'Close', exact: true });
+  if (await close.count()) await close.click();
+
+  await page.getByLabel('Weight, set 1').fill('165');
+
+  await page.waitForFunction(
+    () => {
+      const w = JSON.parse(localStorage.getItem('ironpath_workouts') || '[]')[0] as
+        | { exercises: { sets: { weight?: number }[] }[] }
+        | undefined;
+      return w?.exercises[0].sets[0].weight === 165;
+    },
+    null,
+    { timeout: 10000 },
+  );
+
+  await expect(page.getByText(/Changed in another tab/i)).toHaveCount(0);
+  await expect(page.getByText(/changed somewhere else/i)).toHaveCount(0);
+  expect(autosaveErrors, 'a single tab is open; nothing changed anywhere else').toEqual([]);
+});


### PR DESCRIPTION
Found while writing tests for #212.

## The bug

`updatedAt` arrived with the two-tab concurrency check in v1.4.0, so **nothing logged before that release has one stored.** [storage.ts:490](client/src/lib/storage.ts#L490) filled the gap with `new Date()` — a fresh value on *every read*.

So the stamp a screen loads is always older than the one the next save reads back:

```
page loads      → getWorkouts() → updatedAt = 10:00:00.000  (invented)
autosave fires  → getWorkouts() → updatedAt = 10:00:04.317  (invented again)
                  10:00:04.317 > 10:00:00.000  →  ConcurrentEditError
```

The check fires on every autosave, against a tab that does not exist. The failure is **total and permanent** — the record can never be saved again — and the app blames the user's own device:

> **Changed in another tab**
> This workout was changed somewhere else — another tab or window. Reload to pick up those changes before editing further.

That is a real screenshot from the test run with the fix reverted, with a single tab open.

**Who hits it:** anyone who opens a pre-v1.4.0 session to correct a number. Creating any new workout rewrites the whole stored list and stamps every legacy record, so the window closes as soon as someone trains again — but until then, edits to old sessions are silently lost.

## The fix

Read it as `null`, which is the truth: no basis to detect a conflict. `updateWorkout` skips the check and stamps a real value, so the record heals on its first write and is protected from then on.

**Null is now distinguished from an omitted expectation, and that is what makes it safe.** Null means the caller read a record that had no stamp; if one is stored now it was added after that read, so the record has moved on and the write is refused exactly as for any other stale expectation. Without that distinction a legacy workout would keep the original silent-overwrite bug this check exists to prevent — two tabs on an old session, and the second still erases the first.

Callers that omit the option are unaffected; completing a workout deliberately omits it, and that behaviour is unchanged.

`createdAt` is invented on read in the same way but has no consumers and is never compared, so it is left alone.

## Tests

Three unit tests and one end-to-end test. Each guard confirmed load-bearing by reverting it:

| Reverted | Fails |
|---|---|
| `?? null` → `?? new Date()` | *reads as having no stamp*, *can still be edited*, and the E2E |
| `'expectedUpdatedAt' in options` → `!= null` | *is protected again from its first write onwards*, alone |

The unit test advances the clock between the read and the write — without that both land in the same millisecond and the defect cannot reproduce, which is why it went unnoticed.

Full suite green: **246 E2E, 172 unit**, lint 0 errors, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)