### PR TITLE
Repair the legacy-workout test that broke main

### DIFF
--- a/e2e/collapse-completed.spec.ts
+++ b/e2e/collapse-completed.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from '@playwright/test';
+import { setNumericValue } from './helpers';
 
 /**
  * A finished exercise folds to one line.
@@ -150,8 +151,8 @@ test('finishing an exercise does not fold it under your finger', async ({ page }
   // and everything below jumps up into where the eye already was.
   await open(page);
 
-  await page.getByLabel('Weight, set 1').fill('80');
-  await page.getByLabel('Reps, set 1').fill('12');
+  await setNumericValue(page.getByLabel('Weight, set 1'), '80');
+  await setNumericValue(page.getByLabel('Reps, set 1'), '12');
   await page.getByLabel('Mark set 1 complete').click();
   await dismissCelebration(page);
 
@@ -164,8 +165,8 @@ test('finishing an exercise does not fold it under your finger', async ({ page }
 test('leaving and coming back folds what you finished', async ({ page }) => {
   await open(page);
 
-  await page.getByLabel('Weight, set 1').fill('80');
-  await page.getByLabel('Reps, set 1').fill('12');
+  await setNumericValue(page.getByLabel('Weight, set 1'), '80');
+  await setNumericValue(page.getByLabel('Reps, set 1'), '12');
   await page.getByLabel('Mark set 1 complete').click();
   await dismissCelebration(page);
 

--- a/e2e/legacy-data.spec.ts
+++ b/e2e/legacy-data.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { setNumericValue } from './helpers';
 
 /**
  * A real browser, booting against data written by an older build.
@@ -104,7 +105,13 @@ test('a workout logged before updatedAt existed can still be edited', async ({ p
   const close = page.getByRole('button', { name: 'Close', exact: true });
   if (await close.count()) await close.click();
 
-  await page.getByLabel('Weight, set 1').fill('165');
+  // This exercise is finished, so it arrives folded. Opening it is what
+  // someone correcting an old number actually does.
+  await page.getByRole('button', { name: 'Show Adjustable Cable Crossover' }).click();
+
+  // `setNumericValue`, not `fill` — the caret-to-end race appends otherwise,
+  // and a seeded 60 becomes "60165".
+  await setNumericValue(page.getByLabel('Weight, set 1'), '165');
 
   await page.waitForFunction(
     () => {


### PR DESCRIPTION
**Main is red.** This fixes it. Test-only change — no app code, and the shipped behaviour of both merged PRs is unaffected.

## What happened

#212 and #213 were each green on their own branch, and broke main together. I never tested them merged, which is the actual mistake here.

#213 added a test that opens a workout logged before `updatedAt` existed and edits a weight. That fixture's only exercise has `completed: true` — so once #212's collapse landed, the card **arrives folded** and there is no weight input to fill. `locator.fill` timed out.

## Two problems, not one

**1. The card is folded now.** The test opens it first, which is what someone correcting an old number actually does.

**2. It used `fill` instead of `setNumericValue`** — and hit exactly the caret-to-end race that helper was written for:

```
seeded 60  +  fill("165")  →  "60165"
```

So the weight never matched and the wait timed out. That is why it looked intermittent (3 failures in 5 runs) and why I initially suspected the concurrency guard from #213. It was not the guard — it was the input.

This matters beyond the flake: the race was **masking how load-bearing the fix underneath is.** Measured on the merged tree:

| | before | after |
|---|---|---|
| passes with the fix | 2 of 5 | 100 of 100 |
| fails with the fix reverted | intermittently | 6 of 6 |

**3. The same latent race was in #212's collapse spec.** A seeded 10 reps plus `"12"` would yield `"1012"`. It passed only by luck — the other field seeds 0, and `"080"` parses back to 80. Switched to the helper before it failed on someone else's branch.

## Verification

Run on the **merged tree**, which is what neither PR did:

- **258 E2E, 172 unit**, lint 0 errors, tsc clean
- Both specs at `--repeat-each=5`: 100/100
- Guard still confirmed load-bearing by reverting it

🤖 Generated with [Claude Code](https://claude.com/claude-code)