### PR TITLE
chore: 1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rest-express",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rest-express",
-      "version": "1.4.0",
+      "version": "1.5.0",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@radix-ui/react-alert-dialog": "^1.1.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-express",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "type": "module",
   "license": "AGPL-3.0-or-later",
   "scripts": {


### PR DESCRIPTION
Version bump only — three lines across `package.json` and `package-lock.json`, matching the shape of the 1.4.0 bump. No app code.

`package.json` is the single source, so Settings and the tag agree by construction rather than by remembering to update both. Verified in a real browser: Settings reads **v1.5.0**.

## Why now rather than banking more

Settings has said **1.4.0** on a build with four features 1.4.0 never had. That display was the whole point of #211, and every day it drifts further from the truth.

## What is in it

| | |
|---|---|
| **Progress over time** | your lifts as a sentence — "125 lbs · up 45 since Jul 2025" — with detail per lift |
| **Collapsed completed exercises** | a real session, 4628px → 2208px |
| **Calendar remembers its place** | browsing back and returning no longer resets to today |
| **Build identity** | Settings names the version and the build it came from |
| **Legacy workouts save again** | pre-1.4.0 sessions could not be edited at all |
| **History empty states** | two cards no longer say the same thing |

Minor bump: features added, nothing removed or changed incompatibly.

## Verification

**258 E2E, 172 unit**, lint 0 errors, tsc clean. Version specs pass, including the one asserting the built bundle carries no unsubstituted placeholder.

## After you merge

Release notes are drafted and ready to paste — say the word and I'll hand them over. **The tag and the GitHub release are yours**, as always; I have not created either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)